### PR TITLE
Incomplete macro __cplusplus

### DIFF
--- a/tcti/commonTcti/commonchecks.c
+++ b/tcti/commonTcti/commonchecks.c
@@ -100,3 +100,8 @@ retCommonReceiveChecks:
 
     return rval;
 }
+
+#ifdef __cplusplus
+}
+#endif
+


### PR DESCRIPTION
The macro defined with extern "c" seems to incomplete .
This patch helps to fix the closure of the defined macro 
