### PR TITLE
Add TravisCI and AppVeyor build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: cpp
+compiler:
+  - clang
+  - gcc
+
+addons:
+  apt:
+    packages:
+    - autoconf-archive
+
+install: true
+
+before_script:
+  - ./bootstrap
+script:
+  - mkdir ./build
+  - pushd ./build
+  - ../configure
+  - make 
+  - make test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,8 @@
+version: 1.0.{build}
+environment:
+  TSSTOOLS_PATH: '"C:\Program Files (x86)\Microsoft Visual Studio 10.0"'
+build:
+  project: tss.sln
+  parallel: true
+  verbosity: minimal
+


### PR DESCRIPTION
Testing automatic builds on TravisCI and AppVeyor.

1. Adds a simple .travis.yml build config (Ubuntu Precise).
2. Similarly, a simple appveyor.yml build config (Windows).

Both TravisCI and AppVeyor can be used to produce binary builds of the project code. But more importantly, they can test each platform so developers can check if their pull results might break the alternatesupported build.