### PR TITLE
Fixed bug in TestRM (uninitialized sizes for TPM2B's passed to Create…

### DIFF
--- a/test/tpmclient/tpmclient.cpp
+++ b/test/tpmclient/tpmclient.cpp
@@ -6792,6 +6792,8 @@ void TestRM()
 
     outPublic.t.size = 0;
     creationData.t.size = 0;
+    name.t.size = sizeof( name );
+    creationHash.t.size = sizeof( creationHash );
     rval = Tss2_Sys_CreatePrimary_Complete( sysContext, &newHandle, &outPublic, &creationData,
             &creationHash, &creationTicket, &name );
     CheckPassed( rval );


### PR DESCRIPTION
…PrimaryComplete).

Failures noticed when running under Linux.