### PR TITLE
debug: Missed converting a few calls to DebugPrintBuffer.

### DIFF
--- a/common/sockets.cpp
+++ b/common/sockets.cpp
@@ -25,7 +25,7 @@ TSS2_RC recvBytes( SOCKET tpmSock, unsigned char *data, int len )
 
 #ifdef DEBUG_SOCKETS
     (*printfFunction)( NO_PREFIX, "Receive Bytes from socket #0x%x: \n", tpmSock );
-    DebugPrintBuffer( data, len );
+    DebugPrintBuffer( NO_PREFIX, data, len );
 #endif
 
     return TSS2_RC_SUCCESS;
@@ -38,7 +38,7 @@ TSS2_RC sendBytes( SOCKET tpmSock, const char *data, int len )
 
 #ifdef DEBUG_SOCKETS
     (*printfFunction)(NO_PREFIX, "Send Bytes to socket #0x%x: \n", tpmSock );
-    DebugPrintBuffer( (UINT8 *)data, len );
+    DebugPrintBuffer( NO_PREFIX, (UINT8 *)data, len );
 #endif
 
     for( sentLength = 0; sentLength < len; len -= iResult, sentLength += iResult )

--- a/tcti/platformcommand.c
+++ b/tcti/platformcommand.c
@@ -69,7 +69,7 @@ TSS2_RC PlatformCommand(
     {
 #ifdef DEBUG_SOCKETS
         (*printfFunction)( NO_PREFIX, "Send Bytes to socket #0x%x: \n", TCTI_CONTEXT_INTEL->otherSock );
-        DebugPrintBuffer( (UINT8 *)sendbuf, 4 );
+        DebugPrintBuffer( NO_PREFIX, (UINT8 *)sendbuf, 4 );
 #endif
         // Read result
         iResult = recv( TCTI_CONTEXT_INTEL->otherSock, recvbuf, 4, 0);
@@ -87,7 +87,7 @@ TSS2_RC PlatformCommand(
         {
 #ifdef DEBUG_SOCKETS
             (*printfFunction)(NO_PREFIX, "Receive bytes from socket #0x%x: \n", TCTI_CONTEXT_INTEL->otherSock );
-            DebugPrintBuffer( (UINT8 *)recvbuf, 4 );
+            DebugPrintBuffer( NO_PREFIX, (UINT8 *)recvbuf, 4 );
 #endif
         }
     }


### PR DESCRIPTION
These slipped through as they're only enabled when DEBUG_SOCKETS is
defined.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>