### PR TITLE
Fixed StartAuthSessionWithParams:  when StartAuthSession fails,

### DIFF
--- a/test/common/sample/StartAuthSession.c
+++ b/test/common/sample/StartAuthSession.c
@@ -306,8 +306,11 @@ TPM_RC StartAuthSessionWithParams( SESSION **session,
         if( (*session)->bind == TPM_RH_NULL )
             (*session)->authValueBind.t.size = 0;
 
-
         rval = StartAuthSession( *session );
+        if( rval != TSS2_RC_SUCCESS )
+        {
+            DeleteSession( *session );
+        }
     }
     else
     {


### PR DESCRIPTION
structures were left on the sessions list.  Needed to delete these.
They didn't really cause any problems, but did represent a memory
leak.  And they complicated debug.