### PR TITLE
Tcti init cfg

### DIFF
--- a/include/tcti/tcti_device.h
+++ b/include/tcti/tcti_device.h
@@ -34,29 +34,21 @@ extern "C" {
 
 #include <tcti/magic.h>
 
+typedef struct {
+    const char *device_path;
+} TCTI_DEVICE_CONF;
+
 TSS2_RC InitDeviceTcti (
     TSS2_TCTI_CONTEXT *tctiContext, // OUT
     size_t *contextSize,            // IN/OUT
-    const char *config,              // IN
+    const TCTI_DEVICE_CONF *config,              // IN
     const uint64_t magic,
     const uint32_t version,
-	const char *interfaceName,
-    const uint8_t serverSockets  // Unused for local TPM.
+    const char *interfaceName
     );
-
-TSS2_RC TeardownDeviceTcti (
-    TSS2_TCTI_CONTEXT *tctiContext, // OUT
-    const char *config,              // IN        
-	const char *interfaceName
-    );
-
-#define DEVICE_TCTI_CONFIG_SIZE 250
-
-extern char deviceTctiConfig[DEVICE_TCTI_CONFIG_SIZE];
-
-extern TSS2_RC InitDeviceTctiContext( const char *driverConfig, TSS2_TCTI_CONTEXT **tctiContext );
-
-extern TSS2_RC TeardownDeviceTctiContext( const char *driverConfig, TSS2_TCTI_CONTEXT *tctiContext );
+TSS2_RC InitDeviceTctiContext( const TCTI_DEVICE_CONF *config, TSS2_TCTI_CONTEXT **tctiContext );
+TSS2_RC TeardownDeviceTcti( TSS2_TCTI_CONTEXT *tctiContext );
+TSS2_RC TeardownDeviceTctiContext( TSS2_TCTI_CONTEXT *tctiContext );
 
 #ifdef __cplusplus
 }

--- a/include/tcti/tcti_device.h
+++ b/include/tcti/tcti_device.h
@@ -48,7 +48,6 @@ TSS2_RC InitDeviceTcti (
     );
 TSS2_RC InitDeviceTctiContext( const TCTI_DEVICE_CONF *config, TSS2_TCTI_CONTEXT **tctiContext );
 TSS2_RC TeardownDeviceTcti( TSS2_TCTI_CONTEXT *tctiContext );
-TSS2_RC TeardownDeviceTctiContext( TSS2_TCTI_CONTEXT *tctiContext );
 
 #ifdef __cplusplus
 }

--- a/include/tcti/tcti_socket.h
+++ b/include/tcti/tcti_socket.h
@@ -67,31 +67,30 @@ int WSAGetLastError();
 
 #define DEFAULT_HOSTNAME        "127.0.0.1"
 
-#define HOSTNAME_LENGTH 200
-
 TSS2_RC PlatformCommand(
     TSS2_TCTI_CONTEXT *tctiContext,     /* in */
     char cmd );
 
-int InitSockets( char *hostName, int port, UINT8 serverSockets, SOCKET *otherSock, SOCKET *tpmSock );
+int InitSockets( const char *hostName, UINT16 port, UINT8 serverSockets, SOCKET *otherSock, SOCKET *tpmSock );
 
 void CloseSockets( SOCKET serverSock, SOCKET tpmSock );
+
+typedef struct {
+    const char *hostname;
+    uint16_t port;
+} TCTI_SOCKET_CONF;
 
 TSS2_RC InitSocketTcti (
     TSS2_TCTI_CONTEXT *tctiContext, // OUT
     size_t *contextSize,            // IN/OUT
-    const char *config,             // IN        
+    const TCTI_SOCKET_CONF *config,             // IN
     const uint64_t magic,
     const uint32_t version,
 	const char *interfaceName,
     const uint8_t serverSockets
     );
 
-TSS2_RC TeardownSocketTcti (
-    TSS2_TCTI_CONTEXT *tctiContext, // OUT
-    const char *config,             // IN        
-	const char *interfaceName
-    );
+TSS2_RC TeardownSocketTcti (TSS2_TCTI_CONTEXT *tctiContext);
 
 TSS2_RC recvBytes( SOCKET tpmSock, unsigned char *data, int len );
 

--- a/resourcemgr/resourcemgr.c
+++ b/resourcemgr/resourcemgr.c
@@ -2584,9 +2584,8 @@ UINT32 WINAPI SockServer( LPVOID servStruct )
 #define interfaceConfigSize 250
 
 char simInterfaceConfig[interfaceConfigSize];
-    
-extern TSS2_TCTI_DRIVER_INFO deviceTctiInfo;
-TSS2_TCTI_DRIVER_INFO simInterfaceInfo = { "simulator", "", InitSocketTcti, TeardownSocketTcti };
+const char *resDeviceTctiName = "device TCTI";
+const char *resSocketTctiName = "socket TCTI";
 
 SOCKET simOtherSock;
 SOCKET simTpmSock;
@@ -2597,13 +2596,13 @@ TSS2_RC InitSimulatorTctiContext( const char *driverConfig, TSS2_TCTI_CONTEXT **
     
     TSS2_RC rval = TSS2_RC_SUCCESS;
 
-    rval = simInterfaceInfo.initialize(NULL, &size, driverConfig, 0, 0, simInterfaceInfo.shortName, 1 );
+    rval = InitSocketTcti(NULL, &size, driverConfig, 0, 0, resSocketTctiName, 1 );
     if( rval != TSS2_RC_SUCCESS )
         return rval;
     
     downstreamTctiContext = malloc(size);
 
-    rval = simInterfaceInfo.initialize(*tctiContext, &size, driverConfig, TCTI_MAGIC, TCTI_VERSION, simInterfaceInfo.shortName, 0 );
+    rval = InitSocketTcti(*tctiContext, &size, driverConfig, TCTI_MAGIC, TCTI_VERSION, resSocketTctiName, 0 );
     return rval;
 }
 
@@ -2611,7 +2610,7 @@ TSS2_RC TeardownSimulatorTctiContext( const char *driverConfig )
 {
     TSS2_RC rval;
 
-    rval = simInterfaceInfo.teardown(NULL, driverConfig, simInterfaceInfo.shortName );
+    rval = TeardownSocketTcti(NULL, driverConfig, resSocketTctiName );
     if( rval != TSS2_RC_SUCCESS )
         return rval;
 
@@ -2627,10 +2626,10 @@ TSS2_RC TeardownResMgr(
 
 #if __linux || __unix
     if( !simulator )
-        TeardownSocketTcti( tctiContext, config, deviceTctiInfo.shortName );
+        TeardownSocketTcti( tctiContext, config, resDeviceTctiName );
     else
 #endif        
-        TeardownSocketTcti( tctiContext, config, simInterfaceInfo.shortName );
+        TeardownSocketTcti( tctiContext, config, resSocketTctiName );
 
     TeardownSysContext( &resMgrSysContext );
 
@@ -2986,7 +2985,7 @@ int main(int argc, char* argv[])
         rval = InitDeviceTctiContext( deviceTctiConfig, &downstreamTctiContext );
         if( rval != TSS2_RC_SUCCESS )
         {
-            ResMgrPrintf( NO_PREFIX,  "Resource Mgr, %s, failed initialization: 0x%x.  Exiting...\n", deviceTctiInfo.shortName, rval );
+            ResMgrPrintf( NO_PREFIX,  "Resource Mgr, %s, failed initialization: 0x%x.  Exiting...\n", resDeviceTctiName, rval );
             return( 1 );
         }
 #ifdef DEBUG_RESMGR_INIT        
@@ -3007,7 +3006,7 @@ int main(int argc, char* argv[])
         rval = InitSimulatorTctiContext( simInterfaceConfig, &downstreamTctiContext );
         if( rval != TSS2_RC_SUCCESS )
         {
-            ResMgrPrintf( NO_PREFIX,  "Resource Mgr, %s, failed initialization: 0x%x.  Exiting...\n", simInterfaceInfo.shortName, rval );
+            ResMgrPrintf( NO_PREFIX,  "Resource Mgr, %s, failed initialization: 0x%x.  Exiting...\n", resSocketTctiName, rval );
             return( 1 );
         }
 #ifdef DEBUG_RESMGR_INIT        

--- a/resourcemgr/resourcemgr.c
+++ b/resourcemgr/resourcemgr.c
@@ -2981,9 +2981,9 @@ int main(int argc, char* argv[])
         //
         // Init downstream interface to tpm (in this case the local TPM).
         //
-        sprintf_s( deviceTctiConfig, interfaceConfigSize, "%s ", "/dev/tpm0" );
+        TCTI_DEVICE_CONF deviceTctiConfig = { "/dev/tpm0" };
 
-        rval = InitDeviceTctiContext( deviceTctiConfig, &downstreamTctiContext );
+        rval = InitDeviceTctiContext( &deviceTctiConfig, &downstreamTctiContext );
         if( rval != TSS2_RC_SUCCESS )
         {
             ResMgrPrintf( NO_PREFIX,  "Resource Mgr, %s, failed initialization: 0x%x.  Exiting...\n", resDeviceTctiName, rval );

--- a/resourcemgr/resourcemgr.h
+++ b/resourcemgr/resourcemgr.h
@@ -99,8 +99,6 @@ void ResourceMgrInit( int debugLevel );
 #define DEBUG_GAP_MAX   255
 #endif
 
-extern TSS2_TCTI_DRIVER_INFO resMgrTctiDriverInfo;
-
 TSS2_RC InitResMgr( int debugLevel );
 
 #ifdef __cplusplus

--- a/sysapi/include/tcti_util.h
+++ b/sysapi/include/tcti_util.h
@@ -96,51 +96,6 @@ typedef struct {
 #define TCTI_CONTEXT ( (TSS2_TCTI_CONTEXT_COMMON_CURRENT *)(SYS_CONTEXT->tctiContext) )
 #define TCTI_CONTEXT_INTEL ( (TSS2_TCTI_CONTEXT_INTEL *)tctiContext )
 
-typedef TSS2_RC (*TSS2_TCTI_INITIALIZE_FUNC) (
-    // Buffer allocated by caller to contain
-    // common part of context information.
-    TSS2_TCTI_CONTEXT *tctiContext, // OUT
-    // If tctiContext==NULL writes required size
-    // to this variable. Otherwise expects the
-    // size allocated for context.
-    //
-    // Pass NULL to retrieve required size
-    // as return value.
-    size_t *contextSize,            // IN/OUT
-    // String that determines the configuration
-    // to operate in (e.g. device-path,
-    // remote-server-address, config-file-path).
-    const char *config,             // IN        
-    const uint64_t magic,
-    const uint32_t version,
-    const char *interfaceName,
-    const uint8_t serverSockets
-    );
-
-typedef TSS2_RC (*TSS2_TCTI_TEARDOWN_FUNC) (
-    // Buffer allocated by caller to contain
-    // common part of context information.
-    TSS2_TCTI_CONTEXT *tctiContext, // OUT
-    // String that determines the configuration
-    // to operate in (e.g. device-path,
-    // remote-server-address, config-file-path).
-    const char *config,              // IN
-    const char *interfaceName    
-    );
-
-typedef struct {
-    // Short-Name of the driver.
-    const char *shortName;
-    // Help-String for the driver, to be given
-    // to the users.
-    const char *helpString;
-    // Pointer to an initialize function
-    // for this mode.
-    TSS2_TCTI_INITIALIZE_FUNC initialize; 
-    TSS2_TCTI_TEARDOWN_FUNC teardown;
-} TSS2_TCTI_DRIVER_INFO;
-
-
 // TCTI debug message levels
 #define TSS2_TCTI_DEBUG_MSG_DISABLED 0
 #define TSS2_TCTI_DEBUG_MSG_ENABLED 1

--- a/tcti/tcti_device.c
+++ b/tcti/tcti_device.c
@@ -243,11 +243,10 @@ TSS2_RC LocalTpmSetLocality(
 TSS2_RC InitDeviceTcti (
     TSS2_TCTI_CONTEXT *tctiContext, // OUT
     size_t *contextSize,            // IN/OUT
-    const char *config,              // IN
+    const TCTI_DEVICE_CONF *config,              // IN
     const uint64_t magic,
     const uint32_t version,
-	const char *interfaceName,
-    const uint8_t serverSockets  // Unused for local TPM.
+    const char *interfaceName
     )
 {
     TSS2_RC rval = TSS2_RC_SUCCESS;
@@ -257,6 +256,10 @@ TSS2_RC InitDeviceTcti (
     {
         *contextSize = sizeof( TSS2_TCTI_CONTEXT_INTEL );
         return TSS2_RC_SUCCESS;
+    }
+    else if( config == NULL )
+    {
+        return TSS2_TCTI_RC_BAD_VALUE;
     }
     else
     {
@@ -278,20 +281,7 @@ TSS2_RC InitDeviceTcti (
         ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->currentTctiContext = 0;
         ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->previousStage = TCTI_STAGE_INITIALIZE;
 
-        // Get hostname and port.
-        if( ( strlen( config ) + 2 ) <= ( HOSTNAME_LENGTH  ) )
-        {
-            if( 1 != sscanf( config, "%199s", fileName ) ) 
-            {
-                return( TSS2_TCTI_RC_BAD_VALUE );
-            }
-        }
-        else
-        {
-            return( TSS2_TCTI_RC_INSUFFICIENT_BUFFER );
-        }
-
-        ( ( (TSS2_TCTI_CONTEXT_INTEL *)tctiContext )->devFile ) = open( fileName, O_RDWR );
+        ( ( (TSS2_TCTI_CONTEXT_INTEL *)tctiContext )->devFile ) = open( config->device_path, O_RDWR );
         if( ( (TSS2_TCTI_CONTEXT_INTEL *)tctiContext )->devFile < 0 ) 
         {
             return( TSS2_TCTI_RC_IO_ERROR );
@@ -303,45 +293,34 @@ TSS2_RC InitDeviceTcti (
     return rval;
 }
 
-TSS2_RC TeardownDeviceTcti(
-    TSS2_TCTI_CONTEXT *tctiContext, // OUT
-    const char *config,              // IN        
-	const char *interfaceName
-    )
+TSS2_RC TeardownDeviceTcti(TSS2_TCTI_CONTEXT *tctiContext)
 {
-    OpenOutFile( &outFp );
-    (*tpmLocalTpmPrintf)(NO_PREFIX, "Tearing down %s Interface\n", interfaceName );
-    CloseOutFile( &outFp );
-
     ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->finalize( tctiContext );
 
-  
     return TSS2_RC_SUCCESS;
 }
 
-char deviceTctiConfig[DEVICE_TCTI_CONFIG_SIZE];
-    
-TSS2_RC InitDeviceTctiContext( const char *driverConfig, TSS2_TCTI_CONTEXT **tctiContext )
+TSS2_RC InitDeviceTctiContext( const TCTI_DEVICE_CONF *driverConfig, TSS2_TCTI_CONTEXT **tctiContext )
 {
     size_t size;
     
     TSS2_RC rval = TSS2_RC_SUCCESS;
 
-    rval = InitDeviceTcti(NULL, &size, driverConfig, 0, 0, deviceTctiName, 1 );
+    rval = InitDeviceTcti(NULL, &size, driverConfig, 0, 0, deviceTctiName );
     if( rval != TSS2_RC_SUCCESS )
         return rval;
     
     *tctiContext = malloc(size);
 
-    rval = InitDeviceTcti(*tctiContext, &size, driverConfig, TCTI_MAGIC, TCTI_VERSION, deviceTctiName, 0 );
+    rval = InitDeviceTcti(*tctiContext, &size, driverConfig, TCTI_MAGIC, TCTI_VERSION, deviceTctiName );
     return rval;
 }
 
-TSS2_RC TeardownDeviceTctiContext( const char *driverConfig, TSS2_TCTI_CONTEXT *tctiContext )
+TSS2_RC TeardownDeviceTctiContext( TSS2_TCTI_CONTEXT *tctiContext )
 {
     TSS2_RC rval;
 
-    rval = TeardownDeviceTcti( tctiContext, driverConfig, deviceTctiName );
+    rval = TeardownDeviceTcti( tctiContext );
     if( rval != TSS2_RC_SUCCESS )
         return rval;
 

--- a/tcti/tcti_device.c
+++ b/tcti/tcti_device.c
@@ -48,6 +48,8 @@
 
 #define HOSTNAME_LENGTH 200
 
+const char *deviceTctiName = "device TCTI";
+
 extern void OpenOutFile( FILE **outFp );
 
 extern void CloseOutFile( FILE **outFp );
@@ -319,21 +321,19 @@ TSS2_RC TeardownDeviceTcti(
 
 char deviceTctiConfig[DEVICE_TCTI_CONFIG_SIZE];
     
-TSS2_TCTI_DRIVER_INFO deviceTctiInfo = { "local TPM", "", InitDeviceTcti, TeardownDeviceTcti };
-
 TSS2_RC InitDeviceTctiContext( const char *driverConfig, TSS2_TCTI_CONTEXT **tctiContext )
 {
     size_t size;
     
     TSS2_RC rval = TSS2_RC_SUCCESS;
 
-    rval = deviceTctiInfo.initialize(NULL, &size, driverConfig, 0, 0, deviceTctiInfo.shortName, 1 );
+    rval = InitDeviceTcti(NULL, &size, driverConfig, 0, 0, deviceTctiName, 1 );
     if( rval != TSS2_RC_SUCCESS )
         return rval;
     
     *tctiContext = malloc(size);
 
-    rval = deviceTctiInfo.initialize(*tctiContext, &size, driverConfig, TCTI_MAGIC, TCTI_VERSION, deviceTctiInfo.shortName, 0 );
+    rval = InitDeviceTcti(*tctiContext, &size, driverConfig, TCTI_MAGIC, TCTI_VERSION, deviceTctiName, 0 );
     return rval;
 }
 
@@ -341,7 +341,7 @@ TSS2_RC TeardownDeviceTctiContext( const char *driverConfig, TSS2_TCTI_CONTEXT *
 {
     TSS2_RC rval;
 
-    rval = deviceTctiInfo.teardown( tctiContext, driverConfig, deviceTctiInfo.shortName );
+    rval = TeardownDeviceTcti( tctiContext, driverConfig, deviceTctiName );
     if( rval != TSS2_RC_SUCCESS )
         return rval;
 

--- a/tcti/tcti_device.c
+++ b/tcti/tcti_device.c
@@ -315,14 +315,3 @@ TSS2_RC InitDeviceTctiContext( const TCTI_DEVICE_CONF *driverConfig, TSS2_TCTI_C
     rval = InitDeviceTcti(*tctiContext, &size, driverConfig, TCTI_MAGIC, TCTI_VERSION, deviceTctiName );
     return rval;
 }
-
-TSS2_RC TeardownDeviceTctiContext( TSS2_TCTI_CONTEXT *tctiContext )
-{
-    TSS2_RC rval;
-
-    rval = TeardownDeviceTcti( tctiContext );
-    if( rval != TSS2_RC_SUCCESS )
-        return rval;
-
-    return rval;
-}

--- a/test/tpmclient/tpmclient.cpp
+++ b/test/tpmclient/tpmclient.cpp
@@ -7164,7 +7164,7 @@ void TestLocalTCTI()
         
         TestTctiApis( downstreamTctiContext, 0 );
 
-        TeardownDeviceTctiContext( downstreamTctiContext );
+        TeardownDeviceTcti( downstreamTctiContext );
 
         exit( 0 );
     }

--- a/test/tpmclient/tpmclient.cpp
+++ b/test/tpmclient/tpmclient.cpp
@@ -7138,7 +7138,7 @@ void TestCreate1()
 //
 void TestLocalTCTI()
 {
-    char deviceTctiConfig[DEVICE_TCTI_CONFIG_SIZE];
+    TCTI_DEVICE_CONF deviceTctiConfig = { "/dev/tpm0" };
     TSS2_RC rval = TSS2_RC_SUCCESS;
     
     TSS2_TCTI_CONTEXT *downstreamTctiContext;
@@ -7149,9 +7149,7 @@ void TestLocalTCTI()
     //
     // Init downstream interface to tpm (in this case the local TPM).
     //
-    sprintf_s( deviceTctiConfig, DEVICE_TCTI_CONFIG_SIZE, "%s ", "/dev/tpm0" );
-
-    rval = InitDeviceTctiContext( deviceTctiConfig, &downstreamTctiContext );
+    rval = InitDeviceTctiContext( &deviceTctiConfig, &downstreamTctiContext );
     if( rval != TSS2_RC_SUCCESS )
     {
         TpmClientPrintf( NO_PREFIX,  "Resource Mgr, %s, failed initialization: 0x%x.  Exiting...\n", "local TPM", rval );
@@ -7166,7 +7164,7 @@ void TestLocalTCTI()
         
         TestTctiApis( downstreamTctiContext, 0 );
 
-        TeardownDeviceTctiContext( deviceTctiConfig, downstreamTctiContext );
+        TeardownDeviceTctiContext( downstreamTctiContext );
 
         exit( 0 );
     }

--- a/test/tpmclient/tpmclient.cpp
+++ b/test/tpmclient/tpmclient.cpp
@@ -132,8 +132,10 @@ UINT8 indent = 0;
 
 TSS2_SYS_CONTEXT *sysContext;
 
-#define rmInterfaceConfigSize 250
-char rmInterfaceConfig[rmInterfaceConfigSize];
+TCTI_SOCKET_CONF rmInterfaceConfig = {
+    DEFAULT_HOSTNAME,
+    DEFAULT_RESMGR_TPM_PORT
+};
     
 TSS2_TCTI_CONTEXT *resMgrTctiContext = 0;
 TSS2_ABI_VERSION abiVersion = { TSSWG_INTEROP, TSS_SAPI_FIRST_FAMILY, TSS_SAPI_FIRST_LEVEL, TSS_SAPI_FIRST_VERSION };
@@ -319,7 +321,7 @@ void ErrorHandler( UINT32 rval )
 
 char resMgrInterfaceName[] = "Resource Manager";
 
-TSS2_RC InitTctiResMgrContext( char *rmInterfaceConfig, TSS2_TCTI_CONTEXT **tctiContext, char *name )
+TSS2_RC InitTctiResMgrContext( TCTI_SOCKET_CONF *rmInterfaceConfig, TSS2_TCTI_CONTEXT **tctiContext, char *name )
 {
     size_t size;
     
@@ -342,9 +344,9 @@ TSS2_RC InitTctiResMgrContext( char *rmInterfaceConfig, TSS2_TCTI_CONTEXT **tcti
     return rval;
 }
 
-TSS2_RC TeardownTctiResMgrContext( char *interfaceConfig, TSS2_TCTI_CONTEXT *tctiContext, char *name )
+TSS2_RC TeardownTctiResMgrContext( TSS2_TCTI_CONTEXT *tctiContext )
 {
-    return TeardownSocketTcti( tctiContext, interfaceConfig, name );
+    return TeardownSocketTcti( tctiContext );
 }
 
 void Cleanup()
@@ -355,7 +357,7 @@ void Cleanup()
     {
         PlatformCommand( resMgrTctiContext, MS_SIM_POWER_OFF );
 
-        TeardownTctiResMgrContext( rmInterfaceConfig, resMgrTctiContext, &resMgrInterfaceName[0] );
+        TeardownTctiResMgrContext( resMgrTctiContext );
     }
     
 #ifdef _WIN32        
@@ -2566,10 +2568,10 @@ void TestEvict()
 
     // Try creating a key under the persistent key using a different context.
 
-    rval = InitTctiResMgrContext( rmInterfaceConfig, &otherResMgrTctiContext, &otherResMgrInterfaceName[0] );
+    rval = InitTctiResMgrContext( &rmInterfaceConfig, &otherResMgrTctiContext, &otherResMgrInterfaceName[0] );
     if( rval != TSS2_RC_SUCCESS )
     {
-        TpmClientPrintf( 0, "Resource Mgr, %s, failed initialization: 0x%x.  Exiting...\n", resMgrInterfaceName, rval );
+        TpmClientPrintf( 0, "Resource Mgr, failed initialization: 0x%x.  Exiting...\n", rval );
         Cleanup();
         return;
     }
@@ -2590,7 +2592,7 @@ void TestEvict()
             &creationHash, &creationTicket, &sessionsDataOut );
     CheckPassed( rval );
 
-    rval = TeardownTctiResMgrContext( rmInterfaceConfig, otherResMgrTctiContext, &otherResMgrInterfaceName[0] );
+    rval = TeardownTctiResMgrContext( otherResMgrTctiContext );
     CheckPassed( rval );
     
     TeardownSysContext( &otherSysContext );
@@ -6674,10 +6676,10 @@ void TestRM()
     sessionsData.cmdAuthsCount = 1;
     sessionsData.cmdAuths[0] = &sessionData;
     
-    rval = InitTctiResMgrContext( rmInterfaceConfig, &otherResMgrTctiContext, &otherResMgrInterfaceName[0] );
+    rval = InitTctiResMgrContext( &rmInterfaceConfig, &otherResMgrTctiContext, &otherResMgrInterfaceName[0] );
     if( rval != TSS2_RC_SUCCESS )
     {
-        TpmClientPrintf( 0, "Resource Mgr, %s, failed initialization: 0x%x.  Exiting...\n", resMgrInterfaceName, rval );
+        TpmClientPrintf( 0, "Resource Mgr, %s, failed initialization: 0x%x.  Exiting...\n", otherResMgrInterfaceName, rval );
         Cleanup();
         return;
     }
@@ -6912,7 +6914,7 @@ void TestRM()
     rval = Tss2_Sys_FlushContext( sysContext, newHandleDummy );
     CheckPassed( rval );
    
-    rval = TeardownTctiResMgrContext( rmInterfaceConfig, otherResMgrTctiContext, &otherResMgrInterfaceName[0] );
+    rval = TeardownTctiResMgrContext( otherResMgrTctiContext );
     CheckPassed( rval );
 
     TeardownSysContext( &otherSysContext );
@@ -7353,8 +7355,6 @@ void PrintHelp()
 
 int main(int argc, char* argv[])
 {
-    char hostName[HOSTNAME_LENGTH] = DEFAULT_HOSTNAME;
-    int port = DEFAULT_RESMGR_TPM_PORT;
     int count;
     TSS2_RC rval;
     
@@ -7372,27 +7372,21 @@ int main(int argc, char* argv[])
     {
         for( count = 1; count < argc; count++ )
         {
-            if( 0 == strcmp( argv[count], "-rmhost" ) )
+           if( 0 == strcmp( argv[count], "-rmhost" ) )
             {
                 count++;
-                if( count >= argc || ( strlen( argv[count] ) + 1 <= HOSTNAME_LENGTH ) )
-                {
-                    if( 1 != sscanf( argv[count], "%199s", &hostName[0] ) )
-                    {
-                        PrintHelp();
-                        return 1;
-                    }
-                }
-                else
+                if( count >= argc)
                 {
                     PrintHelp();
                     return 1;
                 }
+                rmInterfaceConfig.hostname = argv[count];
             }
             else if( 0 == strcmp( argv[count], "-rmport" ) )
             {
                 count++;
-                if( count >= argc || 1 != sscanf_s( argv[count], "%d", &port ) )
+                rmInterfaceConfig.port = strtoul(argv[count], NULL, 10);
+                if( count >= argc)
                 {
                     PrintHelp();
                     return 1;
@@ -7479,9 +7473,7 @@ int main(int argc, char* argv[])
     }
 #endif
     
-    sprintf_s( rmInterfaceConfig, rmInterfaceConfigSize, "%s %d ", hostName, port );
-
-    rval = InitTctiResMgrContext( rmInterfaceConfig, &resMgrTctiContext, &resMgrInterfaceName[0] );
+    rval = InitTctiResMgrContext( &rmInterfaceConfig, &resMgrTctiContext, &resMgrInterfaceName[0] );
     if( rval != TSS2_RC_SUCCESS )
     {
         TpmClientPrintf( 0, "Resource Mgr, %s, failed initialization: 0x%x.  Exiting...\n", resMgrInterfaceName, rval );
@@ -7508,7 +7500,7 @@ int main(int argc, char* argv[])
     {
         TpmTest();
 
-        rval = TeardownTctiResMgrContext( rmInterfaceConfig, resMgrTctiContext, &resMgrInterfaceName[0] );
+        rval = TeardownTctiResMgrContext( resMgrTctiContext );
         CheckPassed( rval );
         
         TeardownSysContext( &sysContext );

--- a/test/tpmclient/tpmclient.cpp
+++ b/test/tpmclient/tpmclient.cpp
@@ -135,8 +135,6 @@ TSS2_SYS_CONTEXT *sysContext;
 #define rmInterfaceConfigSize 250
 char rmInterfaceConfig[rmInterfaceConfigSize];
     
-TSS2_TCTI_DRIVER_INFO resMgrInterfaceInfo = { "resMgr", "", InitSocketTcti, TeardownSocketTcti };
-
 TSS2_TCTI_CONTEXT *resMgrTctiContext = 0;
 TSS2_ABI_VERSION abiVersion = { TSSWG_INTEROP, TSS_SAPI_FIRST_FAMILY, TSS_SAPI_FIRST_LEVEL, TSS_SAPI_FIRST_VERSION };
 
@@ -327,7 +325,7 @@ TSS2_RC InitTctiResMgrContext( char *rmInterfaceConfig, TSS2_TCTI_CONTEXT **tcti
     
     TSS2_RC rval;
 
-    rval = resMgrInterfaceInfo.initialize(NULL, &size, rmInterfaceConfig, 0, 0, &resMgrInterfaceName[0], 0 );
+    rval = InitSocketTcti(NULL, &size, rmInterfaceConfig, 0, 0, &resMgrInterfaceName[0], 0 );
     if( rval != TSS2_RC_SUCCESS )
         return rval;
     
@@ -335,7 +333,7 @@ TSS2_RC InitTctiResMgrContext( char *rmInterfaceConfig, TSS2_TCTI_CONTEXT **tcti
 
     if( *tctiContext )
     {
-        rval = resMgrInterfaceInfo.initialize(*tctiContext, &size, rmInterfaceConfig, TCTI_MAGIC, TCTI_VERSION, resMgrInterfaceName, 0 );
+        rval = InitSocketTcti(*tctiContext, &size, rmInterfaceConfig, TCTI_MAGIC, TCTI_VERSION, resMgrInterfaceName, 0 );
     }
     else
     {
@@ -346,7 +344,7 @@ TSS2_RC InitTctiResMgrContext( char *rmInterfaceConfig, TSS2_TCTI_CONTEXT **tcti
 
 TSS2_RC TeardownTctiResMgrContext( char *interfaceConfig, TSS2_TCTI_CONTEXT *tctiContext, char *name )
 {
-    return resMgrInterfaceInfo.teardown( tctiContext, interfaceConfig, name );
+    return TeardownSocketTcti( tctiContext, interfaceConfig, name );
 }
 
 void Cleanup()
@@ -2571,7 +2569,7 @@ void TestEvict()
     rval = InitTctiResMgrContext( rmInterfaceConfig, &otherResMgrTctiContext, &otherResMgrInterfaceName[0] );
     if( rval != TSS2_RC_SUCCESS )
     {
-        TpmClientPrintf( 0, "Resource Mgr, %s, failed initialization: 0x%x.  Exiting...\n", resMgrInterfaceInfo.shortName, rval );
+        TpmClientPrintf( 0, "Resource Mgr, %s, failed initialization: 0x%x.  Exiting...\n", resMgrInterfaceName, rval );
         Cleanup();
         return;
     }
@@ -6679,7 +6677,7 @@ void TestRM()
     rval = InitTctiResMgrContext( rmInterfaceConfig, &otherResMgrTctiContext, &otherResMgrInterfaceName[0] );
     if( rval != TSS2_RC_SUCCESS )
     {
-        TpmClientPrintf( 0, "Resource Mgr, %s, failed initialization: 0x%x.  Exiting...\n", resMgrInterfaceInfo.shortName, rval );
+        TpmClientPrintf( 0, "Resource Mgr, %s, failed initialization: 0x%x.  Exiting...\n", resMgrInterfaceName, rval );
         Cleanup();
         return;
     }
@@ -7141,7 +7139,6 @@ void TestLocalTCTI()
     char deviceTctiConfig[DEVICE_TCTI_CONFIG_SIZE];
     TSS2_RC rval = TSS2_RC_SUCCESS;
     
-    TSS2_TCTI_DRIVER_INFO deviceTctiInfo = { "local TPM", "", InitDeviceTcti, TeardownDeviceTcti };
     TSS2_TCTI_CONTEXT *downstreamTctiContext;
 
     TpmClientPrintf( NO_PREFIX,  "WARNING!!  This test requires that a local TPM is present and that the resource manager has NOT been started.\n\n" );
@@ -7155,7 +7152,7 @@ void TestLocalTCTI()
     rval = InitDeviceTctiContext( deviceTctiConfig, &downstreamTctiContext );
     if( rval != TSS2_RC_SUCCESS )
     {
-        TpmClientPrintf( NO_PREFIX,  "Resource Mgr, %s, failed initialization: 0x%x.  Exiting...\n", deviceTctiInfo.shortName, rval );
+        TpmClientPrintf( NO_PREFIX,  "Resource Mgr, %s, failed initialization: 0x%x.  Exiting...\n", "local TPM", rval );
         CheckPassed( rval );
     }
     else
@@ -7487,7 +7484,7 @@ int main(int argc, char* argv[])
     rval = InitTctiResMgrContext( rmInterfaceConfig, &resMgrTctiContext, &resMgrInterfaceName[0] );
     if( rval != TSS2_RC_SUCCESS )
     {
-        TpmClientPrintf( 0, "Resource Mgr, %s, failed initialization: 0x%x.  Exiting...\n", resMgrInterfaceInfo.shortName, rval );
+        TpmClientPrintf( 0, "Resource Mgr, %s, failed initialization: 0x%x.  Exiting...\n", resMgrInterfaceName, rval );
 #ifdef _WIN32        
         WSACleanup();
 #endif

--- a/test/tpmtest/tpmtest.cpp
+++ b/test/tpmtest/tpmtest.cpp
@@ -137,9 +137,6 @@ TSS2_SYS_CONTEXT *sysContext;
 #define rmInterfaceConfigSize 250
 char rmInterfaceConfig[rmInterfaceConfigSize];
 
-TSS2_TCTI_DRIVER_INFO resMgrInterfaceInfo = { "resMgr", "", InitSocketTcti, TeardownSocketTcti };
-//++++
-
 TSS2_TCTI_CONTEXT *resMgrTctiContext = 0;
 //TSS2_ABI_VERSION abiVersion = { 1, 1, 1, 1 };
 TSS2_ABI_VERSION abiVersion = { TSSWG_INTEROP, TSS_SAPI_FIRST_FAMILY, TSS_SAPI_FIRST_LEVEL, TSS_SAPI_FIRST_VERSION };
@@ -359,7 +356,7 @@ TSS2_RC InitTctiResMgrContext( char *rmInterfaceConfig, TSS2_TCTI_CONTEXT **tcti
     TSS2_RC rval;
 
 //	rval = resMgrTctiDriverInfo.initialize(NULL, &size, driverConfig);
-	rval = resMgrInterfaceInfo.initialize(NULL, &size, rmInterfaceConfig, 0, 0, &resMgrInterfaceName[0], 0 );
+	rval = InitSocketTcti(NULL, &size, rmInterfaceConfig, 0, 0, &resMgrInterfaceName[0], 0 );
     if( rval != TSS2_RC_SUCCESS )
         return rval;
 
@@ -370,7 +367,7 @@ TSS2_RC InitTctiResMgrContext( char *rmInterfaceConfig, TSS2_TCTI_CONTEXT **tcti
 */
     if( *tctiContext )
     {
-        rval = resMgrInterfaceInfo.initialize(*tctiContext, &size, rmInterfaceConfig, TCTI_MAGIC, TCTI_VERSION, resMgrInterfaceName, 0 );
+        rval = InitSocketTcti(*tctiContext, &size, rmInterfaceConfig, TCTI_MAGIC, TCTI_VERSION, resMgrInterfaceName, 0 );
     }
     else
     {
@@ -390,7 +387,7 @@ TSS2_RC TeardownTctiResMgrContext( char *driverConfig )
 //+++++++++++
 TSS2_RC TeardownTctiResMgrContext( char *interfaceConfig, TSS2_TCTI_CONTEXT *tctiContext, char *name )
 {
-    return resMgrInterfaceInfo.teardown( tctiContext, interfaceConfig, name );
+    return TeardownSocketTcti( tctiContext, interfaceConfig, name );
 }
 //+++++++++++
 void Cleanup()
@@ -6267,7 +6264,7 @@ void TestRM()
     rval = InitTctiResMgrContext( rmInterfaceConfig, &otherResMgrTctiContext, &otherResMgrInterfaceName[0] );
     if( rval != TSS2_RC_SUCCESS )
     {
-        TpmClientPrintf( 0, "Resource Mgr, %s, failed initialization: 0x%x.  Exiting...\n", resMgrInterfaceInfo.shortName, rval );
+        TpmClientPrintf( 0, "Resource Mgr, %s, failed initialization: 0x%x.  Exiting...\n", resMgrInterfaceName, rval );
         Cleanup();
         return;
     }
@@ -7950,7 +7947,7 @@ int main(int argc, char* argv[])
     rval = InitTctiResMgrContext( rmInterfaceConfig, &resMgrTctiContext, &resMgrInterfaceName[0] );
     if( rval != TSS2_RC_SUCCESS )
     {
-        TpmClientPrintf( 0, "Resource Mgr, %s, failed initialization: 0x%x.  Exiting...\n", resMgrInterfaceInfo.shortName, rval );
+        TpmClientPrintf( 0, "Resource Mgr, %s, failed initialization: 0x%x.  Exiting...\n", resMgrInterfaceName, rval );
         Cleanup();
         return( 1 );
     }


### PR DESCRIPTION
In this PR:
Remove the TSS2_TCTI_DRIVER_INFO struct.
Trim unnecessary stuff from Init and Teardown functions.
Replace configuration string and parsing logic with simple structure for both TCTIs.