### PR TITLE
Added code to clean up when connection between application and resour…

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -93,7 +93,7 @@ LIBRARY_LDFLAGS = -fPIC
 RESOURCEMGR_INC = -I$(srcdir)/include -I$(srcdir)/common \
     -I$(srcdir)/sysapi/include -I$(srcdir)/resourcemgr \
     -I$(srcdir)/test/tpmclient
-RESOURCEMGR_C = resourcemgr/resourcemgr.c
+RESOURCEMGR_C = resourcemgr/resourcemgr.c resourcemgr/criticalsection_linux.c
 
 TCTICOMMON_INC = -I$(srcdir)/include -I$(srcdir)/common \
     -I$(srcdir)/sysapi/include

--- a/resourcemgr/criticalsection.h
+++ b/resourcemgr/criticalsection.h
@@ -1,0 +1,51 @@
+//**********************************************************************;
+// Copyright (c) 2015, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//**********************************************************************;
+
+#ifndef CRITICALSECTION_H
+#define CRITICALSECTION_H
+
+#ifdef  _WIN32
+typedef HANDLE TPM_MUTEX;
+#elif __linux || __unix
+#include <time.h>
+#include <semaphore.h>
+typedef sem_t TPM_MUTEX;
+#endif
+
+#define MILLISECOND_WAIT 2000
+
+//
+// Uncomment following to see debug messages related to mutex
+// operations.
+//
+//#define DEBUG_MUTEX
+
+TSS2_RC StartCriticalSection( TPM_MUTEX *tpmMutex, char *dbgString );
+TSS2_RC EndCriticalSection( TPM_MUTEX *tpmMutex, char *dbgString );
+
+#endif
+

--- a/resourcemgr/criticalsection_linux.c
+++ b/resourcemgr/criticalsection_linux.c
@@ -1,0 +1,109 @@
+//**********************************************************************;
+// Copyright (c) 2015, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//**********************************************************************;
+
+#include <stdio.h>
+#include <tss2/tpm20.h>
+
+#include "criticalsection.h"
+#include "debug.h"
+
+#if __linux || __unix
+
+//
+// This function starts a critical section, e.g. some code that must
+// not be interfered with.
+//
+// Currently this is used to grant a single connection exclusive
+// access to the TPM.  But it could be used for other critical sections
+// as well.
+//
+TSS2_RC StartCriticalSection( TPM_MUTEX *tpmMutex, char *dbgString )
+{
+	TSS2_RC rval = TSS2_RC_SUCCESS;
+	UINT8 mutexAcquired;
+	int mutexWaitRetVal;
+	struct timespec semWait = { 0, 0 };
+
+	mutexAcquired = 0;
+
+	// Critical section starts here--take the mutex.
+	clock_gettime( CLOCK_REALTIME, &semWait );
+	semWait.tv_sec += MILLISECOND_WAIT / 1000;
+
+	mutexWaitRetVal = sem_timedwait( tpmMutex, &semWait );
+	if( mutexWaitRetVal != 0 )
+	{
+		rval = TSS2_TCTI_RC_TRY_AGAIN;
+	}
+	else
+	{
+		mutexAcquired = 1;
+	}
+
+#ifdef DEBUG_MUTEX
+	if( mutexAcquired )
+	{
+		DebugPrintf(NO_PREFIX, "In %s, acquired mutex\n", dbgString );
+	}
+	else
+	{
+		DebugPrintf(NO_PREFIX, "In %s, failed to release mutex error: %d\n", errno, dbgString );
+	}
+#endif
+
+	return rval;
+}
+
+TSS2_RC EndCriticalSection( TPM_MUTEX *tpmMutex, char *dbgString )
+{
+	TSS2_RC rval = TSS2_RC_SUCCESS;
+	UINT8 mutexReleased = 0;
+
+	if( 0 != sem_post( tpmMutex ) )
+	{
+		rval = TSS2_TCTI_RC_TRY_AGAIN;
+	}
+	else
+	{
+	   mutexReleased = 1;
+	}
+
+#ifdef DEBUG_MUTEX
+	if( mutexReleased )
+	{
+		DebugPrintf(NO_PREFIX, "In PlatformCommand, released mutex\n" );
+	}
+	else
+	{
+		DebugPrintf(NO_PREFIX, "In PlatformCommand, failed to release mutex error: %d\n", errno );
+	}
+#endif
+
+	return rval;
+}
+
+#endif

--- a/resourcemgr/criticalsection_windows.c
+++ b/resourcemgr/criticalsection_windows.c
@@ -1,0 +1,106 @@
+//**********************************************************************;
+// Copyright (c) 2015, Intel Corporation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//**********************************************************************;
+
+#include <stdio.h>
+#include <tss2/tpm20.h>
+
+#include "criticalsection.h"
+#include "debug.h"
+
+#ifdef	_WIN32
+
+//
+// This function starts a critical section, e.g. some code that must
+// not be interfered with.
+//
+// Currently this is used to grant a single connection exclusive
+// access to the TPM.  But it could be used for other critical sections
+// as well.
+//
+TSS2_RC StartCriticalSection( TPM_MUTEX *tpmMutex, char *dbgString )
+{
+	TSS2_RC rval = TSS2_RC_SUCCESS;
+	UINT8 mutexAcquired = 0;
+	DWORD mutexWaitRetVal;
+
+	// Critical section starts here--take the mutex.
+	mutexWaitRetVal = WaitForSingleObject( *tpmMutex, MILLISECOND_WAIT );
+	if( mutexWaitRetVal != WAIT_OBJECT_0 )
+	{
+		rval = TSS2_TCTI_RC_TRY_AGAIN;
+	}
+	else
+	{
+		mutexAcquired = 1;
+	}
+
+#ifdef DEBUG_MUTEX
+	if( mutexAcquired )
+	{
+		DebugPrintf(NO_PREFIX, "In %s, acquired mutex\n", dbgString );
+	}
+	else
+	{
+		DebugPrintf(NO_PREFIX, "In %s, failed to release mutex error: %d\n", dbgString, GetLastError() );
+	}
+#endif
+
+	return rval;
+}
+
+//
+// This function ends the critical section.
+//
+TSS2_RC EndCriticalSection( TPM_MUTEX *tpmMutex, char *dbgString )
+{
+	TSS2_RC rval = TSS2_RC_SUCCESS;
+	UINT8 mutexReleased = 0;
+
+	if( 0 == ReleaseMutex( *tpmMutex ) )
+	{
+		rval = TSS2_TCTI_RC_TRY_AGAIN;
+	}
+	else
+	{
+		mutexReleased = 1;
+	}
+
+#ifdef DEBUG_MUTEX
+	if( mutexReleased )
+	{
+		DebugPrintf(NO_PREFIX, "In %s, released mutex\n", dbgString );
+	}
+	else
+	{
+		DebugPrintf(NO_PREFIX, "In %s, failed to release mutex error: %d\n", dbgString, GetLastError() );
+	}
+#endif
+
+	return rval;
+}
+
+#endif // _WIN32

--- a/resourcemgr/resourceMgr.vcxproj
+++ b/resourcemgr/resourceMgr.vcxproj
@@ -54,7 +54,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions);DEBUG</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\sysapi\include;..\include;..\common</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\sysapi\include;..\include;..\common;.</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -99,6 +99,7 @@
     <ClInclude Include="..\sysapi\include\tss2_tcti_util.h" />
     <ClInclude Include="..\sysapi\include\tss2_tpm2_types.h" />
     <ClInclude Include="..\tcti\commonchecks.h" />
+    <ClInclude Include="criticalsection.h" />
     <ClInclude Include="resourcemgr.h" />
   </ItemGroup>
   <ItemGroup>
@@ -109,6 +110,7 @@
     <ClCompile Include="..\tcti\commonchecks.c" />
     <ClCompile Include="..\tcti\platformcommand.c" />
     <ClCompile Include="..\tcti\tcti_socket.cpp" />
+    <ClCompile Include="criticalsection_windows.c" />
     <ClCompile Include="resourcemgr.c" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
…ce manager dies.

This required adding a couple critical sections to the RM and platformcommand.c.

The current test case for this is in TestEvict() when we tear down the other
TCTI context, line #2526 of tpmclient.cpp.

Addition of the critical sections should also fix the case where multiple
connections are trying to access the TPM at the same time.   We don't yet have
a test case for that, which is issue #133.