### PR TITLE
tcti_socket: Remove simulator flag.

### DIFF
--- a/include/tcti/tcti_socket.h
+++ b/include/tcti/tcti_socket.h
@@ -101,9 +101,6 @@ TSS2_RC SendSessionEndSocketTcti(
     UINT8 tpmCmdServer
     );
 
-extern UINT8 simulator;
-
-
 // Commands to send to OTHER port.
 #define MS_SIM_POWER_ON         1
 #define MS_SIM_POWER_OFF        2

--- a/resourcemgr/resourcemgr.c
+++ b/resourcemgr/resourcemgr.c
@@ -2371,6 +2371,8 @@ UINT8 OtherCmdServer( SERVER_STRUCT *serverStruct )
         }
         
         command = CHANGE_ENDIAN_DWORD( command );
+        if( !simulator )
+            continue;
         switch( command )
         {
             case MS_SIM_POWER_ON:


### PR DESCRIPTION
The resourcemgr is a better place to filter PlatformCommands. The TCTI
shouldn't care whether or not the resourcemgr is talking to the
simulator or not. We effectively move the check up a level in the call
scope to the resource manager. The check now happens before the resource
manager calls PlatformCommand.

Consuming applications will no longer be required to define this
variable. The socket TCTI will always send platform commands when the
command socket is connected.

This resolves #131

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>