### PR TITLE
Make libtpm and resource manage installable + some cleanup.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -44,5 +44,11 @@ $ ../TPM2.0-TSS/configure \
   CXXFLAGS="-O0 -Wall -Werror -fno-operator-names -fpermissive -ggdb3"
 $ make
 
-The tpm2.0-tss software currently does not have an install target. This
-section will be updated with installation instructions when they are relevant.
+Once you've built the tpm2.0-tss software it can be installed with the usual:
+$ sudo make install
+
+This will install libtpm and the resource manager to locations determined at
+configure time. See the output of ./configure --help for the available
+options. Typically you won't need to do much more than provide an alternative
+--prefix option at configure time, and DESTDIR at install time if you're
+looking to create a binary packag.

--- a/Makefile.am
+++ b/Makefile.am
@@ -30,12 +30,14 @@ include src_vars.mk
 
 ACLOCAL_AMFLAGS = -I m4
 
-bin_PROGRAMS = resourcemgr/resourcemgr test/tpmclient/tpmclient test/tpmtest/tpmtest
-noinst_LTLIBRARIES = sysapi/libtpm.la
+sbin_PROGRAMS = resourcemgr/resourcemgr
+noinst_PROGRAMS = test/tpmclient/tpmclient test/tpmtest/tpmtest
+pkglib_LTLIBRARIES = sysapi/libtpm.la
+pkginclude_HEADERS = $(SYSAPI_H)
 
 resourcemgr_resourcemgr_CFLAGS   = $(RESOURCEMGR_INC) $(PTHREAD_CFLAGS)
 resourcemgr_resourcemgr_CXXFLAGS = $(RESOURCEMGR_INC) $(PTHREAD_CFLAGS)
-resourcemgr_resourcemgr_LDADD    = $(noinst_LTLIBRARIES)
+resourcemgr_resourcemgr_LDADD    = $(pkglib_LTLIBRARIES)
 resourcemgr_resourcemgr_LDFLAGS  = $(PTHREAD_LDFLAGS)
 resourcemgr_resourcemgr_SOURCES  = $(RESOURCEMGR_SRC) $(TPMSOCKETS_SRC) \
      $(LOCALTPM_SRC) $(COMMON_SRC)
@@ -45,13 +47,13 @@ sysapi_libtpm_la_SOURCES = $(SYSAPI_C) $(SYSAPIUTIL_C)
 
 test_tpmclient_tpmclient_CFLAGS   = -DSAPI_CLIENT $(TPMCLIENT_INC)
 test_tpmclient_tpmclient_CXXFLAGS = -DSAPI_CLIENT $(TPMCLIENT_INC)
-test_tpmclient_tpmclient_LDADD    = $(noinst_LTLIBRARIES)
+test_tpmclient_tpmclient_LDADD    = $(pkglib_LTLIBRARIES)
 test_tpmclient_tpmclient_SOURCES  = $(COMMON_SRC) $(SAMPLE_SRC) \
     $(TPMCLIENT_SRC) $(TPMSOCKETS_SRC)
 
 test_tpmtest_tpmtest_CFLAGS   = -DSAPI_CLIENT $(TPMTEST_INC)
 test_tpmtest_tpmtest_CXXFLAGS = -DSAPI_CLIENT $(TPMTEST_INC)
-test_tpmtest_tpmtest_LDADD    = $(noinst_LTLIBRARIES)
+test_tpmtest_tpmtest_LDADD    = $(pkglib_LTLIBRARIES)
 test_tpmtest_tpmtest_SOURCES  = $(COMMON_SRC) $(SAMPLE_SRC) \
     $(TPMTEST_SRC) $(TPMSOCKETS_SRC)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -31,27 +31,27 @@ include src_vars.mk
 ACLOCAL_AMFLAGS = -I m4
 
 bin_PROGRAMS = resourcemgr/resourcemgr test/tpmclient/tpmclient test/tpmtest/tpmtest
-noinst_LIBRARIES = sysapi/libtpm.a
+noinst_LTLIBRARIES = sysapi/libtpm.la
 
 resourcemgr_resourcemgr_CFLAGS   = $(RESOURCEMGR_INC) $(PTHREAD_CFLAGS)
 resourcemgr_resourcemgr_CXXFLAGS = $(RESOURCEMGR_INC) $(PTHREAD_CFLAGS)
-resourcemgr_resourcemgr_LDADD    = $(noinst_LIBRARIES)
+resourcemgr_resourcemgr_LDADD    = $(noinst_LTLIBRARIES)
 resourcemgr_resourcemgr_LDFLAGS  = $(PTHREAD_LDFLAGS)
 resourcemgr_resourcemgr_SOURCES  = $(RESOURCEMGR_SRC) $(TPMSOCKETS_SRC) \
      $(LOCALTPM_SRC) $(COMMON_SRC)
 
-sysapi_libtpm_a_CFLAGS  = -I$(srcdir)/sysapi/include/
-sysapi_libtpm_a_SOURCES = $(SYSAPI_C) $(SYSAPIUTIL_C)
+sysapi_libtpm_la_CFLAGS  = -I$(srcdir)/sysapi/include/
+sysapi_libtpm_la_SOURCES = $(SYSAPI_C) $(SYSAPIUTIL_C)
 
 test_tpmclient_tpmclient_CFLAGS   = -DSAPI_CLIENT $(TPMCLIENT_INC)
 test_tpmclient_tpmclient_CXXFLAGS = -DSAPI_CLIENT $(TPMCLIENT_INC)
-test_tpmclient_tpmclient_LDADD    = $(noinst_LIBRARIES)
+test_tpmclient_tpmclient_LDADD    = $(noinst_LTLIBRARIES)
 test_tpmclient_tpmclient_SOURCES  = $(COMMON_SRC) $(SAMPLE_SRC) \
     $(TPMCLIENT_SRC) $(TPMSOCKETS_SRC)
 
 test_tpmtest_tpmtest_CFLAGS   = -DSAPI_CLIENT $(TPMTEST_INC)
 test_tpmtest_tpmtest_CXXFLAGS = -DSAPI_CLIENT $(TPMTEST_INC)
-test_tpmtest_tpmtest_LDADD    = $(noinst_LIBRARIES)
+test_tpmtest_tpmtest_LDADD    = $(noinst_LTLIBRARIES)
 test_tpmtest_tpmtest_SOURCES  = $(COMMON_SRC) $(SAMPLE_SRC) \
     $(TPMTEST_SRC) $(TPMSOCKETS_SRC)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -41,7 +41,7 @@ resourcemgr_resourcemgr_SOURCES  = $(RESOURCEMGR_SRC) $(TPMSOCKETS_SRC) \
      $(LOCALTPM_SRC) $(COMMON_SRC)
 
 sysapi_libtpm_a_CFLAGS  = -I$(srcdir)/sysapi/include/
-sysapi_libtpm_a_SOURCES = $(SYSAPI_SRC) $(SYSAPIUTIL_SRC) $(SYSAPI_INC)
+sysapi_libtpm_a_SOURCES = $(SYSAPI_C) $(SYSAPIUTIL_C)
 
 test_tpmclient_tpmclient_CFLAGS   = -DSAPI_CLIENT $(TPMCLIENT_INC)
 test_tpmclient_tpmclient_CXXFLAGS = -DSAPI_CLIENT $(TPMCLIENT_INC)

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_INIT([tpm2.0-tss], [0.98])
 AC_CONFIG_MACRO_DIR([m4])
 AC_PROG_CC
 AC_PROG_CXX
-LT_INIT([disable-shared])
+LT_INIT()
 AX_PTHREAD([], [AC_MSG_ERROR([requires pthread])])
 AM_INIT_AUTOMAKE([foreign
                   subdir-objects])


### PR DESCRIPTION
This is, I think, the last bits necessary to make the Linux build friendly to the expected workflow. With these changes you can build libtpm and the resource manager like:

configure && make && make install

libtpm will be built as a static, and a dynamic library. The resource manager will be dynamically linked to libtpm by default (thought this can be changed at configure time). Also the sysapi header files are installed so other programs can link against the shared object.

Will: can you take a look at the install locations and make sure they're what you want? I opted to use the 'pkg' standard which installs libraries and headers under in the expected locations ($prefix/lib and $prefix/include respectively) in their own directory. Since the project name is 'tpm2.0-tss' this ends up being on that path: $prefix/lib/tpm2.0-tss and $prefix/include/tpm2.0-tss.
