### PR TITLE
tpmtest: fix one more place needing initializing TPM2B size

### DIFF
--- a/test/tpmtest/tpmtest.cpp
+++ b/test/tpmtest/tpmtest.cpp
@@ -522,6 +522,7 @@ TSS2_RC StartPolicySession( TPMI_SH_AUTH_SESSION *sessionHandle )
 
     salt.t.size = 0;
     symmetric.algorithm = TPM_ALG_NULL;
+    nonceTpm.t.size = sizeof(nonceTpm) - 2;
 
     // Create policy session
     rval = Tss2_Sys_StartAuthSession ( sysContext, TPM_RH_NULL, TPM_RH_NULL, 0, &nonceCaller, &salt,


### PR DESCRIPTION
I found we have new macro to do the TPM2B structure initialization. I would like to make this fix in first, then I will do the macro replacement later.