### PR TITLE
[resourcemgr]fix for Tss2_Sys_ContextSave(session)

### DIFF
--- a/resourcemgr/resourcemgr.c
+++ b/resourcemgr/resourcemgr.c
@@ -2070,6 +2070,8 @@ returnFromResourceMgrReceiveTpmResponse:
     // If command was FlushContext, the entry was already removed from the list.  No eviction
     // necsssary or possible (because no entry exists for this object or sequence anymore).
     if( numHandles &&
+            !( currentCommandCode == TPM_CC_ContextSave &&
+                IsSessionHandle( cmdSavedHandle ) ) &&
             ( currentCommandCode != TPM_CC_FlushContext ) )
     {
         // Create array of handles.


### PR DESCRIPTION
Execute tpmtest with resourcemgr connected to simulator, then follow the hint to run all tests in 2 - STARTUP TESTS, then run all tests in 10 - START_AUTH_SESSION TESTS, will get failure code 0xCF802(TSS2_RESMGR_FIND_FAILED).

The root cause is that the in memory context will be flushed after running savecontext for a session, so the original code try to prevent resourcemgr automatically evicting the context again via setting foundEntryPtr->status.loaded = 0. But this will cause the final call to EvictEntities failed.

The solution is to avoid calling into EvictEntities for Tss2_Sys_ContextSave(session) case while adding more if conditions.