### PR TITLE
tcti_device: Pass -no-undefined flag to linker.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -56,6 +56,7 @@ sysapi_libtss2_la_CFLAGS  = -I$(srcdir)/include -I$(srcdir)/sysapi/include
 sysapi_libtss2_la_SOURCES = $(SYSAPI_C) $(SYSAPIUTIL_C)
 
 tcti_libtctidevice_la_CFLAGS   = $(TCTIDEVICE_INC)
+tcti_libtctidevice_la_LDFLAGS  = -no-undefined
 tcti_libtctidevice_la_SOURCES  = common/debug.c $(TCTIDEVICE_C) \
     sysapi/sysapi_util/changeEndian.c $(TCTICOMMON_C)
 


### PR DESCRIPTION
This will cause an error if the library has any unresolved symbols.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>