### PR TITLE
Tcti device printf

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -46,7 +46,7 @@ libtss2_HEADERS = $(srcdir)/include/tss2/*.h
 libtctidir      = $(includedir)/tcti
 libtcti_HEADERS = $(srcdir)/include/tcti/*.h
 
-test_tcti_device_CFLAGS  = $(CMOCKA_CFLAGS) -I$(srcdir)
+test_tcti_device_CFLAGS  = $(CMOCKA_CFLAGS) -I$(srcdir) -I$(srcdir)/sysapi/include
 test_tcti_device_LDADD   = $(libtss2) $(libtctidevice) $(CMOCKA_LIBS)
 test_tcti_device_SOURCES = test/tcti_device.c test/tcti_device_test.c
 

--- a/common/debug.c
+++ b/common/debug.c
@@ -47,6 +47,25 @@ int DebugPrintf( printf_type type, const char *format, ...)
     return rval;
 }
 
+/* This callback function is intended for use with the TCTI log callback
+ * mechanism. It provides an additional parameter for receiving arbitrary
+ * user specified data.
+ */
+int DebugPrintfCallback( void *data, printf_type type, const char *format, ...)
+{
+    va_list args;
+    int rval = 0;
+
+    if( type == RM_PREFIX )
+        DebugPrintfCallback( data, NO_PREFIX,  "||  " );
+
+    va_start( args, format );
+    rval = vprintf( format, args );
+    va_end (args);
+
+    return rval;
+}
+
 void DebugPrintBuffer( printf_type type, UINT8 *buffer, UINT32 length )
 {
     UINT32  i;

--- a/common/debug.h
+++ b/common/debug.h
@@ -39,6 +39,7 @@ extern "C" {
 
 enum debugLevel { DBG_NO_COMMAND = 0, DBG_COMMAND = 1, DBG_COMMAND_RM = 2, DBG_COMMAND_RM_TABLES = 3 };
 
+int DebugPrintfCallback( void *data, printf_type type, const char *format, ...);
 int DebugPrintf( printf_type type, const char *format, ...);
 void DebugPrintBuffer( printf_type type, UINT8 *command_buffer, UINT32 cnt1 );
 

--- a/include/tcti/common.h
+++ b/include/tcti/common.h
@@ -1,5 +1,5 @@
 //**********************************************************************;
-// Copyright (c) 2015, Intel Corporation
+// Copyright (c) 2016, Intel Corporation
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -25,33 +25,15 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //**********************************************************************;
 
-#ifndef TCTI_DEVICE_H
-#define TCTI_DEVICE_H
-
-#ifdef __cplusplus
-extern "C" {
-#endif
+#ifndef TCTI_COMMON_H
+#define TCTI_COMMON_H
 
 #include <tss2/tpm20.h>
-#include <tcti/common.h>
 
-typedef struct {
-    const char *device_path;
-    TCTI_LOG_CALLBACK logCallback;
-    void *logData;
-} TCTI_DEVICE_CONF;
+#define TCTI_MAGIC 0x7e18e9defa8bc9e2
+#define TCTI_VERSION 0x1
 
-TSS2_RC InitDeviceTcti (
-    TSS2_TCTI_CONTEXT *tctiContext, // OUT
-    size_t *contextSize,            // IN/OUT
-    const TCTI_DEVICE_CONF *config,              // IN
-    const uint64_t magic,
-    const uint32_t version,
-    const char *interfaceName
-    );
+typedef enum { NO_PREFIX = 0, RM_PREFIX = 1 } printf_type;
+typedef int (*TCTI_LOG_CALLBACK)( void *data, printf_type type, const char *format, ...);
 
-#ifdef __cplusplus
-}
-#endif
-
-#endif /* TCTI_DEVICE_H */
+#endif /* TCTI_COMMON_H */

--- a/include/tcti/magic.h
+++ b/include/tcti/magic.h
@@ -1,4 +1,0 @@
-#pragma once
-
-#define TCTI_MAGIC 0x7e18e9defa8bc9e2
-#define TCTI_VERSION 0x1

--- a/include/tcti/tcti_socket.h
+++ b/include/tcti/tcti_socket.h
@@ -33,7 +33,7 @@ extern "C" {
 #endif
 
 #include <tss2/tpm20.h>
-#include <tcti/magic.h>
+#include <tcti/common.h>
 
 #define DEFAULT_SIMULATOR_TPM_PORT        2321
 #define TSS2_SIMULATOR_INTERFACE_INIT_FAILED              ((TSS2_RC)(1 + TSS2_DRIVER_ERROR_LEVEL))
@@ -43,7 +43,6 @@ extern "C" {
 
 #define DEFAULT_HOSTNAME        "127.0.0.1"
 
-typedef enum { NO_PREFIX = 0, RM_PREFIX = 1 } printf_type;
 /* global data defined in the socket TCTI */
 extern int (*printfFunction)( printf_type type, const char *format, ...);
 

--- a/resourcemgr/resourcemgr.c
+++ b/resourcemgr/resourcemgr.c
@@ -2805,7 +2805,7 @@ int main(int argc, char* argv[])
         //
         // Init downstream interface to tpm (in this case the local TPM).
         //
-        TCTI_DEVICE_CONF deviceTctiConfig = { "/dev/tpm0" };
+        TCTI_DEVICE_CONF deviceTctiConfig = { "/dev/tpm0", DebugPrintfCallback, NULL };
 
         rval = InitDeviceTctiContext( &deviceTctiConfig, &downstreamTctiContext, resDeviceTctiName );
         if( rval != TSS2_RC_SUCCESS )

--- a/sysapi/include/tcti_util.h
+++ b/sysapi/include/tcti_util.h
@@ -44,6 +44,11 @@
 #define SOCKET int
 #endif
 
+#include <tcti/common.h>
+
+#define TCTI_LOG_CALLBACK(ctx) ((TSS2_TCTI_CONTEXT_INTEL*)ctx)->logCallback
+#define TCTI_LOG_DATA(ctx)     ((TSS2_TCTI_CONTEXT_INTEL*)ctx)->logData
+
 typedef TSS2_RC (*TCTI_TRANSMIT_PTR)( TSS2_TCTI_CONTEXT *tctiContext, size_t size, uint8_t *command);
 typedef TSS2_RC (*TCTI_RECEIVE_PTR) (TSS2_TCTI_CONTEXT *tctiContext, size_t *size, uint8_t *response, int32_t timeout);
 
@@ -87,6 +92,8 @@ typedef struct {
     int devFile;  
     UINT8 previousStage;            // Used to check for sequencing errors.
     unsigned char responseBuffer[4096];
+    TCTI_LOG_CALLBACK logCallback;
+    void *logData;
 } TSS2_TCTI_CONTEXT_INTEL;
 
 #define TCTI_CONTEXT ( (TSS2_TCTI_CONTEXT_COMMON_CURRENT *)(SYS_CONTEXT->tctiContext) )

--- a/tcti/commonchecks.c
+++ b/tcti/commonchecks.c
@@ -28,7 +28,7 @@
 #include <stdio.h>
 #include <stdlib.h>   // Needed for _wtoi
 
-#include <tcti/magic.h>
+#include <tcti/common.h>
 #include <tss2/tpm20.h>
 #include "sysapi_util.h"
 #include "debug.h"

--- a/tcti/logging.h
+++ b/tcti/logging.h
@@ -1,0 +1,9 @@
+#include <tss2/tpm20.h>
+
+#include "tcti_util.h"
+
+#define TCTI_LOG_CALLBACK_INVOKE(ctx, type, format, ...) \
+    TCTI_LOG_CALLBACK(ctx)(TCTI_LOG_DATA(ctx), type, format, ##__VA_ARGS__)
+#define TCTI_LOG( ctx, type, format, ...) \
+    (TCTI_LOG_CALLBACK( ctx ) != NULL) ? \
+      TCTI_LOG_CALLBACK_INVOKE( ctx, type, format, ##__VA_ARGS__) : 0

--- a/test/tcti_device.c
+++ b/test/tcti_device.c
@@ -14,11 +14,25 @@ tcti_dev_init_size_test (void **state)
                      sizeof (TSS2_TCTI_CONTEXT_INTEL));
 }
 
+static void
+tcti_dev_init_log_test (void **state)
+{
+    tcti_dev_init_log (state);
+}
+
+static void
+tcti_dev_log_called_test (void **state)
+{
+    assert_true (tcti_dev_log_called (state));
+}
+
 int
 main(int argc, char* argv[])
 {
     const UnitTest tests[] = {
         unit_test(tcti_dev_init_size_test),
+        unit_test(tcti_dev_init_log_test),
+        unit_test(tcti_dev_log_called_test),
     };
     return run_tests(tests);
 }

--- a/test/tcti_device_test.c
+++ b/test/tcti_device_test.c
@@ -1,4 +1,9 @@
+#include <stdio.h>
 #include <tcti/tcti_device.h>
+#include <stdbool.h>
+#include "tcti/logging.h"
+#include <setjmp.h>
+#include <cmocka.h>
 
 /* Determine the size of a TCTI context structure. Requires calling the
  * initialization function for the device TCTI with the first parameter
@@ -17,3 +22,79 @@ tcti_dev_init_size (void **state)
     else
         return tcti_size;
 }
+
+/* begin tcti_dev_init_log */
+/* This test configures the device TCTI with a logging callback and some user
+ * data. It checks to be sure that the initialization function sets the
+ * internal data in the TCTI to use / point to this data accordingly.
+ */
+int
+tcti_dev_init_log_callback (void *data, printf_type type, const char *format, ...)
+{
+    return 0;
+}
+void
+tcti_dev_init_log (void **state)
+{
+    void *my_state = *state;
+    size_t tcti_size = 0;
+    uint8_t my_data = 0x9;
+    TSS2_RC ret = TSS2_RC_SUCCESS;
+    TSS2_TCTI_CONTEXT *ctx = NULL;
+    TCTI_DEVICE_CONF conf = {
+        "/dev/null", tcti_dev_init_log_callback, &my_data
+    };
+
+    ret = InitDeviceTcti (NULL, &tcti_size, NULL, TCTI_MAGIC, TCTI_VERSION, NULL);
+    assert_true (ret == TSS2_RC_SUCCESS);
+    ctx = calloc (1, tcti_size);
+    assert_non_null (ctx);
+    ret = InitDeviceTcti (ctx, 0, &conf, TCTI_MAGIC, TCTI_VERSION, NULL);
+    assert_true (ret == TSS2_RC_SUCCESS);
+    assert_true (TCTI_LOG_CALLBACK (ctx) == tcti_dev_init_log_callback);
+    assert_true (*(uint8_t*)TCTI_LOG_DATA (ctx) == my_data);
+    if (ctx)
+        free (ctx);
+}
+/* end tcti dev_init_log */
+
+/* begin tcti_dev_init_log_called */
+/* Initialize TCTI context providing a pointer to a logging function and some
+ * data. The test case calls the logging function through the TCTI interface
+ * and checks to be sure that the function is called and that the user data
+ * provided is what we expect. We detect that the logging function was called
+ * by having it change the user data provided and then detecting this change.
+ * The caller responsible for freeing the context.
+ */
+int
+tcti_dev_log_callback (void *data, printf_type type, const char *format, ...)
+{
+    *(bool*)data = true;
+    return 0;
+}
+
+bool
+tcti_dev_log_called (void **state)
+{
+    void *my_state = *state;
+    size_t tcti_size = 0;
+    bool called = false;
+    TSS2_RC ret = TSS2_RC_SUCCESS;
+    TSS2_TCTI_CONTEXT *ctx = NULL;
+    TCTI_DEVICE_CONF conf = {
+        "/dev/null", tcti_dev_log_callback, &called
+    };
+
+    ret = InitDeviceTcti (NULL, &tcti_size, NULL, TCTI_MAGIC, TCTI_VERSION, NULL);
+    assert_true (ret == TSS2_RC_SUCCESS);
+    ctx = calloc (1, tcti_size);
+    assert_non_null (ctx);
+    ret = InitDeviceTcti (ctx, 0, &conf, TCTI_MAGIC, TCTI_VERSION, NULL);
+    assert_true (ret == TSS2_RC_SUCCESS);
+    if (ctx)
+        free (ctx);
+    /* the 'called' variable should be changed from false to true after this */
+    TCTI_LOG (ctx, NO_PREFIX, "test log call");
+    return called;
+}
+/* end tcti_dev_init_log */

--- a/test/tcti_device_test.h
+++ b/test/tcti_device_test.h
@@ -1,3 +1,6 @@
 #include <stddef.h>
+#include <stdbool.h>
 
 size_t tcti_dev_init_size (void **state);
+void tcti_dev_init_log (void **state);
+bool tcti_dev_log_called (void **state);


### PR DESCRIPTION
This is a significant departure from the way we currently handle the debugging functions in the TCTIs. The way we've done this up till now was to have a global function pointer set at compile time. This was typically controlled by a pre-processor macro. The global data this approach causes a litany of problems.

The refactoring I've been doing has all been leading up to decoupling the TCTIs from the application code (removing this shared global data) while preserving the current debug messages. This PR is an experiment in allowing the application consuming the TCTI to provide a callback function and some data that the TCTI will invoke in place of the global debug function pointer. This PR only addresses the issue in the device TCTI since it's a more simple case. The socket TCTI comes next.

Very interested in feedback not just on the implementation but on the general approach (user supplied callback). This was the most flexible thing I could think up and it's a pretty common pattern (event driven etc) but that's not to say that I've anticipated every possible contingency and it may be that this approach has some flaws that I haven't anticipated.