### PR TITLE
Fixing error for using TSS with tboot 1.8.3(TPM 2.0)

### DIFF
--- a/resourcemgr/resourcemgr.c
+++ b/resourcemgr/resourcemgr.c
@@ -2058,11 +2058,11 @@ exitResourceMgrReceiveTpmResponse:
     
     PrintRMTables();
 
+	// Test and show warning
     testForLoadedSessionsOrObjectsRval = TestForLoadedHandles();
+	if( testForLoadedSessionsOrObjectsRval != TSS2_RC_SUCCESS)
+		ResMgrPrintf( RM_PREFIX, "Result of test for loaded handles : 0x%X\n", testForLoadedSessionsOrObjectsRval );
 
-    if( responseRval == TSS2_RC_SUCCESS )
-        responseRval = testForLoadedSessionsOrObjectsRval;
-    
     if( responseRval != TSS2_RC_SUCCESS )
     {
         // If RM internal error or error from layers below RM occurred,


### PR DESCRIPTION
This commit solves issue #83. tboot 1.8.3(TPM 2.0) creates a
primary hierarchy handle and an object handle during boot process.
However the resource manager of TSS seems to presume these handles
as abnormal objects and returns an error code to the client.

To solve this problem, the resource manager is changed to show
warning instead of returning an error to the client.