### PR TITLE
Fix bad path to resourcemgr directory.

### DIFF
--- a/test/tpmclient/Makefile.in
+++ b/test/tpmclient/Makefile.in
@@ -26,7 +26,7 @@
 # THE POSSIBILITY OF SUCH DAMAGE.
 #;**********************************************************************;
 
-RESOURCE_MGR_HEADERS := $(shell ls ../resourcemgr/*.h )
+RESOURCE_MGR_HEADERS := $(shell ls ../../resourcemgr/*.h )
 SAMPLE_OBJS := $(shell ls ../common/sample/*.c | sed 's/\.\.\/common\/sample/$(TARGET_TYPE)/' | sed 's/\.c$$/\.o /' )
 SAMPLE_HEADERS := $(shell ls ../common/sample/*.h )
 #TPMSOCKETS_OBJS := $(shell ls ../../tcti/tpmsockets/*.cpp | sed 's/\.\.\/\.\.\/tpmsockets/$(TARGET_TYPE)/' | sed 's/\.cpp$$/\.o /' )


### PR DESCRIPTION
This gets rid of an error message output to the console and broken
dependency.