### PR TITLE
cygwin build issue

### DIFF
--- a/resourcemgr/resourcemgr.c
+++ b/resourcemgr/resourcemgr.c
@@ -41,7 +41,7 @@
 typedef HANDLE THREAD_TYPE; 
 
 #define MAX_COMMAND_LINE_ARGS 7
-#elif __linux
+#elif __linux || __unix
 #include "localtpm.h"
 #include <stdarg.h>
 #define sprintf_s   snprintf
@@ -2444,7 +2444,7 @@ UINT32 WINAPI SockServer( LPVOID servStruct )
     SERVER_STRUCT *cmdServerStruct;
 #ifdef  _WIN32
     // do nothing.
-#elif __linux
+#elif __linux || __unix
     
     int rval = 0;
 #endif    
@@ -2484,7 +2484,7 @@ UINT32 WINAPI SockServer( LPVOID servStruct )
             printf( "Resource Mgr failed to create OTHER command server thread.  Exiting...\n" );
             continue;
         }
-#elif __linux
+#elif __linux || __unix
         rval = pthread_create( &cmdServerStruct->threadHandle, 0, (void *)serverStruct->serverFn, cmdServerStruct );
         if( rval != 0 )
         {
@@ -2544,7 +2544,7 @@ TSS2_RC TeardownSimulatorTctiContext( const char *driverConfig )
     return rval;
 }
 
-#if __linux
+#if __linux || __unix
 char localTpmInterfaceConfig[interfaceConfigSize];
     
 TSS2_TCTI_DRIVER_INFO localTpmInterfaceInfo = { "local TPM", "", InitLocalTpmTcti, TeardownLocalTpmTcti };
@@ -2584,7 +2584,7 @@ TSS2_RC TeardownResMgr(
 {
     ResMgrPrintf( NO_PREFIX, "Tearing down Resource Manager\n" );
 
-#if __linux
+#if __linux || __unix
     if( !simulator )
         TeardownSocketsTcti( tctiContext, config, localTpmInterfaceInfo.shortName );
     else
@@ -2793,14 +2793,14 @@ char version[] = "0.85";
 void PrintHelp()
 {
     printf( "Resource manager daemon, Version %s\nUsage:  resourcemgr "
-#if __linux
+#if __linux || __unix
             "[-sim] "
 #endif            
             "[-tpmhost hostname|ip_addr] [-tpmport port] [-apport port]\n"
             "\n"
             "where:\n"
             "\n"
-#if __linux
+#if __linux || __unix
             "-sim tells resource manager to communicate with TPM 2.0 simulator (default: communicates with local TPM; must be specified for running on Windows)\n"
 #endif            
             "-tpmhost specifies the host IP address for communicating with the TPM (default: %s; only valid if -sim used)\n"
@@ -2846,7 +2846,7 @@ int main(int argc, char* argv[])
     {
         for( count = 1; count < argc; count++ )
         {
-#if __linux
+#if __linux || __unix
             if( 0 == strcmp( argv[count], "-sim" ) )
             {
                 simulator = 1;
@@ -2909,7 +2909,7 @@ int main(int argc, char* argv[])
             }
         }
 
-#if __linux
+#if __linux || __unix
         if( !simulator && ( tpmHostNameSpecified == 1 || tpmPortSpecified == 1 ) )
         {
             PrintHelp();
@@ -2927,7 +2927,7 @@ int main(int argc, char* argv[])
 		outFp = 0;
 	}
 
-#if __linux
+#if __linux || __unix
     if( !simulator )
     {
         // Use device driver for local TPM.
@@ -3003,7 +3003,7 @@ int main(int argc, char* argv[])
     {
         printf( "Resource Mgr failed to create OTHER command server thread.  Exiting...\n" );
     }
-#elif __linux
+#elif __linux || __unix
     rval = pthread_create( &sockServerThread, 0, (void *)SockServer, &otherCmdServerStruct );
     if( rval != 0 )
     {

--- a/sysapi/include/tss2_tcti.h
+++ b/sysapi/include/tss2_tcti.h
@@ -57,7 +57,7 @@ extern "C" {
 #include <winsock2.h>
 #include <windows.h>
 typedef HANDLE TSS2_TCTI_POLL_HANDLE;
-#elif defined linux
+#elif defined linux || defined unix
 #include <poll.h>
 typedef struct pollfd TSS2_TCTI_POLL_HANDLE;
 #else

--- a/sysapi/include/tss2_tcti_util.h
+++ b/sysapi/include/tss2_tcti_util.h
@@ -43,7 +43,7 @@
 #error Version mismatch among TSS2 header files !
 #endif  /* TSS2_API_VERSION_1_1_1_1 */
 
-#if defined linux
+#if defined linux || defined unix
 #include <sys/socket.h>
 #define SOCKET int
 #endif


### PR DESCRIPTION
Closes #31 

on cygwin gcc macros can be listed with:
```
~/Documents/TPM/TPM2.0-TSS/sysapi
$ gcc   -dM -E -x c /dev/null |egrep -i "cygwin|unix|win|linux"
#define __WINT_MAX__ 4294967295U
#define __unix__ 1
#define __unix 1
#define __WINT_MIN__ 0U
#define __SIZEOF_WINT_T__ 4
#define unix 1
#define __CYGWIN__ 1
#define __WINT_TYPE__ unsigned int

~/Documents/TPM/TPM2.0-TSS/sysapi
$ g++   -dM -E -x c++ /dev/null |egrep -i "cygwin|unix|win|linux"
#define __WINT_MAX__ 4294967295U
#define __unix__ 1
#define __unix 1
#define __WINT_MIN__ 0U
#define __SIZEOF_WINT_T__ 4
#define unix 1
#define __CYGWIN__ 1
#define __WINT_TYPE__ unsigned int

~/Documents/TPM/TPM2.0-TSS/sysapi
$
```