### PR TITLE
Added codes for flushing loaded handles before the resource manager is started.

### DIFF
--- a/resourcemgr/resourcemgr.c
+++ b/resourcemgr/resourcemgr.c
@@ -613,6 +613,63 @@ endTestForLoadedHandles:
     return rval;
 }    
 
+TSS2_RC FlushAllLoadedHandles()
+{
+    TPMS_CAPABILITY_DATA capabilityData;
+    TSS2_RC rval = TSS2_RC_SUCCESS;
+    TPMI_YES_NO moreData;
+    UINT32 i;
+
+    rval = Tss2_Sys_GetCapability( resMgrSysContext, 0,
+            TPM_CAP_HANDLES, TRANSIENT_FIRST,
+            20, &moreData, &capabilityData, 0 );
+    if( rval != TSS2_RC_SUCCESS )
+        goto endFlushAllLoadedHandles;
+
+    if( capabilityData.data.handles.count != 0 )
+    {
+        ResMgrPrintf( RM_PREFIX, "Flush loaded transient object handles: \n" );
+        ResMgrPrintf( RM_PREFIX, "" );
+        for( i = 0; i < capabilityData.data.handles.count; i++ )
+        {
+            ResMgrPrintf( NO_PREFIX, "0x%8x, ", capabilityData.data.handles.handle[i] );
+            rval = Tss2_Sys_FlushContext( resMgrSysContext, capabilityData.data.handles.handle[i] );
+            if( rval != TSS2_RC_SUCCESS )
+            {
+                SetRmErrorLevel( &rval, TSS2_RESMGR_ERROR_LEVEL );
+                goto endFlushAllLoadedHandles;
+            }
+        }
+        ResMgrPrintf( NO_PREFIX, "\n" );
+    }
+
+    rval = Tss2_Sys_GetCapability( resMgrSysContext, 0,
+            TPM_CAP_HANDLES, LOADED_SESSION_FIRST,
+            20, &moreData, &capabilityData, 0 );
+    if( rval != TSS2_RC_SUCCESS )
+        goto endFlushAllLoadedHandles;
+
+    if( capabilityData.data.handles.count != 0 )
+    {
+        ResMgrPrintf( RM_PREFIX, "Flush loaded session handles: \n" );
+        for( i = 0; i < capabilityData.data.handles.count; i++ )
+        {
+            ResMgrPrintf( NO_PREFIX, "0x%8x, ", capabilityData.data.handles.handle[i] );
+            rval = Tss2_Sys_FlushContext( resMgrSysContext, capabilityData.data.handles.handle[i] );
+            if( rval != TSS2_RC_SUCCESS )
+            {
+                SetRmErrorLevel( &rval, TSS2_RESMGR_ERROR_LEVEL );
+                goto endFlushAllLoadedHandles;
+            }
+        }
+        ResMgrPrintf( NO_PREFIX, "\n" );
+    }
+
+endFlushAllLoadedHandles:
+
+    return rval;
+}
+
 
 
 TSS2_RC AddEntry( TPM_HANDLE virtualHandle, TPM_HANDLE realHandle, TPM_HANDLE parentHandle,
@@ -2971,6 +3028,14 @@ int main(int argc, char* argv[])
     if( rval != TSS2_RC_SUCCESS )
     {
         printf( "Resource Mgr failed to initialize.  Exiting...\n" );
+        return( 1 );
+    }
+
+    // Flush all loaded handles
+    rval = FlushAllLoadedHandles();
+    if( rval != TSS2_RC_SUCCESS )
+    {
+        printf( "Resource Mgr failed to flush all loaded handles.  Exiting...\n" );
         return( 1 );
     }
 


### PR DESCRIPTION
Added codes for flushing loaded handles before the resource manager is started.

tboot 1.8.3(TPM 2.0) create an object handle during boot process.
However, the resource manager of TSS seems to presume this handle as abnormal object and returns an error code to client.

To solve this problems, the resource manager is changed to flush all loaded handles before the resource manager is started.

This commit solved issue #83