### PR TITLE
Add LICENSE file identifying the two licenses in play.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,91 @@
+All copyrights belong to the respective authors of the source code. The
+copyright holder of each source file is clearly indicated in the license
+header of each file.
+
+The source code for this project is provided under two separate licenses. The
+license for each source file is indicated in a comment block at the head of
+the file. For completeness we provide a summary of the relevant sources and
+their license text in full here.
+
+The following files are provided under license from the Trusted Computing
+Group:
+sysapi/include/implementation.h
+sysapi/include/tpmb.h
+sysapi/include/basetypes.h
+
+The text of Trusted Computing Group license is as follows:
+/* Licenses and Notices
+1.	Copyright Licenses:
+
+    Trusted Computing Group (TCG) grants to the user of the source code in
+    this specification (the "Source Code") a worldwide, irrevocable, nonexclusive,
+    royalty free, copyright license to reproduce, create derivative works,
+    distribute, display and perform the Source Code and derivative works
+    thereof, and to grant others the rights granted herein.
+
+    The TCG grants to the user of the other parts of the specification
+    (other than the Source Code) the rights to reproduce, distribute,
+    display, and perform the specification solely for the purpose of
+    developing products based on such documents.
+    
+2.	Source Code Distribution Conditions:
+
+    Redistributions of Source Code must retain the above copyright licenses,
+    this list of conditions and the following disclaimers.
+    
+	Redistributions in binary form must reproduce the above copyright
+    licenses, this list of conditions and the following disclaimers in
+    the documentation and/or other materials provided with the distribution.
+    
+3.	Disclaimers:
+
+    THE COPYRIGHT LICENSES SET FORTH ABOVE DO NOT REPRESENT ANY FORM OF LICENSE
+    OR WAIVER, EXPRESS OR IMPLIED, BY ESTOPPEL OR OTHERWISE, WITH RESPECT TO
+    PATENT RIGHTS HELD BY TCG MEMBERS (OR OTHER THIRD PARTIES) THAT MAY BE NECESSARY
+    TO IMPLEMENT THIS SPECIFICATION OR OTHERWISE. Contact TCG Administration
+    (admin@trustedcomputinggroup.org) for information on specification licensing
+    rights available through TCG membership agreements.
+    
+	THIS SPECIFICATION IS PROVIDED "AS IS" WITH NO EXPRESS OR IMPLIED WARRANTIES
+    WHATSOEVER, INCLUDING ANY WARRANTY OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR
+    PURPOSE, ACCURACY, COMPLETENESS, OR NONINFRINGEMENT OF INTELLECTUAL PROPERTY
+    RIGHTS, OR ANY WARRANTY OTHERWISE ARISING OUT OF ANY PROPOSAL, SPECIFICATION
+    OR SAMPLE.
+
+    Without limitation, TCG and its members and licensors disclaim all liability,
+    including liability for infringement of any proprietary rights, relating to
+    use of information in this specification and to the implementation of this
+    specification, and TCG disclaims all liability for cost of procurement of
+    substitute goods or services, lost profits, loss of use, loss of data or any
+    incidental, consequential, direct, indirect, or special damages, whether
+    under contract, tort, warranty or otherwise, arising in any way out of use
+    or reliance upon this specification or any information herein.
+    
+Any marks and brands contained herein are the property of their respective owner.
+*/
+
+All other sources are provided under a 2-Clause BSD license. The full text of
+this license is as follows:
+/*
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGE.
+*/


### PR DESCRIPTION
This file includes the full text of the 2-clause BSD license used
by Intel, as well as the TCG license. Any future changes to the
licenses in play will be reflected in this file as well as the
relevant source files.

This resolves #67

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>