### PR TITLE
Use directory guard function in place of PHONY for build output direc…

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1,0 +1,1 @@
+dir_guard=@mkdir -p $(@D)

--- a/resourcemgr/Makefile.in
+++ b/resourcemgr/Makefile.in
@@ -26,6 +26,8 @@
 # THE POSSIBILITY OF SUCH DAMAGE.
 #;**********************************************************************;
 
+include ../common.mk
+
 RESOURCE_MGR_OBJS := $(shell ls ./*.c | sed 's/\./$(TARGET_TYPE)/' | sed 's/\.c$$/\.o /' )
 RESOURCE_MGR_HEADERS := $(shell ls ./*.h )
 TPMSOCKETS_OBJS := $(shell ls ../tcti/tpmsockets/*.cpp | sed 's/\.\.\/tcti\/tpmsockets/$(TARGET_TYPE)/' | sed 's/\.cpp$$/\.o /' )
@@ -54,7 +56,7 @@ LIBS = ../sysapi/lib/$(TARGET_TYPE)/libtpm.a
 CFLAGS = $($(TARGET_TYPE)_CFLAGS) $(INCLUDE_DIRS)
 CXXFLAGS = $($(TARGET_TYPE)_CPLUSFLAGS) $(INCLUDE_DIRS)
 
-.PHONY: DIRS tpmlib_debug tpmlib_release all debug release 
+.PHONY: tpmlib_debug tpmlib_release all debug release
 
 all:  debug release 
 
@@ -64,28 +66,30 @@ debug: tpmlib_debug
 release: tpmlib_release
 	$(MAKE) -f Makefile release/resourcemgr TARGET_TYPE=release
 
-DIRS:
-	-@mkdir $(TARGET_TYPE) 2> /dev/null
-
 tpmlib_debug: 
 	@$(MAKE) -C ../sysapi -f Makefile debug
 
 tpmlib_release: 
 	@$(MAKE) -C ../sysapi -f Makefile release
 
-$(TARGET_TYPE)/resourcemgr: DIRS $(OBJS) $(LIBS) Makefile 
+$(TARGET_TYPE)/resourcemgr: $(OBJS) $(LIBS) Makefile
+	$(dir_guard)
 	$(CC) $(CFLAGS) -pthread -o $(TARGET_TYPE)/resourcemgr $(OBJS) $(LIBS)
 
 $(TARGET_TYPE)/%.o: ../resourcemgr/%.c $(RESOURCE_MGR_HEADERS) $(COMMON_HEADERS) $(TPMSOCKETS_HEADERS) $(LOCALTPM_HEADERS) Makefile $(SYSAPI_HEADERS)
+	$(dir_guard)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 $(TARGET_TYPE)/%.o: ../common/%.c $(COMMON_HEADERS) Makefile $(SYSAPI_HEADERS)
+	$(dir_guard)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 $(TARGET_TYPE)/%.o: ../tcti/tpmsockets/%.cpp $(TPMSOCKETS_HEADERS) Makefile $(SYSAPI_HEADERS)
+	$(dir_guard)
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 $(TARGET_TYPE)/%.o: ../tcti/localtpm/%.c $(LOCALTPM_HEADERS) Makefile $(SYSAPI_HEADERS)
+	$(dir_guard)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:

--- a/sysapi/Makefile.in
+++ b/sysapi/Makefile.in
@@ -30,6 +30,8 @@ CC = @CC@
 CFLAGS_DEBUG = @CFLAGS@ -I./include -O0 -Wall -Werror -ggdb3
 CFLAGS_RELEASE = @CFLAGS@ -I./include -Os -Wall -Werror
 
+include ../common.mk
+
 LIB_DIR = ./lib
 BASE_DIR = ./
 
@@ -43,37 +45,38 @@ SYS_API_INCLUDES := $(shell ls include/*.h )
     
 All:  debug release
 
-debug: DIRS $(LIB_DIR)/debug/libtpm.a	
+debug: $(LIB_DIR)/debug/libtpm.a
 
-release: DIRS $(LIB_DIR)/release/libtpm.a	
-
-DIRS:
-	-@mkdir lib 2> /dev/null
-	-@mkdir lib/debug 2> /dev/null
-	-@mkdir lib/release 2> /dev/null
+release: $(LIB_DIR)/release/libtpm.a
 
 $(LIB_DIR)/debug/libtpm.a: $(SYS_API_DEBUG_OBJECTS) $(SYS_API_UTIL_DEBUG_OBJECTS) Makefile
 	echo *** sysapi_objs: $(SYS_API_DEBUG_OBJECTS)
 	echo *** sysapi_util_objs: $(SYS_API_UTIL_DEBUG_OBJECTS)
 	echo *** sysapi_includes: $(SYS_API_INCLUDES)
+	$(dir_guard)
 	ar -qvc $@ $(SYS_API_DEBUG_OBJECTS) $(SYS_API_UTIL_DEBUG_OBJECTS)
 
 $(LIB_DIR)/release/libtpm.a: $(SYS_API_RELEASE_OBJECTS) $(SYS_API_UTIL_RELEASE_OBJECTS) Makefile
 	echo *** sysapi_objs: $(SYS_API_RELEASE_OBJECTS)
 	echo *** sysapi_util_objs: $(SYS_API_UTIL_RELEASE_OBJECTS)
 	echo *** sysapi_includes: $(SYS_API_INCLUDES)
+	$(dir_guard)
 	ar -qvc $@ $(SYS_API_RELEASE_OBJECTS) $(SYS_API_UTIL_RELEASE_OBJECTS)
 
 lib/debug/%.o: sysapi/%.c Makefile $(SYS_API_INCLUDES) 
+	$(dir_guard)
 	$(CC) $(CFLAGS_DEBUG) -c $< -o $@
 
 lib/debug/%.o: sysapi_util/%.c Makefile $(SYS_API_INCLUDES) 
+	$(dir_guard)
 	$(CC) $(CFLAGS_DEBUG) -c $< -o $@
 
 lib/release/%.o: sysapi/%.c Makefile $(SYS_API_INCLUDES) 
+	$(dir_guard)
 	$(CC) $(CFLAGS_RELEASE) -c $< -o $@
 
 lib/release/%.o: sysapi_util/%.c Makefile $(SYS_API_INCLUDES) 
+	$(dir_guard)
 	$(CC) $(CFLAGS_RELEASE) -c $< -o $@
 
 .PHONY : clean

--- a/test/tpmclient/Makefile.in
+++ b/test/tpmclient/Makefile.in
@@ -26,6 +26,8 @@
 # THE POSSIBILITY OF SUCH DAMAGE.
 #;**********************************************************************;
 
+include ../../common.mk
+
 RESOURCE_MGR_HEADERS := $(shell ls ../resourcemgr/*.h )
 SAMPLE_OBJS := $(shell ls ../common/sample/*.c | sed 's/\.\.\/common\/sample/$(TARGET_TYPE)/' | sed 's/\.c$$/\.o /' )
 SAMPLE_HEADERS := $(shell ls ../common/sample/*.h )
@@ -55,7 +57,7 @@ LIBS = ../../sysapi/lib/$(TARGET_TYPE)/libtpm.a
 
 OBJS = $(SYSCONTEXT_OBJS) $(SAMPLE_OBJS) $(TARGET_TYPE)/sapiclient_tpmsockets.o $(COMMON_OBJS) 
 
-.PHONY: tpmlib_debug tpmlib_release DIRS all debug release 
+.PHONY: tpmlib_debug tpmlib_release all debug release
 
 all:  debug release 
 
@@ -65,29 +67,31 @@ debug: tpmlib_debug
 release: tpmlib_release
 	$(MAKE) -f Makefile release/tpmclient TARGET_TYPE=release
 
-DIRS:
-	-@mkdir $(TARGET_TYPE) 2> /dev/null
-
 tpmlib_debug: 
 	@$(MAKE) -C ../../sysapi -f Makefile debug
 
 tpmlib_release: 
 	@$(MAKE) -C ../../sysapi -f Makefile release
 
-$(TARGET_TYPE)/tpmclient: DIRS $(TARGET_TYPE)/tpmclient.o $(OBJS) $(LIBS) Makefile 
+$(TARGET_TYPE)/tpmclient: $(TARGET_TYPE)/tpmclient.o $(OBJS) $(LIBS) Makefile
+	$(dir_guard)
 	$(CXX) $(CXXFLAGS) -o $(@D)/tpmclient $(@D)/tpmclient.o $(OBJS) $(LIBS)
 
 $(TARGET_TYPE)/%.o: %.cpp $(TPMCLIENT_HEADERS) Makefile
+	$(dir_guard)
 	$(CXX) $(CFLAGS) -c $< -o $@
 
 $(TARGET_TYPE)/%.o: ../common/sample/%.c $(COMMON_HEADERS) Makefile $(SYSAPI_HEADERS) $(SAMPLE_HEADERS) 
+	$(dir_guard)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 # Build special version of tpmsockets code for test application.
 $(TARGET_TYPE)/sapiclient_tpmsockets.o: ../../tcti/tpmsockets/*.cpp # $(TPMSOCKETS_HEADERS) Makefile $(SYSAPI_HEADERS) $(COMMON_HEADERS) 
+	$(dir_guard)
 	$(CXX) -DSAPI_CLIENT $(CXXFLAGS) -c $< -o $@
 
 $(TARGET_TYPE)/%.o: ../../common/%.c $(COMMON_HEADERS) Makefile $(SYSAPI_HEADERS) $(COMMON_HEADERS) 
+	$(dir_guard)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:


### PR DESCRIPTION
…tories.

PHONY's don't work well in these cases since a PHONY target is always
considered out of date and rebuilt.

This resolves #5.