### PR TITLE
tpmtest: add a missed size initialization

### DIFF
--- a/test/tpmtest/tpmtest.cpp
+++ b/test/tpmtest/tpmtest.cpp
@@ -2831,7 +2831,7 @@ void TestPolicy()
     for( i = 0; i < num; i++ )
     {
         TPM2B_DIGEST policyDigest;
-
+        policyDigest.t.size = sizeof( policyDigest ) - 2;
         rval = TPM_RC_SUCCESS;
 
         printf( "Policy Test: %s\n", policyTestSetups[i].name );


### PR DESCRIPTION
This might cause random failures.