### PR TITLE
When previously autogenerating code from 1.26 version of TPM 2.0 spec,

### DIFF
--- a/sysapi/include/tss2_sys_api_marshalUnmarshal.h
+++ b/sysapi/include/tss2_sys_api_marshalUnmarshal.h
@@ -509,6 +509,11 @@ void Marshal_TPMT_SENSITIVE(
 	TPMT_SENSITIVE *sensitive
 	);
 
+void Marshal_TPMS_NV_PIN_COUNTER_PARAMETERS(
+	TSS2_SYS_CONTEXT *sysContext,
+	TPMS_NV_PIN_COUNTER_PARAMETERS *nvPinCounterParameters
+	);
+
 void Marshal_TPMA_NV(
 	TSS2_SYS_CONTEXT *sysContext,
 	TPMA_NV nv
@@ -950,6 +955,11 @@ void Unmarshal_TPMT_SENSITIVE(
 void Unmarshal_TPM2B_SENSITIVE(
 	TSS2_SYS_CONTEXT *sysContext,
 	TPM2B_SENSITIVE *sensitive
+	);
+
+void Unmarshal_TPMS_NV_PIN_COUNTER_PARAMETERS(
+	TSS2_SYS_CONTEXT *sysContext,
+	TPMS_NV_PIN_COUNTER_PARAMETERS *nvPinCounterParameters
 	);
 
 void Unmarshal_TPMA_NV(

--- a/sysapi/include/tss2_tpm2_types.h
+++ b/sysapi/include/tss2_tpm2_types.h
@@ -67,9 +67,9 @@ typedef	UINT16	TPM_KEY_BITS;	 /* a key size in bits  */
 typedef	UINT32 TPM_SPEC;
 #define	TPM_SPEC_FAMILY	(0x322E3000 )	 /* ASCII 2.0 with null terminator  */
 #define	TPM_SPEC_LEVEL	(00 )	 /* the level number for the specification  */
-#define	TPM_SPEC_VERSION	(1265 )	 /* the version number of the spec 001.256 * 100  */
+#define	TPM_SPEC_VERSION	(126 )	 /* the version number of the spec 001.26 * 100  */
 #define	TPM_SPEC_YEAR	(2015 )	 /* the year of the version  */
-#define	TPM_SPEC_DAY_OF_YEAR	(219233 )	 /* the day of the year August 1021 2015  */
+#define	TPM_SPEC_DAY_OF_YEAR	(233 )	 /* the day of the year August 21 2015  */
 
 /* Table 7  Definition of UINT32 TPM_GENERATED Constants <O> */
 typedef	UINT32 TPM_GENERATED;
@@ -1802,8 +1802,14 @@ typedef uint32_t	TPM_NV_INDEX;
 #define	TPM_NT_COUNTER	(0x1 )	 /* Counter  contains an 8octet value that is to be used as a counter and can only be modified with TPM2_NV_Increment  */
 #define	TPM_NT_BITS	(0x2 )	 /* Bit Field  contains an 8octet value to be used as a bit field and can only be modified with TPM2_NV_SetBits.  */
 #define	TPM_NT_EXTEND	(0x4 )	 /* Extend  contains a digestsized value used like a PCR. The Index can only be modified using TPM2_NV_Extend. The extend will use the nameAlg of the Index.  */
-#define	TPM_NT_PIN_FAIL	(0x8 )	 /* PIN Fail  contains a PIN limit and a pinCountPIN count that increments on a PIN authorization failure and a pinLimit  */
-#define	TPM_NT_PIN_PASS	(0x9 )	 /* PIN Pass  contains a PIN limit and a PIN countpinCount that increments on a PIN authorization success and a pinLimit  */
+#define	TPM_NT_PIN_FAIL	(0x8 )	 /* PIN Fail  contains a pinCount that increments on a PIN authorization failure and a pinLimit  */
+#define	TPM_NT_PIN_PASS	(0x9 )	 /* PIN Pass  contains a pinCount that increments on a PIN authorization success and a pinLimit  */
+
+/* Table 196  Definition of TPMS_NV_PIN_COUNTER_PARAMETERS Structure */
+typedef	struct {
+	UINT32	pinCount;	 /* This counter shows the current number of successful authValue authorization attempts to access a TPM_NT_PIN_PASS index or the current number of unsuccessful authValue authorization attempts to access a TPM_NT_PIN_FAIL index.  */
+	UINT32	pinLimit;	 /* This threshold is the value of pinCount at which the authValue authorization of the host TPM_NT_PIN_PASS or TPM_NT_PIN_FAIL index is locked out.  */
+} TPMS_NV_PIN_COUNTER_PARAMETERS;
 
 /* Table 197  Definition of UINT32 TPMA_NV Bits */
 #if defined TPM_BITFIELD_LE

--- a/sysapi/sysapi_util/Marshal_TPMS_NV_PIN_COUNTER_PARAMETERS.c
+++ b/sysapi/sysapi_util/Marshal_TPMS_NV_PIN_COUNTER_PARAMETERS.c
@@ -1,0 +1,43 @@
+/***********************************************************************;
+ * Copyright (c) 2015, Intel Corporation
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without 
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, 
+ * this list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice, 
+ * this list of conditions and the following disclaimer in the documentation 
+ * and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ ***********************************************************************/
+
+#include <tpm20.h>   
+#include <tss2_sysapi_util.h>   
+
+void Marshal_TPMS_NV_PIN_COUNTER_PARAMETERS(
+	TSS2_SYS_CONTEXT *sysContext,
+	TPMS_NV_PIN_COUNTER_PARAMETERS *nvPinCounterParameters
+	)
+{
+	if( SYS_CONTEXT->rval != TSS2_RC_SUCCESS )
+		return;
+
+	Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), nvPinCounterParameters->pinCount, &( SYS_CONTEXT->rval ) );
+	Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), nvPinCounterParameters->pinLimit, &( SYS_CONTEXT->rval ) );
+
+	return;
+}

--- a/sysapi/sysapi_util/Unmarshal_TPMS_NV_PIN_COUNTER_PARAMETERS.c
+++ b/sysapi/sysapi_util/Unmarshal_TPMS_NV_PIN_COUNTER_PARAMETERS.c
@@ -1,0 +1,46 @@
+/***********************************************************************;
+ * Copyright (c) 2015, Intel Corporation
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without 
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, 
+ * this list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice, 
+ * this list of conditions and the following disclaimer in the documentation 
+ * and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ ***********************************************************************/
+
+#include <tpm20.h>   
+#include <tss2_sysapi_util.h>   
+
+void Unmarshal_TPMS_NV_PIN_COUNTER_PARAMETERS(
+	TSS2_SYS_CONTEXT *sysContext,
+	TPMS_NV_PIN_COUNTER_PARAMETERS *nvPinCounterParameters
+	)
+{
+	if( SYS_CONTEXT->rval != TSS2_RC_SUCCESS )
+		return;
+
+	if( nvPinCounterParameters == 0 )
+		return;
+
+	Unmarshal_UINT32( SYS_CONTEXT->tpmOutBuffPtr, SYS_CONTEXT->maxResponseSize, &(SYS_CONTEXT->nextData), &nvPinCounterParameters->pinCount, &( SYS_CONTEXT->rval ) );
+	Unmarshal_UINT32( SYS_CONTEXT->tpmOutBuffPtr, SYS_CONTEXT->maxResponseSize, &(SYS_CONTEXT->nextData), &nvPinCounterParameters->pinLimit, &( SYS_CONTEXT->rval ) );
+
+	return;
+}


### PR DESCRIPTION
I forgot to accept all revisions.  This resulted in a few weird values
even though everything would still build.