### PR TITLE
Create shared libraries and set install locations.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.a
+*.la
+*.lo
 *.o
 *.opensdf
 *.pdb
@@ -6,6 +8,7 @@
 *.suo
 .deps/
 .dirstamp
+.libs
 aclocal.m4
 autom4te.cache/
 [Bb]uild/
@@ -28,3 +31,4 @@ missing
 src_vars.mk
 resourcemgr/resourcemgr
 test/tpmclient/tpmclient
+test/tpmtest/tpmtest

--- a/INSTALL
+++ b/INSTALL
@@ -44,5 +44,11 @@ $ ../TPM2.0-TSS/configure \
   CXXFLAGS="-O0 -Wall -Werror -fno-operator-names -fpermissive -ggdb3"
 $ make
 
-The tpm2.0-tss software currently does not have an install target. This
-section will be updated with installation instructions when they are relevant.
+Once you've built the tpm2.0-tss software it can be installed with the usual:
+$ sudo make install
+
+This will install libtpm and the resource manager to locations determined at
+configure time. See the output of ./configure --help for the available
+options. Typically you won't need to do much more than provide an alternative
+--prefix option at configure time, and DESTDIR at install time if you're
+looking to create a binary packag.

--- a/Makefile.am
+++ b/Makefile.am
@@ -30,42 +30,69 @@ include src_vars.mk
 
 ACLOCAL_AMFLAGS = -I m4
 
-bin_PROGRAMS = resourcemgr/resourcemgr test/tpmclient/tpmclient test/tpmtest/tpmtest
-noinst_LTLIBRARIES = sysapi/libtpm.la
+libtpm2sapidir     = $(includedir)/tpm2sapi
+libtpm2tctidevdir  = $(includedir)/tpm2tctidev
+libtpm2tctisockdir = $(includedir)/tpm2tctisock
+libtpm2sapi        = sysapi/libtpm2sapi.la
+libtpm2tctidev     = tcti/libtpm2tctidev.la
+libtpm2tctisock    = tcti/libtpm2tctisock.la
+resourcemgr        = resourcemgr/resourcemgr
+tpmclient          = test/tpmclient/tpmclient
+tpmtest            = test/tpmtest/tpmtest
+
+sbin_PROGRAMS   = $(resourcemgr)
+noinst_PROGRAMS = $(tpmclient) $(tpmtest)
+lib_LTLIBRARIES = $(libtpm2sapi) $(libtpm2tctidev) $(libtpm2tctisock)
+libtpm2sapi_HEADERS     = $(SYSAPI_H)
+libtpm2tctidev_HEADERS  = $(LOCALTPM_H)
+libtpm2tctisock_HEADERS = $(TPMSOCKETS_H)
 
 resourcemgr_resourcemgr_CFLAGS   = $(RESOURCEMGR_INC) $(PTHREAD_CFLAGS)
-resourcemgr_resourcemgr_CXXFLAGS = $(RESOURCEMGR_INC) $(PTHREAD_CFLAGS)
-resourcemgr_resourcemgr_LDADD    = $(noinst_LTLIBRARIES)
+resourcemgr_resourcemgr_LDADD    = $(lib_LTLIBRARIES)
 resourcemgr_resourcemgr_LDFLAGS  = $(PTHREAD_LDFLAGS)
-resourcemgr_resourcemgr_SOURCES  = $(RESOURCEMGR_SRC) $(TPMSOCKETS_SRC) \
-     $(LOCALTPM_SRC) $(COMMON_SRC)
+resourcemgr_resourcemgr_SOURCES  = $(RESOURCEMGR_SRC)
 
-sysapi_libtpm_la_CFLAGS  = -I$(srcdir)/sysapi/include/
-sysapi_libtpm_la_SOURCES = $(SYSAPI_C) $(SYSAPIUTIL_C)
+sysapi_libtpm2sapi_la_CFLAGS  = -I$(srcdir)/sysapi/include/
+sysapi_libtpm2sapi_la_SOURCES = $(SYSAPI_C) $(SYSAPIUTIL_C)
 
-test_tpmclient_tpmclient_CFLAGS   = -DSAPI_CLIENT $(TPMCLIENT_INC)
-test_tpmclient_tpmclient_CXXFLAGS = -DSAPI_CLIENT $(TPMCLIENT_INC)
-test_tpmclient_tpmclient_LDADD    = $(noinst_LTLIBRARIES)
-test_tpmclient_tpmclient_SOURCES  = $(COMMON_SRC) $(SAMPLE_SRC) \
-    $(TPMCLIENT_SRC) $(TPMSOCKETS_SRC)
+tcti_libtpm2tctidev_la_CFLAGS   = $(TCTIDEV_INC)
+tcti_libtpm2tctidev_la_SOURCES  = $(COMMON_C) $(LOCALTPM_C)
 
-test_tpmtest_tpmtest_CFLAGS   = -DSAPI_CLIENT $(TPMTEST_INC)
-test_tpmtest_tpmtest_CXXFLAGS = -DSAPI_CLIENT $(TPMTEST_INC)
-test_tpmtest_tpmtest_LDADD    = $(noinst_LTLIBRARIES)
-test_tpmtest_tpmtest_SOURCES  = $(COMMON_SRC) $(SAMPLE_SRC) \
-    $(TPMTEST_SRC) $(TPMSOCKETS_SRC)
+tcti_libtpm2tctisock_la_CFLAGS   = $(TCTISOCK_INC) $(PTHREAD_CFLAGS)
+tcti_libtpm2tctisock_la_CXXFLAGS = $(TCTISOCK_INC) $(PTHREAD_CFLAGS)
+tcti_libtpm2tctisock_la_LIBADD   = $(libtpm2tctidev)
+tcti_libtpm2tctisock_la_LDFALGS  = $(PTHREAD_LDFLAGS)
+tcti_libtpm2tctisock_la_SOURCES  = $(COMMON_C) $(TPMSOCKETS_CXX) $(RESOURCEMGR_C)
+
+test_tpmclient_tpmclient_CFLAGS   = -DSAPI_CLIENT $(TPMCLIENT_INC) $(PTHREAD_CFLAGS)
+test_tpmclient_tpmclient_CXXFLAGS = -DSAPI_CLIENT $(TPMCLIENT_INC) $(PTHREAD_CFLAGS)
+test_tpmclient_tpmclient_LDADD    = $(libtpm2sapi) $(libtpm2tctisock)
+test_tpmclient_tpmclient_LDFLAGS  = $(PTHREAD_LDFLAGS)
+test_tpmclient_tpmclient_SOURCES  = $(COMMON_C) $(SAMPLE_C) $(TPMCLIENT_CXX)
+
+test_tpmtest_tpmtest_CFLAGS   = -DSAPI_CLIENT $(PTHREAD_CFLAGS) $(TPMTEST_INC)
+test_tpmtest_tpmtest_CXXFLAGS = -DSAPI_CLIENT $(PTHREAD_CFLAGS) $(TPMTEST_INC)
+test_tpmtest_tpmtest_LDADD    = $(libtpm2sapi) $(libtpm2tctisock)
+test_tpmtest_tpmtest_LDFLAGS  = $(PTHREAD_LDFLAGS)
+test_tpmtest_tpmtest_SOURCES  = $(COMMON_C) $(SAMPLE_C) $(TPMTEST_CXX)
+
+TCTIDEV_INC = -I$(srcdir)/sysapi/include -I$(srcdir)/common \
+    -I$(srcdir)/tcti/localtpm -I$(srcdir)/tcti/tpmsockets
+
+TCTISOCK_INC = -I$(srcdir)/sysapi/include -I$(srcdir)/common \
+    -I$(srcdir)/tcti/localtpm -I$(srcdir)/tcti/tpmsockets
 
 RESOURCEMGR_INC = -I$(srcdir)/sysapi/include -I$(srcdir)/common \
     -I$(srcdir)/tcti/tpmsockets -I$(srcdir)/tcti/localtpm \
     -I$(srcdir)/resourcemgr -I$(srcdir)/test/tpmclient
-RESOURCEMGR_SRC = resourcemgr/resourcemgr.c resourcemgr/resourcemgr.h
+RESOURCEMGR_C = resourcemgr/resourcemgr.c
 
 TPMCLIENT_INC = -I$(srcdir)/sysapi/include -I$(srcdir)/test/tpmclient \
     -I$(srcdir)/tcti/tpmsockets -I$(srcdir)/common \
     -I$(srcdir)/test/common/sample -I$(srcdir)/resourcemgr
-TPMCLIENT_SRC = test/tpmclient/tpmclient.cpp test/tpmclient/tpmclient.h
+TPMCLIENT_CXX = test/tpmclient/tpmclient.cpp
 
 TPMTEST_INC = -I$(srcdir)/sysapi/include -I$(srcdir)/test/tpmclient \
     -I$(srcdir)/tcti/tpmsockets -I$(srcdir)/common \
     -I$(srcdir)/test/common/sample -I$(srcdir)/resourcemgr
-TPMTEST_SRC = test/tpmtest/tpmtest.cpp
+TPMTEST_CXX = test/tpmtest/tpmtest.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -31,27 +31,27 @@ include src_vars.mk
 ACLOCAL_AMFLAGS = -I m4
 
 bin_PROGRAMS = resourcemgr/resourcemgr test/tpmclient/tpmclient test/tpmtest/tpmtest
-noinst_LIBRARIES = sysapi/libtpm.a
+noinst_LTLIBRARIES = sysapi/libtpm.la
 
 resourcemgr_resourcemgr_CFLAGS   = $(RESOURCEMGR_INC) $(PTHREAD_CFLAGS)
 resourcemgr_resourcemgr_CXXFLAGS = $(RESOURCEMGR_INC) $(PTHREAD_CFLAGS)
-resourcemgr_resourcemgr_LDADD    = $(noinst_LIBRARIES)
+resourcemgr_resourcemgr_LDADD    = $(noinst_LTLIBRARIES)
 resourcemgr_resourcemgr_LDFLAGS  = $(PTHREAD_LDFLAGS)
 resourcemgr_resourcemgr_SOURCES  = $(RESOURCEMGR_SRC) $(TPMSOCKETS_SRC) \
      $(LOCALTPM_SRC) $(COMMON_SRC)
 
-sysapi_libtpm_a_CFLAGS  = -I$(srcdir)/sysapi/include/
-sysapi_libtpm_a_SOURCES = $(SYSAPI_C) $(SYSAPIUTIL_C)
+sysapi_libtpm_la_CFLAGS  = -I$(srcdir)/sysapi/include/
+sysapi_libtpm_la_SOURCES = $(SYSAPI_C) $(SYSAPIUTIL_C)
 
 test_tpmclient_tpmclient_CFLAGS   = -DSAPI_CLIENT $(TPMCLIENT_INC)
 test_tpmclient_tpmclient_CXXFLAGS = -DSAPI_CLIENT $(TPMCLIENT_INC)
-test_tpmclient_tpmclient_LDADD    = $(noinst_LIBRARIES)
+test_tpmclient_tpmclient_LDADD    = $(noinst_LTLIBRARIES)
 test_tpmclient_tpmclient_SOURCES  = $(COMMON_SRC) $(SAMPLE_SRC) \
     $(TPMCLIENT_SRC) $(TPMSOCKETS_SRC)
 
 test_tpmtest_tpmtest_CFLAGS   = -DSAPI_CLIENT $(TPMTEST_INC)
 test_tpmtest_tpmtest_CXXFLAGS = -DSAPI_CLIENT $(TPMTEST_INC)
-test_tpmtest_tpmtest_LDADD    = $(noinst_LIBRARIES)
+test_tpmtest_tpmtest_LDADD    = $(noinst_LTLIBRARIES)
 test_tpmtest_tpmtest_SOURCES  = $(COMMON_SRC) $(SAMPLE_SRC) \
     $(TPMTEST_SRC) $(TPMSOCKETS_SRC)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -41,7 +41,7 @@ resourcemgr_resourcemgr_SOURCES  = $(RESOURCEMGR_SRC) $(TPMSOCKETS_SRC) \
      $(LOCALTPM_SRC) $(COMMON_SRC)
 
 sysapi_libtpm_a_CFLAGS  = -I$(srcdir)/sysapi/include/
-sysapi_libtpm_a_SOURCES = $(SYSAPI_SRC) $(SYSAPIUTIL_SRC) $(SYSAPI_INC)
+sysapi_libtpm_a_SOURCES = $(SYSAPI_C) $(SYSAPIUTIL_C)
 
 test_tpmclient_tpmclient_CFLAGS   = -DSAPI_CLIENT $(TPMCLIENT_INC)
 test_tpmclient_tpmclient_CXXFLAGS = -DSAPI_CLIENT $(TPMCLIENT_INC)

--- a/bootstrap
+++ b/bootstrap
@@ -33,9 +33,9 @@ echo "Generating file lists: ${VARS_FILE}"
   src_listvar "test/common/sample" "*.h" "SAMPLE_H"
   printf "SAMPLE_SRC = \$(SAMPLE_C) \$(SAMPLE_H)\n"
 
-  src_listvar "tcti/tpmsockets" "*.cpp" "TPMSOCKETS_C"
+  src_listvar "tcti/tpmsockets" "*.cpp" "TPMSOCKETS_CXX"
   src_listvar "tcti/tpmsockets" "*.h" "TPMSOCKETS_H"
-  printf "TPMSOCKETS_SRC = \$(TPMSOCKETS_C) \$(TPMSOCKETS_H)\n"
+  printf "TPMSOCKETS_SRC = \$(TPMSOCKETS_CXX) \$(TPMSOCKETS_H)\n"
 ) > ${VARS_FILE}
 
 printf "Running libtoolize ...\n"

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_INIT([tpm2.0-tss], [0.98])
 AC_CONFIG_MACRO_DIR([m4])
 AC_PROG_CC
 AC_PROG_CXX
-LT_INIT([disable-shared])
+LT_INIT()
 AX_PTHREAD([], [AC_MSG_ERROR([requires pthread])])
 AM_INIT_AUTOMAKE([foreign
                   subdir-objects])


### PR DESCRIPTION
This pull request resolves #37 and #38. To test it do the following:

$ ./bootstrap
$ ./configure --prefix=/usr
$ make -j$(($(nproc)*2)) 2>&1 | tee build.log
$ mkdir destdir && DESTDIR=$(pwd)/destdir make install

This will build the code which will produce the new libraries described in #38. It will then install everything into a subdirectory called 'destdir' in the source tree. This is how most distros build packages but it's useful here so you can see where everything will be installed. You can poke around in this directory to see the libraries landing in destdir/usr/lib and headers in destdir/usr/include.