### PR TITLE
build local tpm TCTI as library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.a
+*.la
+*.lo
 *.o
 *.opensdf
 *.pdb
@@ -6,6 +8,7 @@
 *.suo
 .deps/
 .dirstamp
+.libs
 aclocal.m4
 autom4te.cache/
 [Bb]uild/
@@ -28,3 +31,4 @@ missing
 src_vars.mk
 resourcemgr/resourcemgr
 test/tpmclient/tpmclient
+test/tpmtest/tpmtest

--- a/INSTALL
+++ b/INSTALL
@@ -44,5 +44,11 @@ $ ../TPM2.0-TSS/configure \
   CXXFLAGS="-O0 -Wall -Werror -fno-operator-names -fpermissive -ggdb3"
 $ make
 
-The tpm2.0-tss software currently does not have an install target. This
-section will be updated with installation instructions when they are relevant.
+Once you've built the tpm2.0-tss software it can be installed with:
+$ sudo make install
+
+This will install libtpm2sapi and the resource manager to locations determined
+at configure time. See the output of ./configure --help for the available
+options. Typically you won't need to do much more than provide an alternative
+--prefix option at configure time, and maybe DESTDIR at install time for
+packaging.

--- a/Makefile.am
+++ b/Makefile.am
@@ -30,42 +30,55 @@ include src_vars.mk
 
 ACLOCAL_AMFLAGS = -I m4
 
-bin_PROGRAMS = resourcemgr/resourcemgr test/tpmclient/tpmclient test/tpmtest/tpmtest
-noinst_LTLIBRARIES = sysapi/libtpm.la
+# stuff to build, what that stuff is, and where/if to install said stuff
+sbin_PROGRAMS   = $(resourcemgr)
+noinst_PROGRAMS = $(tpmclient) $(tpmtest)
+lib_LTLIBRARIES = $(libtpm2sapi)
 
+# headers and where to install them
+libtpm2sapidir      = $(includedir)/tpm2sapi
+libtpm2sapi_HEADERS = $(SYSAPI_H)
+
+# how to build stuff
 resourcemgr_resourcemgr_CFLAGS   = $(RESOURCEMGR_INC) $(PTHREAD_CFLAGS)
 resourcemgr_resourcemgr_CXXFLAGS = $(RESOURCEMGR_INC) $(PTHREAD_CFLAGS)
-resourcemgr_resourcemgr_LDADD    = $(noinst_LTLIBRARIES)
+resourcemgr_resourcemgr_LDADD    = $(libtpm2sapi)
 resourcemgr_resourcemgr_LDFLAGS  = $(PTHREAD_LDFLAGS)
-resourcemgr_resourcemgr_SOURCES  = $(RESOURCEMGR_SRC) $(TPMSOCKETS_SRC) \
-     $(LOCALTPM_SRC) $(COMMON_SRC)
+resourcemgr_resourcemgr_SOURCES  = $(RESOURCEMGR_C) $(TPMSOCKETS_CXX) \
+    $(LOCALTPM_C) $(COMMON_C)
 
-sysapi_libtpm_la_CFLAGS  = -I$(srcdir)/sysapi/include/
-sysapi_libtpm_la_SOURCES = $(SYSAPI_C) $(SYSAPIUTIL_C)
+sysapi_libtpm2sapi_la_CFLAGS  = -I$(srcdir)/sysapi/include/
+sysapi_libtpm2sapi_la_SOURCES = $(SYSAPI_C) $(SYSAPIUTIL_C)
 
 test_tpmclient_tpmclient_CFLAGS   = -DSAPI_CLIENT $(TPMCLIENT_INC)
 test_tpmclient_tpmclient_CXXFLAGS = -DSAPI_CLIENT $(TPMCLIENT_INC)
-test_tpmclient_tpmclient_LDADD    = $(noinst_LTLIBRARIES)
-test_tpmclient_tpmclient_SOURCES  = $(COMMON_SRC) $(SAMPLE_SRC) \
-    $(TPMCLIENT_SRC) $(TPMSOCKETS_SRC)
+test_tpmclient_tpmclient_LDADD    = $(libtpm2sapi)
+test_tpmclient_tpmclient_SOURCES  = $(TPMCLIENT_CXX) $(TPMSOCKETS_CXX) \
+    $(COMMON_C) $(SAMPLE_C)
 
 test_tpmtest_tpmtest_CFLAGS   = -DSAPI_CLIENT $(TPMTEST_INC)
 test_tpmtest_tpmtest_CXXFLAGS = -DSAPI_CLIENT $(TPMTEST_INC)
-test_tpmtest_tpmtest_LDADD    = $(noinst_LTLIBRARIES)
-test_tpmtest_tpmtest_SOURCES  = $(COMMON_SRC) $(SAMPLE_SRC) \
-    $(TPMTEST_SRC) $(TPMSOCKETS_SRC)
+test_tpmtest_tpmtest_LDADD    = $(libtpm2sapi)
+test_tpmtest_tpmtest_SOURCES  = $(TPMTEST_CXX) $(TPMSOCKETS_CXX) \
+    $(COMMON_C) $(SAMPLE_C)
 
+# simple variables
 RESOURCEMGR_INC = -I$(srcdir)/sysapi/include -I$(srcdir)/common \
     -I$(srcdir)/tcti/tpmsockets -I$(srcdir)/tcti/localtpm \
     -I$(srcdir)/resourcemgr -I$(srcdir)/test/tpmclient
-RESOURCEMGR_SRC = resourcemgr/resourcemgr.c resourcemgr/resourcemgr.h
+RESOURCEMGR_C = resourcemgr/resourcemgr.c
 
-TPMCLIENT_INC = -I$(srcdir)/sysapi/include -I$(srcdir)/test/tpmclient \
-    -I$(srcdir)/tcti/tpmsockets -I$(srcdir)/common \
+TPMCLIENT_INC = -I$(srcdir)/sysapi/include -I$(srcdir)/tcti/tpmsockets \
+    -I$(srcdir)/test/tpmclient -I$(srcdir)/common \
     -I$(srcdir)/test/common/sample -I$(srcdir)/resourcemgr
-TPMCLIENT_SRC = test/tpmclient/tpmclient.cpp test/tpmclient/tpmclient.h
+TPMCLIENT_CXX = test/tpmclient/tpmclient.cpp
 
-TPMTEST_INC = -I$(srcdir)/sysapi/include -I$(srcdir)/test/tpmclient \
-    -I$(srcdir)/tcti/tpmsockets -I$(srcdir)/common \
+TPMTEST_INC = -I$(srcdir)/sysapi/include -I$(srcdir)/tcti/tpmsockets \
+    -I$(srcdir)/test/tpmclient -I$(srcdir)/common \
     -I$(srcdir)/test/common/sample -I$(srcdir)/resourcemgr
-TPMTEST_SRC = test/tpmtest/tpmtest.cpp
+TPMTEST_CXX = test/tpmtest/tpmtest.cpp
+
+libtpm2sapi = sysapi/libtpm2sapi.la
+resourcemgr = resourcemgr/resourcemgr
+tpmclient   = test/tpmclient/tpmclient
+tpmtest     = test/tpmtest/tpmtest

--- a/Makefile.am
+++ b/Makefile.am
@@ -31,27 +31,27 @@ include src_vars.mk
 ACLOCAL_AMFLAGS = -I m4
 
 bin_PROGRAMS = resourcemgr/resourcemgr test/tpmclient/tpmclient test/tpmtest/tpmtest
-noinst_LIBRARIES = sysapi/libtpm.a
+noinst_LTLIBRARIES = sysapi/libtpm.la
 
 resourcemgr_resourcemgr_CFLAGS   = $(RESOURCEMGR_INC) $(PTHREAD_CFLAGS)
 resourcemgr_resourcemgr_CXXFLAGS = $(RESOURCEMGR_INC) $(PTHREAD_CFLAGS)
-resourcemgr_resourcemgr_LDADD    = $(noinst_LIBRARIES)
+resourcemgr_resourcemgr_LDADD    = $(noinst_LTLIBRARIES)
 resourcemgr_resourcemgr_LDFLAGS  = $(PTHREAD_LDFLAGS)
 resourcemgr_resourcemgr_SOURCES  = $(RESOURCEMGR_SRC) $(TPMSOCKETS_SRC) \
      $(LOCALTPM_SRC) $(COMMON_SRC)
 
-sysapi_libtpm_a_CFLAGS  = -I$(srcdir)/sysapi/include/
-sysapi_libtpm_a_SOURCES = $(SYSAPI_C) $(SYSAPIUTIL_C)
+sysapi_libtpm_la_CFLAGS  = -I$(srcdir)/sysapi/include/
+sysapi_libtpm_la_SOURCES = $(SYSAPI_C) $(SYSAPIUTIL_C)
 
 test_tpmclient_tpmclient_CFLAGS   = -DSAPI_CLIENT $(TPMCLIENT_INC)
 test_tpmclient_tpmclient_CXXFLAGS = -DSAPI_CLIENT $(TPMCLIENT_INC)
-test_tpmclient_tpmclient_LDADD    = $(noinst_LIBRARIES)
+test_tpmclient_tpmclient_LDADD    = $(noinst_LTLIBRARIES)
 test_tpmclient_tpmclient_SOURCES  = $(COMMON_SRC) $(SAMPLE_SRC) \
     $(TPMCLIENT_SRC) $(TPMSOCKETS_SRC)
 
 test_tpmtest_tpmtest_CFLAGS   = -DSAPI_CLIENT $(TPMTEST_INC)
 test_tpmtest_tpmtest_CXXFLAGS = -DSAPI_CLIENT $(TPMTEST_INC)
-test_tpmtest_tpmtest_LDADD    = $(noinst_LIBRARIES)
+test_tpmtest_tpmtest_LDADD    = $(noinst_LTLIBRARIES)
 test_tpmtest_tpmtest_SOURCES  = $(COMMON_SRC) $(SAMPLE_SRC) \
     $(TPMTEST_SRC) $(TPMSOCKETS_SRC)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -41,7 +41,7 @@ resourcemgr_resourcemgr_SOURCES  = $(RESOURCEMGR_SRC) $(TPMSOCKETS_SRC) \
      $(LOCALTPM_SRC) $(COMMON_SRC)
 
 sysapi_libtpm_a_CFLAGS  = -I$(srcdir)/sysapi/include/
-sysapi_libtpm_a_SOURCES = $(SYSAPI_SRC) $(SYSAPIUTIL_SRC) $(SYSAPI_INC)
+sysapi_libtpm_a_SOURCES = $(SYSAPI_C) $(SYSAPIUTIL_C)
 
 test_tpmclient_tpmclient_CFLAGS   = -DSAPI_CLIENT $(TPMCLIENT_INC)
 test_tpmclient_tpmclient_CXXFLAGS = -DSAPI_CLIENT $(TPMCLIENT_INC)

--- a/Makefile.am
+++ b/Makefile.am
@@ -33,22 +33,27 @@ ACLOCAL_AMFLAGS = -I m4
 # stuff to build, what that stuff is, and where/if to install said stuff
 sbin_PROGRAMS   = $(resourcemgr)
 noinst_PROGRAMS = $(tpmclient) $(tpmtest)
-lib_LTLIBRARIES = $(libtpm2sapi)
+lib_LTLIBRARIES = $(libtpm2sapi) $(libtpm2tctidev)
 
 # headers and where to install them
 libtpm2sapidir      = $(includedir)/tpm2sapi
 libtpm2sapi_HEADERS = $(SYSAPI_H)
+libtpm2tctidir      = $(includedir)/tpm2tcti
+libtpm2tcti_HEADERS = $(LOCALTPM_H)
 
 # how to build stuff
 resourcemgr_resourcemgr_CFLAGS   = $(RESOURCEMGR_INC) $(PTHREAD_CFLAGS)
 resourcemgr_resourcemgr_CXXFLAGS = $(RESOURCEMGR_INC) $(PTHREAD_CFLAGS)
-resourcemgr_resourcemgr_LDADD    = $(libtpm2sapi)
+resourcemgr_resourcemgr_LDADD    = $(libtpm2sapi) $(libtpm2tctidev)
 resourcemgr_resourcemgr_LDFLAGS  = $(PTHREAD_LDFLAGS)
 resourcemgr_resourcemgr_SOURCES  = $(RESOURCEMGR_C) $(TPMSOCKETS_CXX) \
-    $(LOCALTPM_C) $(COMMON_C)
+    $(COMMON_C)
 
 sysapi_libtpm2sapi_la_CFLAGS  = -I$(srcdir)/sysapi/include/
 sysapi_libtpm2sapi_la_SOURCES = $(SYSAPI_C) $(SYSAPIUTIL_C)
+
+tcti_libtpm2tctidev_la_CFLAGS   = $(TCTIDEV_INC)
+tcti_libtpm2tctidev_la_SOURCES  = common/debug.c $(LOCALTPM_C)
 
 test_tpmclient_tpmclient_CFLAGS   = -DSAPI_CLIENT $(TPMCLIENT_INC)
 test_tpmclient_tpmclient_CXXFLAGS = -DSAPI_CLIENT $(TPMCLIENT_INC)
@@ -68,6 +73,9 @@ RESOURCEMGR_INC = -I$(srcdir)/sysapi/include -I$(srcdir)/common \
     -I$(srcdir)/resourcemgr -I$(srcdir)/test/tpmclient
 RESOURCEMGR_C = resourcemgr/resourcemgr.c
 
+TCTIDEV_INC = -I$(srcdir)/sysapi/include -I$(srcdir)/common \
+    -I$(srcdir)/tcti/localtpm
+
 TPMCLIENT_INC = -I$(srcdir)/sysapi/include -I$(srcdir)/tcti/tpmsockets \
     -I$(srcdir)/test/tpmclient -I$(srcdir)/common \
     -I$(srcdir)/test/common/sample -I$(srcdir)/resourcemgr
@@ -79,6 +87,7 @@ TPMTEST_INC = -I$(srcdir)/sysapi/include -I$(srcdir)/tcti/tpmsockets \
 TPMTEST_CXX = test/tpmtest/tpmtest.cpp
 
 libtpm2sapi = sysapi/libtpm2sapi.la
+libtpm2tctidev = tcti/libtpm2tctidev.la
 resourcemgr = resourcemgr/resourcemgr
 tpmclient   = test/tpmclient/tpmclient
 tpmtest     = test/tpmtest/tpmtest

--- a/bootstrap
+++ b/bootstrap
@@ -33,9 +33,9 @@ echo "Generating file lists: ${VARS_FILE}"
   src_listvar "test/common/sample" "*.h" "SAMPLE_H"
   printf "SAMPLE_SRC = \$(SAMPLE_C) \$(SAMPLE_H)\n"
 
-  src_listvar "tcti/tpmsockets" "*.cpp" "TPMSOCKETS_C"
+  src_listvar "tcti/tpmsockets" "*.cpp" "TPMSOCKETS_CXX"
   src_listvar "tcti/tpmsockets" "*.h" "TPMSOCKETS_H"
-  printf "TPMSOCKETS_SRC = \$(TPMSOCKETS_C) \$(TPMSOCKETS_H)\n"
+  printf "TPMSOCKETS_SRC = \$(TPMSOCKETS_CXX) \$(TPMSOCKETS_H)\n"
 ) > ${VARS_FILE}
 
 printf "Running libtoolize ...\n"

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_INIT([tpm2.0-tss], [0.98])
 AC_CONFIG_MACRO_DIR([m4])
 AC_PROG_CC
 AC_PROG_CXX
-LT_INIT([disable-shared])
+LT_INIT()
 AX_PTHREAD([], [AC_MSG_ERROR([requires pthread])])
 AM_INIT_AUTOMAKE([foreign
                   subdir-objects])


### PR DESCRIPTION
This PR builds on #60 
It separates the local TPM TCTI into it's own library.
Additionally the resourcemgr now links against this library instead of including the sources directly.