### PR TITLE
Fixed bug in SetEncryptParam:  should be checking that encrypParamSiz…

### DIFF
--- a/sysapi/sysapi/EncryptParam.c
+++ b/sysapi/sysapi/EncryptParam.c
@@ -86,7 +86,7 @@ TSS2_RC Tss2_Sys_SetEncryptParam(
 
         if( rval == TSS2_RC_SUCCESS )
         {
-            if( encryptParamSize < currEncryptParamSize )
+            if( encryptParamSize != currEncryptParamSize )
             {
                 return TSS2_SYS_RC_BAD_SIZE;
             }


### PR DESCRIPTION
…e is

not equal to the current encrypt param's size (was check <).