### PR TITLE
Fixed bugs in AddSession and DeleteSession (these never worked right to

### DIFF
--- a/test/tpmclient/tpmclient.cpp
+++ b/test/tpmclient/tpmclient.cpp
@@ -6354,8 +6354,15 @@ void CmdRspAuthsTests()
             &testSessionHandle, &nonceTpm );
     CheckPassed( rval ); // #17
 
-    // Others?
-    
+    // Now delete sessions.
+    rval = EndAuthSession( encryptSession );
+    CheckPassed( rval );
+
+    rval = EndAuthSession( decryptSession );
+    CheckPassed( rval );
+
+    rval = EndAuthSession( auditSession );
+    CheckPassed( rval );
 }
 
 void GetSetEncryptParamTests()


### PR DESCRIPTION
begin with).

Because AddSession never worked right (the list always had only the latest
created session), fixing these bugs cause a failure in the simple HMAC session
test (HMAC computed incorrectly because GetSessionStruct found the wrong
session (multiple entries with same session handle).  This required fixes
in CmdRspAuthsTests to delete previously created sessions.