### PR TITLE
Clean up library flags & add export maps for TCTIs.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -60,7 +60,7 @@ resourcemgr_resourcemgr_SOURCES  = $(RESOURCEMGR_C) $(TCTISOCKET_C) \
     common/sockets.cpp
 
 sysapi_libtss2_la_CFLAGS  = -I$(srcdir)/include -I$(srcdir)/sysapi/include
-sysapi_libtss2_la_LDFLAGS = $(LIBRARY_LDFLAGS)
+sysapi_libtss2_la_LDFLAGS = $(LIBRARY_LDFLAGS) -Wl,--no-undefined
 sysapi_libtss2_la_SOURCES = $(SYSAPI_C) $(SYSAPIUTIL_C)
 
 tcti_libtctidevice_la_CFLAGS   = $(TCTIDEVICE_INC)

--- a/Makefile.am
+++ b/Makefile.am
@@ -60,14 +60,17 @@ resourcemgr_resourcemgr_SOURCES  = $(RESOURCEMGR_C) $(TCTISOCKET_C) \
     common/sockets.cpp
 
 sysapi_libtss2_la_CFLAGS  = -I$(srcdir)/include -I$(srcdir)/sysapi/include
+sysapi_libtss2_la_LDFLAGS = $(LIBRARY_LDFLAGS)
 sysapi_libtss2_la_SOURCES = $(SYSAPI_C) $(SYSAPIUTIL_C)
 
 tcti_libtctidevice_la_CFLAGS   = $(TCTIDEVICE_INC)
+tcti_libtctidevice_la_LDFLAGS  = $(LIBRARY_LDFLAGS)
 tcti_libtctidevice_la_SOURCES  = common/debug.c $(TCTIDEVICE_C) \
     sysapi/sysapi_util/changeEndian.c $(TCTICOMMON_C)
 
 tcti_libtctisocket_la_CFLAGS   = -DSAPI_CLIENT $(TCTISOCKET_INC)
 tcti_libtctisocket_la_CXXFLAGS = -DSAPI_CLIENT $(TCTISOCKET_INC)
+tcti_libtctisocket_la_LDFLAGS  = $(LIBRARY_LDFLAGS)
 tcti_libtctisocket_la_SOURCES  =  common/debug.c $(TCTISOCKET_C) \
     sysapi/sysapi_util/changeEndian.c $(TCTISOCKET_CXX) $(TCTICOMMON_C) \
     common/sockets.cpp
@@ -81,6 +84,8 @@ test_tpmtest_tpmtest_CFLAGS   = -DSAPI_CLIENT $(TPMTEST_INC)
 test_tpmtest_tpmtest_CXXFLAGS = -DSAPI_CLIENT $(TPMTEST_INC)
 test_tpmtest_tpmtest_LDADD    = $(libtss2) $(libtctisocket) $(libtctidevice)
 test_tpmtest_tpmtest_SOURCES  = $(TPMTEST_CXX) $(COMMON_C) $(SAMPLE_C)
+
+LIBRARY_LDFLAGS = -fPIC
 
 # simple variables
 RESOURCEMGR_INC = -I$(srcdir)/include -I$(srcdir)/common \

--- a/Makefile.am
+++ b/Makefile.am
@@ -64,13 +64,15 @@ sysapi_libtss2_la_LDFLAGS = $(LIBRARY_LDFLAGS)
 sysapi_libtss2_la_SOURCES = $(SYSAPI_C) $(SYSAPIUTIL_C)
 
 tcti_libtctidevice_la_CFLAGS   = $(TCTIDEVICE_INC)
-tcti_libtctidevice_la_LDFLAGS  = $(LIBRARY_LDFLAGS)
+tcti_libtctidevice_la_LDFLAGS  = $(LIBRARY_LDFLAGS) \
+    -Wl,--version-script=$(srcdir)/tcti/tcti_device.map
 tcti_libtctidevice_la_SOURCES  = common/debug.c $(TCTIDEVICE_C) \
     sysapi/sysapi_util/changeEndian.c $(TCTICOMMON_C)
 
 tcti_libtctisocket_la_CFLAGS   = -DSAPI_CLIENT $(TCTISOCKET_INC)
 tcti_libtctisocket_la_CXXFLAGS = -DSAPI_CLIENT $(TCTISOCKET_INC)
-tcti_libtctisocket_la_LDFLAGS  = $(LIBRARY_LDFLAGS)
+tcti_libtctisocket_la_LDFLAGS  = $(LIBRARY_LDFLAGS) \
+    -Wl,--version-script=$(srcdir)/tcti/tcti_socket.map
 tcti_libtctisocket_la_SOURCES  =  common/debug.c $(TCTISOCKET_C) \
     sysapi/sysapi_util/changeEndian.c $(TCTISOCKET_CXX) $(TCTICOMMON_C) \
     common/sockets.cpp

--- a/Makefile.am
+++ b/Makefile.am
@@ -63,7 +63,6 @@ sysapi_libtss2_la_CFLAGS  = -I$(srcdir)/include -I$(srcdir)/sysapi/include
 sysapi_libtss2_la_SOURCES = $(SYSAPI_C) $(SYSAPIUTIL_C)
 
 tcti_libtctidevice_la_CFLAGS   = $(TCTIDEVICE_INC)
-tcti_libtctidevice_la_LDFLAGS  = -no-undefined
 tcti_libtctidevice_la_SOURCES  = common/debug.c $(TCTIDEVICE_C) \
     sysapi/sysapi_util/changeEndian.c $(TCTICOMMON_C)
 

--- a/tcti/tcti_device.map
+++ b/tcti/tcti_device.map
@@ -1,0 +1,6 @@
+{
+    global:
+        InitDeviceTcti;
+    local:
+        *;
+};

--- a/tcti/tcti_socket.map
+++ b/tcti/tcti_socket.map
@@ -1,0 +1,8 @@
+{
+    global:
+        InitSocketTcti;
+        PlatformCommand;
+        TeardownSocketTcti;
+    local:
+        *;
+};


### PR DESCRIPTION
This codifies the fix for #105 and is a mechanism for keeping it from happening again. We need to do the same for libtss2.so but that's still a ways off.