### PR TITLE
debug: Remove global variable rmDebugPrefix.

### DIFF
--- a/common/debug.c
+++ b/common/debug.c
@@ -32,17 +32,13 @@
 #include <tss2/tpm20.h>
 #include "debug.h"
 
-printf_type rmDebugPrefix = NO_PREFIX;
-
 int DebugPrintf( printf_type type, const char *format, ...)
 {
     va_list args;
     int rval = 0;
 
-    if( type == RM_PREFIX && rmDebugPrefix == RM_PREFIX )
-    {
-        DebugPrintf( NO_PREFIX, "||  " );
-    }
+    if( type == RM_PREFIX )
+        printf( "||  " );
 
     va_start( args, format );
     rval = vprintf( format, args );
@@ -51,7 +47,7 @@ int DebugPrintf( printf_type type, const char *format, ...)
     return rval;
 }
 
-void DebugPrintBuffer( UINT8 *buffer, UINT32 length )
+void DebugPrintBuffer( printf_type type, UINT8 *buffer, UINT32 length )
 {
     UINT32  i;
     
@@ -60,7 +56,7 @@ void DebugPrintBuffer( UINT8 *buffer, UINT32 length )
         if( ( i % 16 ) == 0 )
         {
             DebugPrintf(NO_PREFIX, "\n");
-            if( rmDebugPrefix == RM_PREFIX )
+            if( type == RM_PREFIX )
                 DebugPrintf(NO_PREFIX,  "||  " );
         }
         

--- a/common/debug.h
+++ b/common/debug.h
@@ -40,14 +40,12 @@ extern "C" {
 enum debugLevel { DBG_NO_COMMAND = 0, DBG_COMMAND = 1, DBG_COMMAND_RM = 2, DBG_COMMAND_RM_TABLES = 3 };
 
 int DebugPrintf( printf_type type, const char *format, ...);
-void DebugPrintBuffer( UINT8 *command_buffer, UINT32 cnt1 );
-
-extern printf_type rmDebugPrefix;
+void DebugPrintBuffer( printf_type type, UINT8 *command_buffer, UINT32 cnt1 );
 
 #ifdef DEBUG
-#define DEBUG_PRINT_BUFFER( buffer, length )  DebugPrintBuffer( buffer, length )
+#define DEBUG_PRINT_BUFFER( type, buffer, length )  DebugPrintBuffer( type, buffer, length )
 #else
-#define DEBUG_PRINT_BUFFER( buffer, length )
+#define DEBUG_PRINT_BUFFER( type, buffer, length )
 #endif
 
 #ifdef __cplusplus

--- a/common/sockets.cpp
+++ b/common/sockets.cpp
@@ -17,8 +17,6 @@ TSS2_RC recvBytes( SOCKET tpmSock, unsigned char *data, int len )
     {
         iResult = recv( tpmSock, (char *)&( data[bytesRead] ), length, 0);
         if (iResult == SOCKET_ERROR) {
-            if( rmDebugPrefix == RM_PREFIX )
-                DebugPrintf( NO_PREFIX, "||  " );
             (*printfFunction)(NO_PREFIX, "In recvBytes, recv failed (socket: 0x%x) with error: %d\n",
                     tpmSock, WSAGetLastError() );
             return TSS2_TCTI_RC_IO_ERROR;
@@ -26,7 +24,7 @@ TSS2_RC recvBytes( SOCKET tpmSock, unsigned char *data, int len )
     }
 
 #ifdef DEBUG_SOCKETS
-    (*printfFunction)( rmDebugPrefix, "Receive Bytes from socket #0x%x: \n", tpmSock );
+    (*printfFunction)( NO_PREFIX, "Receive Bytes from socket #0x%x: \n", tpmSock );
     DebugPrintBuffer( data, len );
 #endif
 
@@ -39,8 +37,6 @@ TSS2_RC sendBytes( SOCKET tpmSock, const char *data, int len )
     int sentLength = 0;
 
 #ifdef DEBUG_SOCKETS
-    if( rmDebugPrefix == RM_PREFIX )
-        DebugPrintf( NO_PREFIX, "||  " );
     (*printfFunction)(NO_PREFIX, "Send Bytes to socket #0x%x: \n", tpmSock );
     DebugPrintBuffer( (UINT8 *)data, len );
 #endif

--- a/resourcemgr/resourcemgr.c
+++ b/resourcemgr/resourcemgr.c
@@ -1210,7 +1210,6 @@ TSS2_RC ResourceMgrSendTpmCommand(
 
     rmErrorDuringSend = 0;
 
-    rmDebugPrefix = RM_PREFIX;
     //
     // DO RESOURCE MGR THINGS.
     //
@@ -1437,8 +1436,6 @@ TSS2_RC ResourceMgrSendTpmCommand(
     
 SendCommand:
   
-    rmDebugPrefix = NO_PREFIX;
-
     ((TSS2_TCTI_CONTEXT_INTEL *)downstreamTctiContext )->status.debugMsgLevel = TSS2_TCTI_DEBUG_MSG_ENABLED;
 
     if( responseRval == TSS2_RC_SUCCESS )
@@ -1586,7 +1583,6 @@ TSS2_RC ResourceMgrReceiveTpmResponse(
         // If an RM error occurred during the send, just return
         // the error response byte stream here.
         CopyErrorResponse( response_size, response_buffer );
-        rmDebugPrefix = RM_PREFIX;
         responseRval = CHANGE_ENDIAN_DWORD( ( (TPM20_ErrorResponse *)response_buffer )->responseCode );
         goto returnFromResourceMgrReceiveTpmResponse;
     }
@@ -1646,8 +1642,6 @@ TSS2_RC ResourceMgrReceiveTpmResponse(
         {
             ((TSS2_TCTI_CONTEXT_INTEL *)downstreamTctiContext)->status.debugMsgLevel = TSS2_TCTI_DEBUG_MSG_DISABLED;
         }
-
-        rmDebugPrefix = RM_PREFIX;
 
         if( rval == TSS2_RC_SUCCESS )
         {
@@ -2099,9 +2093,6 @@ exitResourceMgrReceiveTpmResponse:
 
     ((TSS2_TCTI_CONTEXT_INTEL *)downstreamTctiContext )->status.debugMsgLevel = TSS2_TCTI_DEBUG_MSG_ENABLED;
     
-    rmDebugPrefix = NO_PREFIX;
-
-
     return rval;
 }
 

--- a/tcti/platformcommand.c
+++ b/tcti/platformcommand.c
@@ -68,7 +68,7 @@ TSS2_RC PlatformCommand(
     else
     {
 #ifdef DEBUG_SOCKETS
-        (*printfFunction)( rmDebugPrefix, "Send Bytes to socket #0x%x: \n", TCTI_CONTEXT_INTEL->otherSock );
+        (*printfFunction)( NO_PREFIX, "Send Bytes to socket #0x%x: \n", TCTI_CONTEXT_INTEL->otherSock );
         DebugPrintBuffer( (UINT8 *)sendbuf, 4 );
 #endif
         // Read result

--- a/tcti/tcti_device.c
+++ b/tcti/tcti_device.c
@@ -76,9 +76,9 @@ TSS2_RC LocalTpmSendTpmCommand(
 
         if( ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext )->status.debugMsgLevel == TSS2_TCTI_DEBUG_MSG_ENABLED )
         {
-            (*tpmLocalTpmPrintf)( rmDebugPrefix, "\n" );
-            (*tpmLocalTpmPrintf)(rmDebugPrefix, "Cmd sent: %s\n", commandCodeStrings[ commandCode - TPM_CC_FIRST ]  );
-            DEBUG_PRINT_BUFFER( command_buffer, cnt );
+            (*tpmLocalTpmPrintf)( NO_PREFIX, "\n" );
+            (*tpmLocalTpmPrintf)( NO_PREFIX, "Cmd sent: %s\n", commandCodeStrings[ commandCode - TPM_CC_FIRST ]  );
+            DEBUG_PRINT_BUFFER( NO_PREFIX, command_buffer, cnt );
         }
 #endif
 
@@ -168,9 +168,9 @@ TSS2_RC LocalTpmReceiveTpmResponse(
     if( ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext )->status.debugMsgLevel == TSS2_TCTI_DEBUG_MSG_ENABLED &&
             ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->responseSize > 0 )
     {
-        (*tpmLocalTpmPrintf)( rmDebugPrefix, "\n" );
-        (*tpmLocalTpmPrintf)( rmDebugPrefix, "Response Received: " );
-        DEBUG_PRINT_BUFFER( response_buffer, ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->responseSize );
+        (*tpmLocalTpmPrintf)( NO_PREFIX, "\n" );
+        (*tpmLocalTpmPrintf)( NO_PREFIX, "Response Received: " );
+        DEBUG_PRINT_BUFFER( NO_PREFIX, response_buffer, ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->responseSize );
     }
 #endif
 

--- a/tcti/tcti_socket.cpp
+++ b/tcti/tcti_socket.cpp
@@ -109,12 +109,12 @@ TSS2_RC SocketSendTpmCommand(
 #ifdef DEBUG
         (*printfFunction)(NO_PREFIX, "\n" );
         if( commandCode >= TPM_CC_NV_UndefineSpaceSpecial && commandCode <= TPM_CC_PolicyNvWritten )     
-            (*printfFunction)(rmDebugPrefix, "Cmd sent: %s\n", commandCodeStrings[ commandCode - TPM_CC_FIRST ] );            
+            (*printfFunction)( NO_PREFIX, "Cmd sent: %s\n", commandCodeStrings[ commandCode - TPM_CC_FIRST ] );            
         else
-            (*printfFunction)(rmDebugPrefix, "Cmd sent: 0x%4.4x\n", CHANGE_ENDIAN_DWORD(commandCode ) );
+            (*printfFunction)( NO_PREFIX, "Cmd sent: 0x%4.4x\n", CHANGE_ENDIAN_DWORD(commandCode ) );
 #endif
 #ifdef DEBUG_SOCKETS
-        (*printfFunction)(rmDebugPrefix, "Command sent on socket #0x%x: %s\n", TCTI_CONTEXT_INTEL->tpmSock, commandCodeStrings[ commandCode - TPM_CC_FIRST ]  );
+        (*printfFunction)( NO_PREFIX, "Command sent on socket #0x%x: %s\n", TCTI_CONTEXT_INTEL->tpmSock, commandCodeStrings[ commandCode - TPM_CC_FIRST ]  );
 #endif        
     }
     // Size TPM 1.2 and TPM 2.0 headers overlap exactly, we can use
@@ -151,7 +151,7 @@ TSS2_RC SocketSendTpmCommand(
 #ifdef DEBUG
     if( ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext )->status.debugMsgLevel == TSS2_TCTI_DEBUG_MSG_ENABLED )
     {
-        (*printfFunction)(rmDebugPrefix, "Locality = %d", ( (TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->status.locality );
+        (*printfFunction)( NO_PREFIX, "Locality = %d", ( (TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->status.locality );
     }
 #endif
     
@@ -170,7 +170,7 @@ TSS2_RC SocketSendTpmCommand(
 #ifdef DEBUG
     if( ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext )->status.debugMsgLevel == TSS2_TCTI_DEBUG_MSG_ENABLED )
     {
-        DEBUG_PRINT_BUFFER( command_buffer, cnt1 );
+        DEBUG_PRINT_BUFFER( NO_PREFIX, command_buffer, cnt1 );
     }
 #endif
     ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->status.commandSent = 1;
@@ -389,10 +389,10 @@ TSS2_RC SocketReceiveTpmResponse(
                 ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->responseSize > 0 )
         {
 #ifdef DEBUG
-            (*printfFunction)( rmDebugPrefix, "Response Received: " );
+            (*printfFunction)( NO_PREFIX, "Response Received: " );
 #endif
 #ifdef DEBUG_SOCKETS
-            (*printfFunction)( rmDebugPrefix, "from socket #0x%x:\n", TCTI_CONTEXT_INTEL->tpmSock );
+            (*printfFunction)( NO_PREFIX, "from socket #0x%x:\n", TCTI_CONTEXT_INTEL->tpmSock );
 #endif
         }
         
@@ -418,7 +418,7 @@ TSS2_RC SocketReceiveTpmResponse(
 #ifdef DEBUG
         if( ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext )->status.debugMsgLevel == TSS2_TCTI_DEBUG_MSG_ENABLED )
         {
-            DEBUG_PRINT_BUFFER( response_buffer, ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->responseSize );
+            DEBUG_PRINT_BUFFER( NO_PREFIX, response_buffer, ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->responseSize );
         }
 #endif
 

--- a/test/tpmclient/tpmclient.cpp
+++ b/test/tpmclient/tpmclient.cpp
@@ -882,9 +882,9 @@ void TestTctiApis( TSS2_TCTI_CONTEXT *tstTctiContext, int againstRM )
     if( responseBufferError )
     {
         DebugPrintf( NO_PREFIX, "\nERROR!!  responseBuffer after receive is incorrect, s/b:\n" );
-        DebugPrintBuffer( (UINT8 *)&goodRspBuffer[0], responseSize );
+        DebugPrintBuffer( NO_PREFIX, (UINT8 *)&goodRspBuffer[0], responseSize );
         DebugPrintf( NO_PREFIX, "\nwas:\n" );
-        DebugPrintBuffer( (UINT8 *)&responseBuffer, responseSize );
+        DebugPrintBuffer( NO_PREFIX, (UINT8 *)&responseBuffer, responseSize );
         Cleanup();
     }
     
@@ -1221,9 +1221,9 @@ void TestSapiApis()
     if( rpBufferError )
     {
         DebugPrintf( NO_PREFIX, "\nERROR!!  Tss2_Sys_GetRpBuffer returned wrong rpBuffer contents:\nrpBuffer was: \n\t" );
-        DebugPrintBuffer( (UINT8 *)&rpBuffer, rpBufferUsedSize );
+        DebugPrintBuffer( NO_PREFIX, (UINT8 *)&rpBuffer, rpBufferUsedSize );
         DebugPrintf( NO_PREFIX, "\nrpBuffer s/b:\n\t" );
-        DebugPrintBuffer( (UINT8 *)&(goodRpBuffer[0]), rpBufferUsedSize );
+        DebugPrintBuffer( NO_PREFIX, (UINT8 *)&(goodRpBuffer[0]), rpBufferUsedSize );
         Cleanup();
     }
     
@@ -3052,7 +3052,7 @@ void TestPolicy()
             CheckPassed( rval );
 #ifdef DEBUG
             DebugPrintf( NO_PREFIX, "Built policy digest:  \n" );
-            DebugPrintBuffer( &(policyDigest.t.buffer[0]), policyDigest.t.size );
+            DebugPrintBuffer( NO_PREFIX, &(policyDigest.t.buffer[0]), policyDigest.t.size );
 #endif
         }
 
@@ -3061,7 +3061,7 @@ void TestPolicy()
         {
 #ifdef DEBUG
             DebugPrintf( NO_PREFIX, "Policy digest used to create object:  \n" );
-            DebugPrintBuffer( &(policyDigest.t.buffer[0]), policyDigest.t.size );
+            DebugPrintBuffer( NO_PREFIX, &(policyDigest.t.buffer[0]), policyDigest.t.size );
 #endif
             
             rval = ( *policyTestSetups[i].createObjectFn )( sysContext, &policySession, &policyDigest);
@@ -3076,7 +3076,7 @@ void TestPolicy()
             CheckPassed( rval );
 #ifdef DEBUG
             DebugPrintf( NO_PREFIX, "Command policy digest:  \n" );
-            DebugPrintBuffer( &(policyDigest.t.buffer[0]), policyDigest.t.size );
+            DebugPrintBuffer( NO_PREFIX, &(policyDigest.t.buffer[0]), policyDigest.t.size );
 #endif
         }
 
@@ -3410,7 +3410,7 @@ void ProvisionOtherIndices()
     CheckPassed( rval );
 
     // Now save the policy digest from the first OR branch.
-    DEBUG_PRINT_BUFFER( &( nvPolicyHash.t.buffer[0] ), nvPolicyHash.t.size );
+    DEBUG_PRINT_BUFFER( NO_PREFIX, &( nvPolicyHash.t.buffer[0] ), nvPolicyHash.t.size );
 
     // 4.  CreateNvIndex
     otherIndicesSessionData.sessionHandle = TPM_RS_PW;
@@ -3526,7 +3526,7 @@ void ProvisionNvAux()
     CheckPassed( rval );
 
     // Now save the policy digest.
-    DEBUG_PRINT_BUFFER( &( nvPolicyHash.t.buffer[0] ), nvPolicyHash.t.size );
+    DEBUG_PRINT_BUFFER( NO_PREFIX, &( nvPolicyHash.t.buffer[0] ), nvPolicyHash.t.size );
 
     // 4.  CreateNvIndex
     nvAuxSessionData.sessionHandle = TPM_RS_PW;
@@ -5655,7 +5655,7 @@ void TestEncryptDecryptSession()
         CheckPassed( rval );
 
         DebugPrintf( NO_PREFIX, "Decrypted read data = " );
-        DEBUG_PRINT_BUFFER( &readData.t.buffer[0], (UINT32 )readData.t.size );
+        DEBUG_PRINT_BUFFER( NO_PREFIX, &readData.t.buffer[0], (UINT32 )readData.t.size );
 
         // Check that write and read data are equal.
         if( memcmp( (void *)&readData.t.buffer[0],
@@ -5848,7 +5848,7 @@ void GetSetDecryptParamTests()
 #ifdef DEBUG
     DebugPrintf( NO_PREFIX, "cpBuffer = ");
 #endif    
-    DEBUG_PRINT_BUFFER( (UINT8 *)cpBuffer1, cpBufferUsedSize1 );
+    DEBUG_PRINT_BUFFER( NO_PREFIX, (UINT8 *)cpBuffer1, cpBufferUsedSize1 );
     
     // Test for no decrypt param.
     rval = Tss2_Sys_NV_Read_Prepare( decryptParamTestSysContext, TPM20_INDEX_PASSWORD_TEST, TPM20_INDEX_PASSWORD_TEST, sizeof( nvWriteData ) - 2, 0 ); 
@@ -5906,7 +5906,7 @@ void GetSetDecryptParamTests()
 #ifdef DEBUG
     DebugPrintf( NO_PREFIX, "cpBuffer = ");
 #endif    
-    DEBUG_PRINT_BUFFER( (UINT8 *)cpBuffer2, cpBufferUsedSize2 );
+    DEBUG_PRINT_BUFFER( NO_PREFIX, (UINT8 *)cpBuffer2, cpBufferUsedSize2 );
 
     if( cpBufferUsedSize1 != cpBufferUsedSize2 )
     {

--- a/test/tpmtest/tpmtest.cpp
+++ b/test/tpmtest/tpmtest.cpp
@@ -3078,7 +3078,7 @@ void ProvisionOtherIndices()
     CheckPassed( rval );
 
     // Now save the policy digest from the first OR branch.
-    DEBUG_PRINT_BUFFER( &( nvPolicyHash.t.buffer[0] ), nvPolicyHash.t.size );
+    DEBUG_PRINT_BUFFER( NO_PREFIX, &( nvPolicyHash.t.buffer[0] ), nvPolicyHash.t.size );
 
     // 4.  CreateNvIndex
     otherIndicesSessionData.sessionHandle = TPM_RS_PW;
@@ -3193,7 +3193,7 @@ void ProvisionNvAux()
     CheckPassed( rval );
 
     // Now save the policy digest.
-    DEBUG_PRINT_BUFFER( &( nvPolicyHash.t.buffer[0] ), nvPolicyHash.t.size );
+    DEBUG_PRINT_BUFFER( NO_PREFIX, &( nvPolicyHash.t.buffer[0] ), nvPolicyHash.t.size );
 
     // 4.  CreateNvIndex
     nvAuxSessionData.sessionHandle = TPM_RS_PW;
@@ -5425,7 +5425,7 @@ void TestEncryptDecryptSession()
         CheckPassed( rval );
 
         printf( "Decrypted read data = " );
-        DEBUG_PRINT_BUFFER( &readData.t.buffer[0], (UINT32 )readData.t.size );
+        DEBUG_PRINT_BUFFER( NO_PREFIX, &readData.t.buffer[0], (UINT32 )readData.t.size );
 
         // Check that write and read data are equal.
         if( memcmp( (void *)&readData.t.buffer[0],
@@ -5612,7 +5612,7 @@ void GetSetDecryptParamTests()
 #ifdef DEBUG
     printf( "cpBuffer = ");
 #endif
-    DEBUG_PRINT_BUFFER( (UINT8 *)cpBuffer1, cpBufferUsedSize1 );
+    DEBUG_PRINT_BUFFER( NO_PREFIX, (UINT8 *)cpBuffer1, cpBufferUsedSize1 );
 
     // Test for no decrypt param.
     rval = Tss2_Sys_NV_Read_Prepare( decryptParamTestSysContext, TPM20_INDEX_PASSWORD_TEST, TPM20_INDEX_PASSWORD_TEST, sizeof( nvWriteData ) - 2, 0 );
@@ -5669,7 +5669,7 @@ void GetSetDecryptParamTests()
 #ifdef DEBUG
     printf( "cpBuffer = ");
 #endif
-    DEBUG_PRINT_BUFFER( (UINT8 *)cpBuffer2, cpBufferUsedSize2 );
+    DEBUG_PRINT_BUFFER( NO_PREFIX, (UINT8 *)cpBuffer2, cpBufferUsedSize2 );
 
     if( cpBufferUsedSize1 != cpBufferUsedSize2 )
     {


### PR DESCRIPTION
This global variable seemed to act like an escape hatch overriding the
flag passed to the debug function. As someone coming along and trying to
pick up this code I found it confusing when debug function refused to
print a prefix even though I had asked it to. Not hard to figure out but
global flags like this have the potential to cause unexpected behavior.
IMHO it's better to simplify the code and remove this.

To compensate for the loss of the rmDebugPrefix flag in the
DebugPrintBuffer function I've added another parameter for callers to pass
a printf_type flag to obtain the same behavior as when the rmDebugPrefix
flag was set.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>