### PR TITLE
headers: Add tpm20.h include to both TCTI headers.

### DIFF
--- a/include/tcti/tcti_device.h
+++ b/include/tcti/tcti_device.h
@@ -32,6 +32,7 @@
 extern "C" {
 #endif
 
+#include <tss2/tpm20.h>
 #include <tcti/magic.h>
 
 typedef struct {

--- a/include/tcti/tcti_socket.h
+++ b/include/tcti/tcti_socket.h
@@ -32,6 +32,7 @@
 extern "C" {
 #endif
 
+#include <tss2/tpm20.h>
 #include <tcti/magic.h>
 
 #define DEFAULT_SIMULATOR_TPM_PORT        2321


### PR DESCRIPTION
Both of these headers reference types from the TSS2 spec. The argument
could be made that programs including a TCTI should include the TSS2
headers first but I've gone for the simple approach.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>