### PR TITLE
Move TCTI_MAGIC and TCTI_VERSION values to a common include.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,6 +29,8 @@
 include src_vars.mk
 
 ACLOCAL_AMFLAGS = -I m4
+AM_CFLAGS = -I$(srcdir)/include
+AM_CPPFLAGS = -I$(srcdir)/include
 
 # stuff to build, what that stuff is, and where/if to install said stuff
 sbin_PROGRAMS   = $(resourcemgr)

--- a/include/tpm2sapi/tss2_sysapi_util.h
+++ b/include/tpm2sapi/tss2_sysapi_util.h
@@ -43,9 +43,6 @@ extern "C" {
 
 enum cmdStates { CMD_STAGE_INITIALIZE, CMD_STAGE_PREPARE, CMD_STAGE_SEND_COMMAND, CMD_STAGE_RECEIVE_RESPONSE, CMD_STAGE_ALL = 0xff };
 
-#define TCTI_MAGIC 0x7e18e9defa8bc9e2
-#define TCTI_VERSION 0x1
-
 typedef struct {
     //
     // These are inputs to system API functions.

--- a/include/tpm2tcti/localtpm.h
+++ b/include/tpm2tcti/localtpm.h
@@ -32,6 +32,8 @@
 extern "C" {
 #endif
 
+#include <tpm2tcti/magic.h>
+
 TSS2_RC InitLocalTpmTcti (
     TSS2_TCTI_CONTEXT *tctiContext, // OUT
     size_t *contextSize,            // IN/OUT

--- a/include/tpm2tcti/magic.h
+++ b/include/tpm2tcti/magic.h
@@ -1,0 +1,4 @@
+#pragma once
+
+#define TCTI_MAGIC 0x7e18e9defa8bc9e2
+#define TCTI_VERSION 0x1

--- a/include/tpm2tcti/tpmsockets.h
+++ b/include/tpm2tcti/tpmsockets.h
@@ -32,6 +32,8 @@
 extern "C" {
 #endif
 
+#include <tpm2tcti/magic.h>
+
 #ifndef _WIN32
 #include <sys/socket.h>
 #include <sys/un.h>

--- a/resourcemgr/resourceMgr.vcxproj
+++ b/resourcemgr/resourceMgr.vcxproj
@@ -39,7 +39,7 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
-    <IncludePath>$(SolutionDir)tcti\commontcti;$(IncludePath);..\include\tpm2sapi;..\test\tpmclient;..\common;..\include\tpm2tcti</IncludePath>
+    <IncludePath>$(SolutionDir)tcti\commontcti;$(IncludePath);..\include\tpm2sapi;..\test\tpmclient;..\common;..\include\tpm2tcti;..\include</IncludePath>
     <OutDir>$(Configuration)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/tcti/commonTcti/commonchecks.c
+++ b/tcti/commonTcti/commonchecks.c
@@ -28,6 +28,7 @@
 #include <stdio.h>
 #include <stdlib.h>   // Needed for _wtoi
 
+#include <tpm2tcti/magic.h>
 #include "tpm20.h"
 #include "tss2_sysapi_util.h"
 #include "debug.h"


### PR DESCRIPTION
These two values must be specified by clients consuming our TCTI
interface. Currently they reside in the tss2_sapi_util.h file that we
include in the tpm2sapi headers. This is a non-standard file that will
be removed soon and so this value must be moved to keep from breaking
client code. Since these two values are used by both the dev and socket
TCTIs I've put them into a common 'magic.h' file.

This resolves #109

Signed-off-by: Philip Tricca <flihp@twobit.us>