### PR TITLE
Remove debug data from TCTI function signature.

### DIFF
--- a/common/tcti_device_util.c
+++ b/common/tcti_device_util.c
@@ -1,5 +1,6 @@
 #include <tcti/tcti_device.h>
 #include "tcti_util.h"
+#include "debug.h"
 
 TSS2_RC InitDeviceTctiContext( const TCTI_DEVICE_CONF *driverConfig, TSS2_TCTI_CONTEXT **tctiContext, const char *deviceTctiName )
 {
@@ -7,13 +8,14 @@ TSS2_RC InitDeviceTctiContext( const TCTI_DEVICE_CONF *driverConfig, TSS2_TCTI_C
 
     TSS2_RC rval = TSS2_RC_SUCCESS;
 
-    rval = InitDeviceTcti(NULL, &size, driverConfig, deviceTctiName );
+    rval = InitDeviceTcti(NULL, &size, driverConfig );
     if( rval != TSS2_RC_SUCCESS )
         return rval;
 
     *tctiContext = malloc(size);
 
-    rval = InitDeviceTcti(*tctiContext, &size, driverConfig, deviceTctiName );
+    DebugPrintf( NO_PREFIX, "Initializing %s Interface\n", deviceTctiName );
+    rval = InitDeviceTcti(*tctiContext, &size, driverConfig );
     return rval;
 }
 

--- a/include/tcti/tcti_device.h
+++ b/include/tcti/tcti_device.h
@@ -44,8 +44,7 @@ typedef struct {
 TSS2_RC InitDeviceTcti (
     TSS2_TCTI_CONTEXT *tctiContext, // OUT
     size_t *contextSize,            // IN/OUT
-    const TCTI_DEVICE_CONF *config,              // IN
-    const char *interfaceName
+    const TCTI_DEVICE_CONF *config  // IN
     );
 
 #ifdef __cplusplus

--- a/include/tcti/tcti_socket.h
+++ b/include/tcti/tcti_socket.h
@@ -59,7 +59,6 @@ TSS2_RC InitSocketTcti (
     TSS2_TCTI_CONTEXT *tctiContext, // OUT
     size_t *contextSize,            // IN/OUT
     const TCTI_SOCKET_CONF *config,             // IN
-	const char *interfaceName,
     const uint8_t serverSockets
     );
 

--- a/resourcemgr/resourcemgr.c
+++ b/resourcemgr/resourcemgr.c
@@ -2520,13 +2520,14 @@ TSS2_RC InitSimulatorTctiContext( TCTI_SOCKET_CONF *tcti_conf, TSS2_TCTI_CONTEXT
     
     TSS2_RC rval = TSS2_RC_SUCCESS;
 
-    rval = InitSocketTcti(NULL, &size, tcti_conf, resSocketTctiName, 1 );
+    rval = InitSocketTcti(NULL, &size, tcti_conf, 1 );
     if( rval != TSS2_RC_SUCCESS )
         return rval;
     
     *tctiContext = malloc(size);
 
-    rval = InitSocketTcti(*tctiContext, &size, tcti_conf, resSocketTctiName, 0 );
+    DebugPrintf( NO_PREFIX, "Initializing %s Interface\n", resSocketTctiName );
+    rval = InitSocketTcti(*tctiContext, &size, tcti_conf, 0 );
     return rval;
 }
 

--- a/tcti/tcti_device.c
+++ b/tcti/tcti_device.c
@@ -222,8 +222,7 @@ TSS2_RC LocalTpmSetLocality(
 TSS2_RC InitDeviceTcti (
     TSS2_TCTI_CONTEXT *tctiContext, // OUT
     size_t *contextSize,            // IN/OUT
-    const TCTI_DEVICE_CONF *config,              // IN
-    const char *interfaceName
+    const TCTI_DEVICE_CONF *config  // IN
     )
 {
     TSS2_RC rval = TSS2_RC_SUCCESS;
@@ -256,8 +255,6 @@ TSS2_RC InitDeviceTcti (
         ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->previousStage = TCTI_STAGE_INITIALIZE;
         TCTI_LOG_CALLBACK( tctiContext ) = config->logCallback;
         TCTI_LOG_DATA( tctiContext ) = config->logData;
-
-        TCTI_LOG( tctiContext, NO_PREFIX, "Initializing %s Interface\n", interfaceName );
 
         ( ( (TSS2_TCTI_CONTEXT_INTEL *)tctiContext )->devFile ) = open( config->device_path, O_RDWR );
         if( ( (TSS2_TCTI_CONTEXT_INTEL *)tctiContext )->devFile < 0 ) 

--- a/tcti/tcti_socket.cpp
+++ b/tcti/tcti_socket.cpp
@@ -464,7 +464,6 @@ TSS2_RC InitSocketTcti (
     TSS2_TCTI_CONTEXT *tctiContext, // OUT
     size_t *contextSize,            // IN/OUT
     const TCTI_SOCKET_CONF *conf,              // IN
-	const char *interfaceName,
     const uint8_t serverSockets
     )
 {
@@ -479,8 +478,6 @@ TSS2_RC InitSocketTcti (
     }
     else
     {
-        (*printfFunction)(NO_PREFIX, "Initializing %s Interface\n", interfaceName );
-
         // Init TCTI context.
         ((TSS2_TCTI_CONTEXT_COMMON_V1 *)tctiContext)->magic = TCTI_MAGIC;
         ((TSS2_TCTI_CONTEXT_COMMON_V1 *)tctiContext)->version = TCTI_VERSION;

--- a/test/tcti_device_test.c
+++ b/test/tcti_device_test.c
@@ -16,7 +16,7 @@ tcti_dev_init_size (void **state)
     size_t tcti_size = 0;
     TSS2_RC ret = TSS2_RC_SUCCESS;
 
-    ret = InitDeviceTcti (NULL, &tcti_size, NULL, NULL);
+    ret = InitDeviceTcti (NULL, &tcti_size, NULL);
     if (ret != TSS2_RC_SUCCESS)
         return 0;
     else
@@ -45,11 +45,11 @@ tcti_dev_init_log (void **state)
         "/dev/null", tcti_dev_init_log_callback, &my_data
     };
 
-    ret = InitDeviceTcti (NULL, &tcti_size, NULL, NULL);
+    ret = InitDeviceTcti (NULL, &tcti_size, NULL);
     assert_true (ret == TSS2_RC_SUCCESS);
     ctx = calloc (1, tcti_size);
     assert_non_null (ctx);
-    ret = InitDeviceTcti (ctx, 0, &conf, NULL);
+    ret = InitDeviceTcti (ctx, 0, &conf);
     assert_true (ret == TSS2_RC_SUCCESS);
     assert_true (TCTI_LOG_CALLBACK (ctx) == tcti_dev_init_log_callback);
     assert_true (*(uint8_t*)TCTI_LOG_DATA (ctx) == my_data);
@@ -85,11 +85,11 @@ tcti_dev_log_called (void **state)
         "/dev/null", tcti_dev_log_callback, &called
     };
 
-    ret = InitDeviceTcti (NULL, &tcti_size, NULL, NULL);
+    ret = InitDeviceTcti (NULL, &tcti_size, NULL);
     assert_true (ret == TSS2_RC_SUCCESS);
     ctx = calloc (1, tcti_size);
     assert_non_null (ctx);
-    ret = InitDeviceTcti (ctx, 0, &conf, NULL);
+    ret = InitDeviceTcti (ctx, 0, &conf);
     assert_true (ret == TSS2_RC_SUCCESS);
     if (ctx)
         free (ctx);

--- a/test/tpmclient/tpmclient.cpp
+++ b/test/tpmclient/tpmclient.cpp
@@ -268,7 +268,7 @@ TSS2_RC InitTctiResMgrContext( TCTI_SOCKET_CONF *rmInterfaceConfig, TSS2_TCTI_CO
     
     TSS2_RC rval;
 
-    rval = InitSocketTcti(NULL, &size, rmInterfaceConfig, &resMgrInterfaceName[0], 0 );
+    rval = InitSocketTcti(NULL, &size, rmInterfaceConfig, 0 );
     if( rval != TSS2_RC_SUCCESS )
         return rval;
     
@@ -276,7 +276,8 @@ TSS2_RC InitTctiResMgrContext( TCTI_SOCKET_CONF *rmInterfaceConfig, TSS2_TCTI_CO
 
     if( *tctiContext )
     {
-        rval = InitSocketTcti(*tctiContext, &size, rmInterfaceConfig, resMgrInterfaceName, 0 );
+        DebugPrintf( NO_PREFIX, "Initializing %s Interface\n", name);
+        rval = InitSocketTcti(*tctiContext, &size, rmInterfaceConfig, 0 );
     }
     else
     {

--- a/test/tpmtest/tpmtest.cpp
+++ b/test/tpmtest/tpmtest.cpp
@@ -283,14 +283,15 @@ TSS2_RC InitTctiResMgrContext( TCTI_SOCKET_CONF *rmInterfaceConfig, TSS2_TCTI_CO
 
     TSS2_RC rval;
 
-	rval = InitSocketTcti(NULL, &size, rmInterfaceConfig, &resMgrInterfaceName[0], 0 );
+    rval = InitSocketTcti(NULL, &size, rmInterfaceConfig, 0 );
     if( rval != TSS2_RC_SUCCESS )
         return rval;
 
     *tctiContext = (TSS2_TCTI_CONTEXT *)malloc(size);
     if( *tctiContext )
     {
-        rval = InitSocketTcti(*tctiContext, &size, rmInterfaceConfig, resMgrInterfaceName, 0 );
+        DebugPrintf( NO_PREFIX, "Initializing %s Interface\n", name );
+        rval = InitSocketTcti(*tctiContext, &size, rmInterfaceConfig, 0 );
     }
     else
     {


### PR DESCRIPTION
Both the device and socket TCTI init functions take as a final parameter
a string. AFAIK these strings are only used in a debug print function as
a way to track which TCTI is being initialized and when. This is useful
to client code but not something that should be reflected in the API
that we expose.

This patch removes this parameter and the corresponding debug printf
call from both TCTI init functions. An identical debug printf is added
to each client (resourcemgr, tpmclient, tpmtest) to keep the output
consistent. Unit tests are updated as well.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>