### PR TITLE
tcti: Remove magic & version parameters from the Init functions.

### DIFF
--- a/common/tcti_device_util.c
+++ b/common/tcti_device_util.c
@@ -7,13 +7,13 @@ TSS2_RC InitDeviceTctiContext( const TCTI_DEVICE_CONF *driverConfig, TSS2_TCTI_C
 
     TSS2_RC rval = TSS2_RC_SUCCESS;
 
-    rval = InitDeviceTcti(NULL, &size, driverConfig, 0, 0, deviceTctiName );
+    rval = InitDeviceTcti(NULL, &size, driverConfig, deviceTctiName );
     if( rval != TSS2_RC_SUCCESS )
         return rval;
 
     *tctiContext = malloc(size);
 
-    rval = InitDeviceTcti(*tctiContext, &size, driverConfig, TCTI_MAGIC, TCTI_VERSION, deviceTctiName );
+    rval = InitDeviceTcti(*tctiContext, &size, driverConfig, deviceTctiName );
     return rval;
 }
 

--- a/include/tcti/common.h
+++ b/include/tcti/common.h
@@ -30,9 +30,6 @@
 
 #include <tss2/tpm20.h>
 
-#define TCTI_MAGIC 0x7e18e9defa8bc9e2
-#define TCTI_VERSION 0x1
-
 typedef enum { NO_PREFIX = 0, RM_PREFIX = 1 } printf_type;
 typedef int (*TCTI_LOG_CALLBACK)( void *data, printf_type type, const char *format, ...);
 

--- a/include/tcti/tcti_device.h
+++ b/include/tcti/tcti_device.h
@@ -45,8 +45,6 @@ TSS2_RC InitDeviceTcti (
     TSS2_TCTI_CONTEXT *tctiContext, // OUT
     size_t *contextSize,            // IN/OUT
     const TCTI_DEVICE_CONF *config,              // IN
-    const uint64_t magic,
-    const uint32_t version,
     const char *interfaceName
     );
 

--- a/include/tcti/tcti_socket.h
+++ b/include/tcti/tcti_socket.h
@@ -59,8 +59,6 @@ TSS2_RC InitSocketTcti (
     TSS2_TCTI_CONTEXT *tctiContext, // OUT
     size_t *contextSize,            // IN/OUT
     const TCTI_SOCKET_CONF *config,             // IN
-    const uint64_t magic,
-    const uint32_t version,
 	const char *interfaceName,
     const uint8_t serverSockets
     );

--- a/resourcemgr/resourcemgr.c
+++ b/resourcemgr/resourcemgr.c
@@ -2488,13 +2488,13 @@ TSS2_RC InitSimulatorTctiContext( TCTI_SOCKET_CONF *tcti_conf, TSS2_TCTI_CONTEXT
     
     TSS2_RC rval = TSS2_RC_SUCCESS;
 
-    rval = InitSocketTcti(NULL, &size, tcti_conf, 0, 0, resSocketTctiName, 1 );
+    rval = InitSocketTcti(NULL, &size, tcti_conf, resSocketTctiName, 1 );
     if( rval != TSS2_RC_SUCCESS )
         return rval;
     
     *tctiContext = malloc(size);
 
-    rval = InitSocketTcti(*tctiContext, &size, tcti_conf, TCTI_MAGIC, TCTI_VERSION, resSocketTctiName, 0 );
+    rval = InitSocketTcti(*tctiContext, &size, tcti_conf, resSocketTctiName, 0 );
     return rval;
 }
 

--- a/sysapi/include/tcti_util.h
+++ b/sysapi/include/tcti_util.h
@@ -46,6 +46,9 @@
 
 #include <tcti/common.h>
 
+#define TCTI_MAGIC   0x7e18e9defa8bc9e2
+#define TCTI_VERSION 0x1
+
 #define TCTI_LOG_CALLBACK(ctx) ((TSS2_TCTI_CONTEXT_INTEL*)ctx)->logCallback
 #define TCTI_LOG_DATA(ctx)     ((TSS2_TCTI_CONTEXT_INTEL*)ctx)->logData
 

--- a/tcti/tcti_device.c
+++ b/tcti/tcti_device.c
@@ -223,8 +223,6 @@ TSS2_RC InitDeviceTcti (
     TSS2_TCTI_CONTEXT *tctiContext, // OUT
     size_t *contextSize,            // IN/OUT
     const TCTI_DEVICE_CONF *config,              // IN
-    const uint64_t magic,
-    const uint32_t version,
     const char *interfaceName
     )
 {
@@ -243,8 +241,8 @@ TSS2_RC InitDeviceTcti (
     else
     {
         // Init TCTI context.
-        ((TSS2_TCTI_CONTEXT_COMMON_V1 *)tctiContext)->magic = magic;
-        ((TSS2_TCTI_CONTEXT_COMMON_V1 *)tctiContext)->version = version;
+        ((TSS2_TCTI_CONTEXT_COMMON_V1 *)tctiContext)->magic = TCTI_MAGIC;
+        ((TSS2_TCTI_CONTEXT_COMMON_V1 *)tctiContext)->version = TCTI_VERSION;
         ((TSS2_TCTI_CONTEXT_COMMON_V1 *)tctiContext)->transmit = LocalTpmSendTpmCommand;
         ((TSS2_TCTI_CONTEXT_COMMON_V1 *)tctiContext)->receive = LocalTpmReceiveTpmResponse;
         ((TSS2_TCTI_CONTEXT_COMMON_V1 *)tctiContext)->finalize = LocalTpmFinalize;

--- a/tcti/tcti_socket.cpp
+++ b/tcti/tcti_socket.cpp
@@ -464,8 +464,6 @@ TSS2_RC InitSocketTcti (
     TSS2_TCTI_CONTEXT *tctiContext, // OUT
     size_t *contextSize,            // IN/OUT
     const TCTI_SOCKET_CONF *conf,              // IN
-    const uint64_t magic,
-    const uint32_t version,
 	const char *interfaceName,
     const uint8_t serverSockets
     )
@@ -484,8 +482,8 @@ TSS2_RC InitSocketTcti (
         (*printfFunction)(NO_PREFIX, "Initializing %s Interface\n", interfaceName );
 
         // Init TCTI context.
-        ((TSS2_TCTI_CONTEXT_COMMON_V1 *)tctiContext)->magic = magic;
-        ((TSS2_TCTI_CONTEXT_COMMON_V1 *)tctiContext)->version = version;
+        ((TSS2_TCTI_CONTEXT_COMMON_V1 *)tctiContext)->magic = TCTI_MAGIC;
+        ((TSS2_TCTI_CONTEXT_COMMON_V1 *)tctiContext)->version = TCTI_VERSION;
         ((TSS2_TCTI_CONTEXT_COMMON_V1 *)tctiContext)->transmit = SocketSendTpmCommand;
         ((TSS2_TCTI_CONTEXT_COMMON_V1 *)tctiContext)->receive = SocketReceiveTpmResponse;
         ((TSS2_TCTI_CONTEXT_COMMON_V1 *)tctiContext)->finalize = SocketFinalize;

--- a/test/tpmclient/tpmclient.cpp
+++ b/test/tpmclient/tpmclient.cpp
@@ -267,7 +267,7 @@ TSS2_RC InitTctiResMgrContext( TCTI_SOCKET_CONF *rmInterfaceConfig, TSS2_TCTI_CO
     
     TSS2_RC rval;
 
-    rval = InitSocketTcti(NULL, &size, rmInterfaceConfig, 0, 0, &resMgrInterfaceName[0], 0 );
+    rval = InitSocketTcti(NULL, &size, rmInterfaceConfig, &resMgrInterfaceName[0], 0 );
     if( rval != TSS2_RC_SUCCESS )
         return rval;
     
@@ -275,7 +275,7 @@ TSS2_RC InitTctiResMgrContext( TCTI_SOCKET_CONF *rmInterfaceConfig, TSS2_TCTI_CO
 
     if( *tctiContext )
     {
-        rval = InitSocketTcti(*tctiContext, &size, rmInterfaceConfig, TCTI_MAGIC, TCTI_VERSION, resMgrInterfaceName, 0 );
+        rval = InitSocketTcti(*tctiContext, &size, rmInterfaceConfig, resMgrInterfaceName, 0 );
     }
     else
     {

--- a/test/tpmtest/tpmtest.cpp
+++ b/test/tpmtest/tpmtest.cpp
@@ -283,14 +283,14 @@ TSS2_RC InitTctiResMgrContext( TCTI_SOCKET_CONF *rmInterfaceConfig, TSS2_TCTI_CO
 
     TSS2_RC rval;
 
-	rval = InitSocketTcti(NULL, &size, rmInterfaceConfig, 0, 0, &resMgrInterfaceName[0], 0 );
+	rval = InitSocketTcti(NULL, &size, rmInterfaceConfig, &resMgrInterfaceName[0], 0 );
     if( rval != TSS2_RC_SUCCESS )
         return rval;
 
     *tctiContext = (TSS2_TCTI_CONTEXT *)malloc(size);
     if( *tctiContext )
     {
-        rval = InitSocketTcti(*tctiContext, &size, rmInterfaceConfig, TCTI_MAGIC, TCTI_VERSION, resMgrInterfaceName, 0 );
+        rval = InitSocketTcti(*tctiContext, &size, rmInterfaceConfig, resMgrInterfaceName, 0 );
     }
     else
     {


### PR DESCRIPTION
Allowing users to pass these values causes a situation where an unusable
TCTI context is created. There's no real reason to expose this data to
consumers of this library. This internal data has also been moved from the
installed common include file to the private sysapi/include/tcti_util.h.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>