### PR TITLE
debug: Stop using global printfFunction pointer in debug functions.

### DIFF
--- a/common/debug.c
+++ b/common/debug.c
@@ -59,14 +59,14 @@ void DebugPrintBuffer( UINT8 *buffer, UINT32 length )
     {
         if( ( i % 16 ) == 0 )
         {
-            (*printfFunction)(NO_PREFIX, "\n");
+            DebugPrintf(NO_PREFIX, "\n");
             if( rmDebugPrefix == RM_PREFIX )
-                (*printfFunction)(NO_PREFIX,  "||  " );
+                DebugPrintf(NO_PREFIX,  "||  " );
         }
         
-        (*printfFunction)(NO_PREFIX,  "%2.2x ", buffer[i] );
+        DebugPrintf(NO_PREFIX,  "%2.2x ", buffer[i] );
     }
-    (*printfFunction)(NO_PREFIX,  "\n\n" );
+    DebugPrintf(NO_PREFIX,  "\n\n" );
     fflush( stdout );
 }
 

--- a/common/debug.h
+++ b/common/debug.h
@@ -29,6 +29,7 @@
 #define DEBUG_H
 
 #include <tss2/tpm20.h>
+#include <tcti/tcti_socket.h>
 #include <stdio.h>
 #include "sockets.h"
 
@@ -37,14 +38,9 @@ extern "C" {
 #endif
 
 enum debugLevel { DBG_NO_COMMAND = 0, DBG_COMMAND = 1, DBG_COMMAND_RM = 2, DBG_COMMAND_RM_TABLES = 3 };
-typedef enum { NO_PREFIX = 0, RM_PREFIX = 1 } printf_type;
 
 int DebugPrintf( printf_type type, const char *format, ...);
 void DebugPrintBuffer( UINT8 *command_buffer, UINT32 cnt1 );
-
-void DebugPrintBufferOpen( UINT8 *buffer, UINT32 length );
-
-extern int (*printfFunction)( printf_type type, const char *format, ...);
 
 extern printf_type rmDebugPrefix;
 

--- a/common/sockets.cpp
+++ b/common/sockets.cpp
@@ -1,3 +1,4 @@
+#include <tcti/tcti_socket.h>
 #include "debug.h"
 #include "sockets.h"
 

--- a/include/tcti/tcti_socket.h
+++ b/include/tcti/tcti_socket.h
@@ -42,6 +42,10 @@ extern "C" {
 
 #define DEFAULT_HOSTNAME        "127.0.0.1"
 
+typedef enum { NO_PREFIX = 0, RM_PREFIX = 1 } printf_type;
+/* global data defined in the socket TCTI */
+extern int (*printfFunction)( printf_type type, const char *format, ...);
+
 TSS2_RC PlatformCommand(
     TSS2_TCTI_CONTEXT *tctiContext,     /* in */
     char cmd );


### PR DESCRIPTION
We also remove the extern declaration of the same function pointer in the
debug header since it's not defined in the debug implementation. This
requires that we move the declaration to the socket TCTI header. This is
a bit ugly as it exposes this global data to clients but at least it's
not misleading. The enumeration we use as the second parameter to this
function must be moved to the socket TCTI header as well.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>