### PR TITLE
resourcemgr: Default to simulator port when connecting to the simulator.

### DIFF
--- a/resourcemgr/resourcemgr.c
+++ b/resourcemgr/resourcemgr.c
@@ -2475,7 +2475,7 @@ const char *resDeviceTctiName = "device TCTI";
 const char *resSocketTctiName = "socket TCTI";
 TCTI_SOCKET_CONF simInterfaceConfig = {
     DEFAULT_HOSTNAME,
-    DEFAULT_RESMGR_TPM_PORT
+    DEFAULT_SIMULATOR_TPM_PORT
 };
 
 SOCKET simOtherSock;


### PR DESCRIPTION
This regression brought to you by
6feb976cc62bab3a3ec4687bcf308c4e703f27ce.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>