### PR TITLE
tcti_device: Move convenience functions to common directory.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -80,7 +80,7 @@ test_tpmclient_tpmclient_SOURCES  = $(TPMCLIENT_CXX) $(COMMON_C) $(SAMPLE_C)
 
 test_tpmtest_tpmtest_CFLAGS   = -DSAPI_CLIENT $(TPMTEST_INC)
 test_tpmtest_tpmtest_CXXFLAGS = -DSAPI_CLIENT $(TPMTEST_INC)
-test_tpmtest_tpmtest_LDADD    = $(libtss2) $(libtctisocket)
+test_tpmtest_tpmtest_LDADD    = $(libtss2) $(libtctisocket) $(libtctidevice)
 test_tpmtest_tpmtest_SOURCES  = $(TPMTEST_CXX) $(COMMON_C) $(SAMPLE_C)
 
 # simple variables

--- a/common/tcti_device_util.c
+++ b/common/tcti_device_util.c
@@ -1,0 +1,25 @@
+#include <tcti/tcti_device.h>
+#include "tcti_util.h"
+
+TSS2_RC InitDeviceTctiContext( const TCTI_DEVICE_CONF *driverConfig, TSS2_TCTI_CONTEXT **tctiContext, const char *deviceTctiName )
+{
+    size_t size;
+
+    TSS2_RC rval = TSS2_RC_SUCCESS;
+
+    rval = InitDeviceTcti(NULL, &size, driverConfig, 0, 0, deviceTctiName );
+    if( rval != TSS2_RC_SUCCESS )
+        return rval;
+
+    *tctiContext = malloc(size);
+
+    rval = InitDeviceTcti(*tctiContext, &size, driverConfig, TCTI_MAGIC, TCTI_VERSION, deviceTctiName );
+    return rval;
+}
+
+TSS2_RC TeardownDeviceTcti(TSS2_TCTI_CONTEXT *tctiContext)
+{
+    ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->finalize( tctiContext );
+
+    return TSS2_RC_SUCCESS;
+}

--- a/common/tcti_device_util.h
+++ b/common/tcti_device_util.h
@@ -1,0 +1,13 @@
+#include <tss2/tpm20.h>
+#include <tcti/tcti_device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+TSS2_RC InitDeviceTctiContext( const TCTI_DEVICE_CONF *config, TSS2_TCTI_CONTEXT **tctiContext, const char *deviceTctiName );
+TSS2_RC TeardownDeviceTcti(TSS2_TCTI_CONTEXT *tctiContext);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/tcti/tcti_device.h
+++ b/include/tcti/tcti_device.h
@@ -47,8 +47,6 @@ TSS2_RC InitDeviceTcti (
     const uint32_t version,
     const char *interfaceName
     );
-TSS2_RC InitDeviceTctiContext( const TCTI_DEVICE_CONF *config, TSS2_TCTI_CONTEXT **tctiContext );
-TSS2_RC TeardownDeviceTcti( TSS2_TCTI_CONTEXT *tctiContext );
 
 #ifdef __cplusplus
 }

--- a/resourcemgr/resourcemgr.c
+++ b/resourcemgr/resourcemgr.c
@@ -31,6 +31,7 @@
 #include <tss2/tpm20.h>
 #include <tcti/tcti_device.h>
 #include <tcti/tcti_socket.h>
+#include "tcti_device_util.h"
 #include "resourcemgr.h"
 //#include <sample.h>
 #include "sockets.h"
@@ -2806,7 +2807,7 @@ int main(int argc, char* argv[])
         //
         TCTI_DEVICE_CONF deviceTctiConfig = { "/dev/tpm0" };
 
-        rval = InitDeviceTctiContext( &deviceTctiConfig, &downstreamTctiContext );
+        rval = InitDeviceTctiContext( &deviceTctiConfig, &downstreamTctiContext, resDeviceTctiName );
         if( rval != TSS2_RC_SUCCESS )
         {
             DebugPrintf( NO_PREFIX,  "Resource Mgr, %s, failed initialization: 0x%x.  Exiting...\n", resDeviceTctiName, rval );

--- a/tcti/tcti_device.c
+++ b/tcti/tcti_device.c
@@ -48,8 +48,6 @@
 
 #define HOSTNAME_LENGTH 200
 
-const char *deviceTctiName = "device TCTI";
-
 int (*tpmLocalTpmPrintf)( printf_type type, const char *format, ...) = DebugPrintf;
 
 TSS2_RC LocalTpmSendTpmCommand(
@@ -275,28 +273,5 @@ TSS2_RC InitDeviceTcti (
         }
     }
 
-    return rval;
-}
-
-TSS2_RC TeardownDeviceTcti(TSS2_TCTI_CONTEXT *tctiContext)
-{
-    ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->finalize( tctiContext );
-
-    return TSS2_RC_SUCCESS;
-}
-
-TSS2_RC InitDeviceTctiContext( const TCTI_DEVICE_CONF *driverConfig, TSS2_TCTI_CONTEXT **tctiContext )
-{
-    size_t size;
-    
-    TSS2_RC rval = TSS2_RC_SUCCESS;
-
-    rval = InitDeviceTcti(NULL, &size, driverConfig, 0, 0, deviceTctiName );
-    if( rval != TSS2_RC_SUCCESS )
-        return rval;
-    
-    *tctiContext = malloc(size);
-
-    rval = InitDeviceTcti(*tctiContext, &size, driverConfig, TCTI_MAGIC, TCTI_VERSION, deviceTctiName );
     return rval;
 }

--- a/test/tpmclient/tpmclient.cpp
+++ b/test/tpmclient/tpmclient.cpp
@@ -59,6 +59,7 @@
 #include "sample.h"
 #include "resourcemgr.h"
 #include "tpmclient.h"
+#include "tcti_device_util.h"
 
 // This is done to allow the tests to access fields
 // in the sysContext structure that are needed for
@@ -7066,6 +7067,7 @@ void TestLocalTCTI()
 {
     TCTI_DEVICE_CONF deviceTctiConfig = { "/dev/tpm0" };
     TSS2_RC rval = TSS2_RC_SUCCESS;
+    const char *deviceTctiName = "Local Device TCTI";
     
     TSS2_TCTI_CONTEXT *downstreamTctiContext;
 
@@ -7075,7 +7077,7 @@ void TestLocalTCTI()
     //
     // Init downstream interface to tpm (in this case the local TPM).
     //
-    rval = InitDeviceTctiContext( &deviceTctiConfig, &downstreamTctiContext );
+    rval = InitDeviceTctiContext( &deviceTctiConfig, &downstreamTctiContext, deviceTctiName );
     if( rval != TSS2_RC_SUCCESS )
     {
         DebugPrintf( NO_PREFIX,  "Resource Mgr, %s, failed initialization: 0x%x.  Exiting...\n", "local TPM", rval );


### PR DESCRIPTION
Both the InitDeviceTctiContext and TeardownDeviceTcti functions are not
part of the SAPI/TCTI spec. This commit moves them from the exposed
interface for the device TCTI to common/tcti_device_util.[ch]. AFAIK
these functions were created for convenience in the resourcemgr and test
applications.

This also includes a change to the signatures of these functions adding the name string that's passed into the InitDeviceTcti as a parameter to break coupling with another bit of global data.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>