### PR TITLE
test: Integrate cmocka into autotools build, add basic test case for …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,8 @@ test/tpmclient/tpmclient
 .klocwork/
 ipch/
 test/tpmtest/tpmtest
+test-driver
+test-suite.log
+test/tcti_device
+test/*.log
+test/*.trs

--- a/INSTALL
+++ b/INSTALL
@@ -6,6 +6,7 @@ GNU Libtool
 C compiler
 C++ compiler
 C Library Development Libraries and Header Files (for pthreads headers)
+cmocka unit test framework
 
 Currently the tpm2.0-tss is only distributed via GitHub as we have not yet
 produced an official source release. To obtain the tpm2.0-tss sources you

--- a/Makefile.am
+++ b/Makefile.am
@@ -36,12 +36,19 @@ AM_CPPFLAGS = -I$(srcdir)/include
 sbin_PROGRAMS   = $(resourcemgr)
 noinst_PROGRAMS = $(tpmclient) $(tpmtest)
 lib_LTLIBRARIES = $(libtss2) $(libtctidevice) $(libtctisocket)
+# unit tests
+check_PROGRAMS  = test/tcti_device
+TESTS = $(check_PROGRAMS)
 
 # headers and where to install them
 libtss2dir      = $(includedir)/tss2
 libtss2_HEADERS = $(srcdir)/include/tss2/*.h
 libtctidir      = $(includedir)/tcti
 libtcti_HEADERS = $(srcdir)/include/tcti/*.h
+
+test_tcti_device_CFLAGS  = $(CMOCKA_CFLAGS) -I$(srcdir)
+test_tcti_device_LDADD   = $(libtss2) $(libtctidevice) $(CMOCKA_LIBS)
+test_tcti_device_SOURCES = test/tcti_device.c test/tcti_device_test.c
 
 # how to build stuff
 resourcemgr_resourcemgr_CFLAGS   = $(RESOURCEMGR_INC) $(PTHREAD_CFLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -11,4 +11,5 @@ AX_PTHREAD([], [AC_MSG_ERROR([requires pthread])])
 AM_INIT_AUTOMAKE([foreign
                   subdir-objects])
 AC_CONFIG_FILES([Makefile])
+PKG_CHECK_MODULES([CMOCKA],[cmocka])
 AC_OUTPUT

--- a/test/tcti_device.c
+++ b/test/tcti_device.c
@@ -1,0 +1,24 @@
+#include <stdio.h>
+
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include <tss2/tpm20.h>
+#include "tcti_device_test.h"
+#include "sysapi/include/tcti_util.h"
+
+static void
+tcti_dev_init_size_test (void **state)
+{
+    assert_int_equal(tcti_dev_init_size (state),
+                     sizeof (TSS2_TCTI_CONTEXT_INTEL));
+}
+
+int
+main(int argc, char* argv[])
+{
+    const UnitTest tests[] = {
+        unit_test(tcti_dev_init_size_test),
+    };
+    return run_tests(tests);
+}

--- a/test/tcti_device_test.c
+++ b/test/tcti_device_test.c
@@ -1,0 +1,19 @@
+#include <tcti/tcti_device.h>
+
+/* Determine the size of a TCTI context structure. Requires calling the
+ * initialization function for the device TCTI with the first parameter
+ * (the TCTI context) NULL.
+ */
+size_t
+tcti_dev_init_size (void **state)
+{
+    void *my_state = *state;
+    size_t tcti_size = 0;
+    TSS2_RC ret = TSS2_RC_SUCCESS;
+
+    ret = InitDeviceTcti (NULL, &tcti_size, NULL, 0, 0, NULL);
+    if (ret != TSS2_RC_SUCCESS)
+        return 0;
+    else
+        return tcti_size;
+}

--- a/test/tcti_device_test.h
+++ b/test/tcti_device_test.h
@@ -1,0 +1,3 @@
+#include <stddef.h>
+
+size_t tcti_dev_init_size (void **state);


### PR DESCRIPTION
…device TCTI.

The current test layout I'm trying is a module (.c & .h file) in the
base test/ directory that is a collection of test functions for a
specific module of code from the tpm2.0-tss project. This test module is
named after the module it tests and the suffix '_test' is appended.
There should be NO dependency on the test framework in this module.

This test module is accompanied by a driver that sets up the test
framework with the tests from the module. This driver is given the name
of the module that it tests.

This resolves #18 

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>