### PR TITLE
tpmtest: fix simple TPM2B initialization issues

### DIFF
--- a/test/common/sample/DecryptEncrypt.c
+++ b/test/common/sample/DecryptEncrypt.c
@@ -56,7 +56,7 @@ TSS2_RC GenerateSessionEncryptDecryptKey( SESSION *session, TPM2B_MAX_BUFFER *cf
     
     if( rval == TSS2_RC_SUCCESS )
     {
-        key.t.size = sizeof( key ) - 2;
+        INIT_SIMPLE_TPM2B_SIZE( key );
         rval = KDFa( session->authHash, &( sessionValue.b ), "CFB", &( session->nonceNewer.b ),
                 &( session->nonceOlder.b ), session->symmetric.keyBits.sym + blockSize, &key );
         if( rval == TSS2_RC_SUCCESS )

--- a/test/common/sample/SessionHmac.c
+++ b/test/common/sample/SessionHmac.c
@@ -71,7 +71,7 @@ UINT32 TpmComputeSessionHmac(
         return rval;
     }
 
-    pHash.t.size = sizeof( TPM2B_DIGEST ) - 2;
+    INIT_SIMPLE_TPM2B_SIZE( pHash );
     rval = ( *CalcPHash )( sysContext, handle1, handle2, pSession->authHash,
             responseCode, &pHash );
     if( rval != TPM_RC_SUCCESS )

--- a/test/tpmclient/tpmclient.cpp
+++ b/test/tpmclient/tpmclient.cpp
@@ -2019,6 +2019,7 @@ void TestNV()
     sessionsData.cmdAuthsCount = 1;
     sessionsData.cmdAuths[0] = &sessionData;
 
+    INIT_SIMPLE_TPM2B_SIZE( nvData );
     rval = Tss2_Sys_NV_Read( sysContext, TPM_RH_PLATFORM, TPM20_INDEX_TEST1, &sessionsData, 32, 0, &nvData, &sessionsDataOut ); 
     CheckFailed( rval, TPM_RC_2 + TPM_RC_HANDLE );
 
@@ -2372,6 +2373,8 @@ void TestCreate(){
     // Do SAPI test for non-zero sized outPublic
     outPublic.t.size = 0xff;
     creationData.t.size = 0;
+    INIT_SIMPLE_TPM2B_SIZE( creationHash );
+    INIT_SIMPLE_TPM2B_SIZE( name );
     rval = Tss2_Sys_CreatePrimary( sysContext, TPM_RH_PLATFORM, &sessionsData, &inSensitive, &inPublic,
             &outsideInfo, &creationPCR, &handle2048rsa, &outPublic, &creationData, &creationHash,
             &creationTicket, &name, &sessionsDataOut );
@@ -2382,6 +2385,8 @@ void TestCreate(){
     
     outPublic.t.size = 0;
     INIT_SIMPLE_TPM2B_SIZE( creationData );
+    INIT_SIMPLE_TPM2B_SIZE( creationHash );
+    INIT_SIMPLE_TPM2B_SIZE( name );
     rval = Tss2_Sys_CreatePrimary( sysContext, TPM_RH_PLATFORM, &sessionsData, &inSensitive, &inPublic,
             &outsideInfo, &creationPCR, &handle2048rsa, &outPublic, &creationData, &creationHash,
             &creationTicket, &name, &sessionsDataOut );
@@ -2392,6 +2397,8 @@ void TestCreate(){
     
     outPublic.t.size = 0;
     creationData.t.size = 0;
+    INIT_SIMPLE_TPM2B_SIZE( creationHash );
+    INIT_SIMPLE_TPM2B_SIZE( name );
     rval = Tss2_Sys_CreatePrimary( sysContext, TPM_RH_PLATFORM, &sessionsData, &inSensitive, &inPublic,
             &outsideInfo, &creationPCR, &handle2048rsa, &outPublic, &creationData, &creationHash,
             &creationTicket, &name, &sessionsDataOut );
@@ -2416,6 +2423,7 @@ void TestCreate(){
     outsideInfo.t.size = 0;
     outPublic.t.size = 0;
     creationData.t.size = 0;
+    INIT_SIMPLE_TPM2B_SIZE( outPrivate );
     INIT_SIMPLE_TPM2B_SIZE( creationHash );
     rval = Tss2_Sys_Create( sysContext, handle2048rsa, &sessionsData, &inSensitive, &inPublic,
             &outsideInfo, &creationPCR,
@@ -3031,6 +3039,7 @@ TPM_RC PasswordUnseal( TSS2_SYS_CONTEXT *sysContext, SESSION *policySession )
     
     // Now try to unseal the blob after setting the password.
     // This test should pass.
+    INIT_SIMPLE_TPM2B_SIZE( outData );
     cmdAuth.hmac.t.size = sizeof( passwordPCRTestPassword );
     memcpy( &cmdAuth.hmac.t.buffer, passwordPCRTestPassword, sizeof( passwordPCRTestPassword ) );
     rval = Tss2_Sys_Unseal( sysContext, blobHandle, &cmdAuthArray, &outData, 0 );
@@ -7074,6 +7083,8 @@ void TestCreate1()
     // Do SAPI test for non-zero sized outPublic
     outPublic.t.size = 0xff;
     creationData.t.size = 0;
+    INIT_SIMPLE_TPM2B_SIZE( creationHash );
+    INIT_SIMPLE_TPM2B_SIZE( name );
     rval = Tss2_Sys_CreatePrimary( sysContext, TPM_RH_OWNER, &sessionsData, &inSensitive, &inPublic,
             &outsideInfo, &creationPCR, &handle2048rsa, &outPublic, &creationData, &creationHash,
             &creationTicket, &name, &sessionsDataOut );
@@ -7081,6 +7092,8 @@ void TestCreate1()
 
     outPublic.t.size = 0;
     creationData.t.size = 0;
+    INIT_SIMPLE_TPM2B_SIZE( creationHash );
+    INIT_SIMPLE_TPM2B_SIZE( name );
     rval = Tss2_Sys_CreatePrimary( sysContext, TPM_RH_OWNER, &sessionsData, &inSensitive, &inPublic,
             &outsideInfo, &creationPCR, &handle2048rsa, &outPublic, &creationData, &creationHash,
             &creationTicket, &name, &sessionsDataOut );

--- a/test/tpmtest/tpmtest.cpp
+++ b/test/tpmtest/tpmtest.cpp
@@ -525,7 +525,7 @@ TSS2_RC StartPolicySession( TPMI_SH_AUTH_SESSION *sessionHandle )
 
     salt.t.size = 0;
     symmetric.algorithm = TPM_ALG_NULL;
-    nonceTpm.t.size = sizeof(nonceTpm) - 2;
+    INIT_SIMPLE_TPM2B_SIZE( nonceTpm );
 
     // Create policy session
     rval = Tss2_Sys_StartAuthSession ( sysContext, TPM_RH_NULL, TPM_RH_NULL, 0, &nonceCaller, &salt,
@@ -1326,11 +1326,11 @@ void TestGetRandom()
 
     printf( "\nGET_RANDOM TESTS:\n" );
 
-    randomBytes1.t.size = sizeof( randomBytes1 ) - 2;
+    INIT_SIMPLE_TPM2B_SIZE( randomBytes1 );
     rval = Tss2_Sys_GetRandom( sysContext, 0, 20, &randomBytes1, 0 );
     CheckPassed( rval );
 
-    randomBytes2.t.size = sizeof( randomBytes2 ) - 2;
+    INIT_SIMPLE_TPM2B_SIZE( randomBytes2 );
     rval = Tss2_Sys_GetRandom( sysContext, 0, 20, &randomBytes2, 0 );
     CheckPassed( rval );
 
@@ -1593,7 +1593,7 @@ void TestNV()
     sessionsData.cmdAuthsCount = 1;
     sessionsData.cmdAuths[0] = &sessionData;
 
-    nvData.t.size = sizeof( nvData ) - 2;
+    INIT_SIMPLE_TPM2B_SIZE( nvData );
     rval = Tss2_Sys_NV_Read( sysContext, TPM_RH_PLATFORM, TPM20_INDEX_TEST1, &sessionsData, 32, 0, &nvData, &sessionsDataOut );
     CheckFailed( rval, TPM_RC_2 + TPM_RC_HANDLE );
 
@@ -1601,11 +1601,11 @@ void TestNV()
     CheckPassed( rval );
 
     nvPublic.t.size = 0;
-    nvName.t.size = sizeof( nvName ) - 2;
+    INIT_SIMPLE_TPM2B_SIZE( nvName );
     rval = Tss2_Sys_NV_ReadPublic( sysContext, TPM20_INDEX_TEST1, 0, &nvPublic, &nvName, 0 );
     CheckPassed( rval );
 
-    nvData.t.size = sizeof( nvData ) - 2;
+    INIT_SIMPLE_TPM2B_SIZE( nvData );
     rval = Tss2_Sys_NV_Read( sysContext, TPM_RH_PLATFORM, TPM20_INDEX_TEST1, &sessionsData, 32, 0, &nvData, &sessionsDataOut );
     CheckFailed( rval, TPM_RC_NV_UNINITIALIZED );
 
@@ -1636,7 +1636,7 @@ void TestNV()
     rval = Tss2_Sys_NV_Write( sysContext, TPM_RH_PLATFORM, TPM20_INDEX_TEST1, &sessionsData, &nvWriteData, 0, &sessionsDataOut );
     CheckPassed( rval );
 
-    nvData.t.size = sizeof( nvData ) - 2;
+    INIT_SIMPLE_TPM2B_SIZE( nvData );
     rval = Tss2_Sys_NV_Read( sysContext, TPM_RH_PLATFORM, TPM20_INDEX_TEST1, &sessionsData, 32, 0, &nvData, &sessionsDataOut );
     CheckPassed( rval );
 
@@ -1672,11 +1672,11 @@ void TestNV()
     CheckPassed( rval );
 
     nvPublic.t.size = 0;
-    nvName.t.size = sizeof( nvName ) - 2;
+    INIT_SIMPLE_TPM2B_SIZE( nvName );
     rval = Tss2_Sys_NV_ReadPublic( sysContext, TPM20_INDEX_TEST2, 0, &nvPublic, &nvName, 0 );
     CheckPassed( rval );
 
-    nvData.t.size = sizeof( nvData ) - 2;
+    INIT_SIMPLE_TPM2B_SIZE( nvData );
     rval = Tss2_Sys_NV_Read( sysContext, TPM_RH_PLATFORM, TPM20_INDEX_TEST2, &sessionsData, 32, 0, &nvData, 0 );
     if (tpmType != TPM_TYPE_PTT)
         CheckFailed( rval, TPM_RC_NV_AUTHORIZATION );
@@ -1835,7 +1835,7 @@ void TestHierarchyControl()
     CheckFailed( rval, TSS2_SYS_RC_BAD_VALUE );
 
     nvPublic.t.size = 0;
-    nvName.t.size = sizeof( nvName ) - 2;
+    INIT_SIMPLE_TPM2B_SIZE( nvName );
     rval = Tss2_Sys_NV_ReadPublic( sysContext, TPM20_INDEX_TEST1, 0, &nvPublic, &nvName, 0 );
     CheckPassed( rval );
 
@@ -2045,8 +2045,8 @@ void TPM2Create()
     outsideInfo.t.size = 0;
     outPublic.t.size = 0;
     creationData.t.size = 0;
-    outPrivate.t.size = sizeof( outPrivate ) - 2;
-    creationHash.t.size = sizeof( creationHash ) -2;
+    INIT_SIMPLE_TPM2B_SIZE( outPrivate );
+    INIT_SIMPLE_TPM2B_SIZE( creationHash );
     rval = Tss2_Sys_Create( sysContext, handle2048rsa, &sessionsData, &inSensitive, &inPublic,
             &outsideInfo, &creationPCR,
             &outPrivate, &outPublic, &creationData,
@@ -2097,21 +2097,21 @@ void TPM2Load()
 void TestCreate()
 {
     UINT32 rval;
-    TPM2B_SENSITIVE_CREATE  inSensitive = { { sizeof( TPM2B_SENSITIVE_CREATE ) - 2, } };
-    TPM2B_PUBLIC            inPublic = { { sizeof( TPM2B_PUBLIC ) - 2, } };
-    TPM2B_DATA              outsideInfo = { { sizeof( TPM2B_DATA ) - 2, } };
+    TPM2B_SENSITIVE_CREATE  inSensitive;
+    TPM2B_PUBLIC            inPublic;
+    TPM2B_DATA              outsideInfo;
     TPML_PCR_SELECTION      creationPCR;
     TPMS_AUTH_COMMAND sessionData;
     TPMS_AUTH_RESPONSE sessionDataOut;
     TSS2_SYS_CMD_AUTHS sessionsData;
 
     TSS2_SYS_RSP_AUTHS sessionsDataOut;
-    TPM2B_NAME name = { { sizeof( TPM2B_NAME ) - 2, } };
-    TPM2B_NAME name1 = { { sizeof( TPM2B_NAME ) - 2, } };
-    TPM2B_PRIVATE outPrivate = { { sizeof( TPM2B_PRIVATE ) - 2, } };
-    TPM2B_PUBLIC outPublic = { { sizeof( TPM2B_PUBLIC ) - 2, } };
-    TPM2B_CREATION_DATA creationData =  { { sizeof( TPM2B_CREATION_DATA ) - 2, } };
-    TPM2B_DIGEST creationHash = { { sizeof( TPM2B_DIGEST ) - 2, } };
+    TPM2B_NAME name;
+    TPM2B_NAME name1;
+    TPM2B_PRIVATE outPrivate;
+    TPM2B_PUBLIC outPublic;
+    TPM2B_CREATION_DATA creationData;
+    TPM2B_DIGEST creationHash;
     TPMT_TK_CREATION creationTicket = { 0, 0, { { sizeof( TPM2B_DIGEST ) - 2, } } };
 
     TPMS_AUTH_COMMAND *sessionDataArray[1];
@@ -2177,6 +2177,8 @@ void TestCreate()
     // Do SAPI test for non-zero sized outPublic
     outPublic.t.size = 0xff;
     creationData.t.size = 0;
+    INIT_SIMPLE_TPM2B_SIZE( creationHash );
+    INIT_SIMPLE_TPM2B_SIZE( name );
     rval = Tss2_Sys_CreatePrimary( sysContext, TPM_RH_NULL, &sessionsData, &inSensitive, &inPublic,
             &outsideInfo, &creationPCR, &handle2048rsa, &outPublic, &creationData, &creationHash,
             &creationTicket, &name, &sessionsDataOut );
@@ -2218,8 +2220,8 @@ void TestCreate()
     outsideInfo.t.size = 0;
     outPublic.t.size = 0;
     creationData.t.size = 0;
-    outPrivate.t.size = sizeof( outPrivate ) - 2;
-    creationHash.t.size = sizeof( creationHash ) -2;
+    INIT_SIMPLE_TPM2B_SIZE( outPrivate );
+    INIT_SIMPLE_TPM2B_SIZE( creationHash );
     rval = Tss2_Sys_Create( sysContext, handle2048rsa, &sessionsData, &inSensitive, &inPublic,
             &outsideInfo, &creationPCR,
             &outPrivate, &outPublic, &creationData,
@@ -2230,6 +2232,7 @@ void TestCreate()
             &loadedSha1KeyHandle, &name, &sessionsDataOut);
     CheckPassed( rval );
 
+    INIT_SIMPLE_TPM2B_SIZE( name1 );
     rval = (*HandleToNameFunctionPtr)( loadedSha1KeyHandle, &name1 );
     CheckPassed( rval );
     printf( "Name of loaded key: " );
@@ -2562,8 +2565,8 @@ TPM_RC CreateDataBlob( TSS2_SYS_CONTEXT *sysContext, SESSION **policySession, TP
 
     outPublic.t.size = 0;
     creationData.t.size = 0;
-    srkName.t.size = sizeof( srkName ) - 2;
-    creationHash.t.size = sizeof( creationHash ) -2;
+    INIT_SIMPLE_TPM2B_SIZE( srkName );
+    INIT_SIMPLE_TPM2B_SIZE( creationHash );
     rval = Tss2_Sys_CreatePrimary( sysContext, TPM_RH_OWNER, &cmdAuthArray,
             &inSensitive, &inPublic, &outsideInfo, &creationPcr,
             &srkHandle, &outPublic, &creationData, &creationHash,
@@ -2592,8 +2595,8 @@ TPM_RC CreateDataBlob( TSS2_SYS_CONTEXT *sysContext, SESSION **policySession, TP
     outsideInfo.t.size = 0;
     outPublic.t.size = 0;
     creationData.t.size = 0;
-    outPrivate.t.size = sizeof( outPrivate ) - 2;
-    creationHash.t.size = sizeof( creationHash ) -2;
+    INIT_SIMPLE_TPM2B_SIZE( outPrivate );
+    INIT_SIMPLE_TPM2B_SIZE( creationHash );
     rval = Tss2_Sys_Create( sysContext, srkHandle, &cmdAuthArray,
             &inSensitive, &inPublic, &outsideInfo, &creationPcr,
             &outPrivate, &outPublic, &creationData, &creationHash,
@@ -2601,7 +2604,7 @@ TPM_RC CreateDataBlob( TSS2_SYS_CONTEXT *sysContext, SESSION **policySession, TP
     CheckPassed( rval );
 
     // Now we need to load the object.
-    blobName.t.size = sizeof( blobName ) - 2;
+    INIT_SIMPLE_TPM2B_SIZE( blobName );
     rval = Tss2_Sys_Load( sysContext, srkHandle, &cmdAuthArray, &outPrivate, &outPublic, &blobHandle, &blobName, 0 );
     CheckPassed( rval );
 
@@ -2624,7 +2627,7 @@ TPM_RC AuthValueUnseal( TSS2_SYS_CONTEXT *sysContext, SESSION *policySession )
 
     // Now try to unseal the blob without setting the HMAC.
     // This test should fail.
-    outData.t.size = sizeof( outData ) - 2;
+    INIT_SIMPLE_TPM2B_SIZE( outData );
     rval = Tss2_Sys_Unseal( sysContext, blobHandle, &cmdAuthArray, &outData, 0 );
     CheckFailed( rval, TPM_RC_S + TPM_RC_1 + TPM_RC_AUTH_FAIL );
 
@@ -2651,7 +2654,7 @@ TPM_RC AuthValueUnseal( TSS2_SYS_CONTEXT *sysContext, SESSION *policySession )
             TPM_HT_NO_HANDLE, &cmdAuthArray, 1 );
     CheckPassed( rval );
 
-    outData.t.size = sizeof( outData ) - 2;
+    INIT_SIMPLE_TPM2B_SIZE( outData );
     rval = Tss2_Sys_Unseal( sysContext, blobHandle, &cmdAuthArray, &outData, 0 );
     CheckPassed( rval );
 
@@ -2684,7 +2687,7 @@ TPM_RC PasswordUnseal( TSS2_SYS_CONTEXT *sysContext, SESSION *policySession )
 
     // Now try to unseal the blob without setting the password.
     // This test should fail.
-    outData.t.size = sizeof( outData ) - 2;
+    INIT_SIMPLE_TPM2B_SIZE( outData );
     rval = Tss2_Sys_Unseal( sysContext, blobHandle, &cmdAuthArray, &outData, 0 );
     CheckFailed( rval, TPM_RC_S + TPM_RC_1 + TPM_RC_AUTH_FAIL );
 
@@ -2693,7 +2696,7 @@ TPM_RC PasswordUnseal( TSS2_SYS_CONTEXT *sysContext, SESSION *policySession )
 
     // Now try to unseal the blob after setting the password.
     // This test should pass.
-    outData.t.size = sizeof( outData ) - 2;
+    INIT_SIMPLE_TPM2B_SIZE( outData );
     cmdAuth.hmac.t.size = sizeof( passwordPCRTestPassword );
     memcpy( &cmdAuth.hmac.t.buffer, passwordPCRTestPassword, sizeof( passwordPCRTestPassword ) );
     rval = Tss2_Sys_Unseal( sysContext, blobHandle, &cmdAuthArray, &outData, 0 );
@@ -2737,7 +2740,7 @@ void TestPolicy()
     for( i = 0; i < num; i++ )
     {
         TPM2B_DIGEST policyDigest;
-        policyDigest.t.size = sizeof( policyDigest ) - 2;
+        INIT_SIMPLE_TPM2B_SIZE( policyDigest );
         rval = TPM_RC_SUCCESS;
 
         printf( "Policy Test: %s\n", policyTestSetups[i].name );
@@ -2924,7 +2927,7 @@ void TestHash()
     dataToHash.t.size = 0;
     for( i = 1; i < 5; i++ )
     {
-        result.t.size = sizeof( result ) - 2;
+        INIT_SIMPLE_TPM2B_SIZE( result );
         rval = Tss2_Sys_SequenceComplete ( sysContext, sequenceHandle[i], &sessionsData, &dataToHash,
                 TPM_RH_PLATFORM, &result, &validation, &sessionsDataOut );
         CheckPassed( rval );
@@ -3028,7 +3031,7 @@ void TestQuote()
     sessionsData.cmdAuths[0] = &sessionData;
 
     // Test with wrong type of key.
-    quoted.t.size = sizeof( quoted ) - 2;
+    INIT_SIMPLE_TPM2B_SIZE( quoted );
     rval = Tss2_Sys_Quote ( sysContext, loadedSha1KeyHandle, &sessionsData, &qualifyingData, &inScheme,
             &pcrSelection,  &quoted, &signature, &sessionsDataOut );
     CheckPassed( rval );
@@ -3195,7 +3198,7 @@ void ProvisionNvAux()
     CheckPassed( rval );
 
     // 3.  GetPolicyDigest and save it
-    nvPolicyHash.t.size = sizeof( nvPolicyHash ) - 2;
+    INIT_SIMPLE_TPM2B_SIZE( nvPolicyHash );
     rval = Tss2_Sys_PolicyGetDigest( sysContext, nvAuxPolicyAuthHandle, 0, &nvPolicyHash, 0 );
     CheckPassed( rval );
 
@@ -3360,11 +3363,11 @@ void TpmOtherIndicesReadWriteTest()
     rval = Tss2_Sys_NV_Write( sysContext, INDEX_LCP_OWN, INDEX_LCP_OWN, &nullSessionsData, &nvWriteData, 0, &nullSessionsDataOut );
     CheckPassed( rval );
 
-    nvData.t.size = sizeof( nvData ) - 2;
+    INIT_SIMPLE_TPM2B_SIZE( nvData );
     rval = Tss2_Sys_NV_Read( sysContext, INDEX_LCP_SUP, INDEX_LCP_SUP, &nullSessionsData, 4, 0, &nvData, &nullSessionsDataOut );
     CheckPassed( rval );
 
-    nvData.t.size = sizeof( nvData ) - 2;
+    INIT_SIMPLE_TPM2B_SIZE( nvData );
     rval = Tss2_Sys_NV_Read( sysContext, INDEX_LCP_OWN, INDEX_LCP_OWN, &nullSessionsData, 4, 0, &nvData, &nullSessionsDataOut );
     CheckPassed( rval );
 }
@@ -3659,15 +3662,15 @@ void TestUnseal()
     outPublic.t.size = 0;
     creationData.t.size = 0;
     outsideInfo.t.size = 0;
-    outPrivate.t.size = sizeof( outPrivate ) - 2;
-    creationHash.t.size = sizeof( creationHash ) -2;
+    INIT_SIMPLE_TPM2B_SIZE( outPrivate );
+    INIT_SIMPLE_TPM2B_SIZE( creationHash );
     rval = Tss2_Sys_Create( sysContext, handle2048rsa, &sessionsData, &inSensitive, &inPublic,
             &outsideInfo, &creationPCR,
             &outPrivate, &outPublic, &creationData,
             &creationHash, &creationTicket, &sessionsDataOut );
     CheckPassed( rval );
 
-    name.t.size = sizeof( name ) - 2;
+    INIT_SIMPLE_TPM2B_SIZE( name );
     rval = Tss2_Sys_LoadExternal ( sysContext, 0, 0, &outPublic,
             TPM_RH_OWNER, &loadedObjectHandle, &name, 0 );
     CheckPassed( rval );
@@ -3675,7 +3678,7 @@ void TestUnseal()
     rval = Tss2_Sys_FlushContext( sysContext, loadedObjectHandle );
     CheckPassed( rval );
 
-    name.t.size = sizeof( name ) - 2;
+    INIT_SIMPLE_TPM2B_SIZE( name );
     rval = Tss2_Sys_Load ( sysContext, handle2048rsa, &sessionsData, &outPrivate, &outPublic,
             &loadedObjectHandle, &name, &sessionsDataOut);
     CheckPassed( rval );
@@ -3683,7 +3686,7 @@ void TestUnseal()
     sessionData.hmac.t.size = sizeof( authStr ) - 1;
     memcpy( &( sessionData.hmac.t.buffer[0] ), authStr, sizeof( authStr ) - 1 );
 
-    outData.t.size = sizeof( outData ) - 2;
+    INIT_SIMPLE_TPM2B_SIZE( outData );
     rval = Tss2_Sys_Unseal( sysContext, loadedObjectHandle, &sessionsData, &outData, &sessionsDataOut );
 
     rval = Tss2_Sys_FlushContext( sysContext, loadedObjectHandle );
@@ -4440,7 +4443,7 @@ void SimpleHmacOrPolicyTest( bool hmacTest )
         CheckPassed( rval );
 
         // Get policy digest.
-        authPolicy.t.size = sizeof( authPolicy ) - 2;
+        INIT_SIMPLE_TPM2B_SIZE( authPolicy );
         rval = Tss2_Sys_PolicyGetDigest( simpleTestContext,
                 trialPolicySession->sessionHandle,
                 0, &authPolicy, 0 );
@@ -4802,7 +4805,7 @@ void HmacSessionTest()
                     label.t.size = strlen( "SECRET" ) + 1;
 
                     // Encrypt salt with tpmKey.
-                    encryptedSalt.t.size = sizeof( encryptedSalt ) - 2;
+                    INIT_SIMPLE_TPM2B_SIZE( encryptedSalt );
                     rval = Tss2_Sys_RSA_Encrypt( sysContext, handle2048rsa,
                             0, (TPM2B_PUBLIC_KEY_RSA *)( hmacTestSetups[j].salt ),
                             &inScheme, &label, (TPM2B_PUBLIC_KEY_RSA *)&encryptedSalt, 0 );
@@ -4979,7 +4982,7 @@ void HmacSessionTest()
                 }
                 sessionsData.cmdAuths[0]->sessionAttributes.decrypt = 0;
 
-                nvData.t.size = sizeof( nvData ) - 2;
+                INIT_SIMPLE_TPM2B_SIZE( nvData );
                 sessionCmdRval = Tss2_Sys_NV_Read( rdSysContext, TPM20_INDEX_PASSWORD_TEST,
                         TPM20_INDEX_PASSWORD_TEST, &sessionsData, sizeof( dataToWrite ), 0, &nvData, &sessionsDataOut );
                 CheckPassed( sessionCmdRval );
@@ -5087,7 +5090,7 @@ void HmacSessionTest()
                             TPM20_INDEX_PASSWORD_TEST, &sessionsData, sessionCmdRval );
                     CheckPassed( rval );
 
-                    nvData.t.size = sizeof( nvData ) - 2;
+                    INIT_SIMPLE_TPM2B_SIZE( nvData );
                     sessionCmdRval = Tss2_Sys_NV_Read( rdSysContext, TPM20_INDEX_PASSWORD_TEST,
                             TPM20_INDEX_PASSWORD_TEST, &sessionsData, sizeof( dataToWrite ), 0, &nvData, &sessionsDataOut );
                     sessionsData.cmdAuths[0]->sessionAttributes.encrypt = 0;
@@ -5346,7 +5349,7 @@ void TestEncryptDecryptSession()
         // Now read the data without encrypt set.
         nvRdWrCmdAuths.cmdAuthsCount = 1;
         nvRdWrRspAuths.rspAuthsCount = 1;
-        readData.t.size = sizeof( readData ) - 2;
+        INIT_SIMPLE_TPM2B_SIZE( readData );
         rval = Tss2_Sys_NV_Read( sysContext, TPM20_INDEX_TEST1,
                 TPM20_INDEX_TEST1, &nvRdWrCmdAuths,
                 sizeof( writeDataString ), 0, &readData,
@@ -5410,7 +5413,7 @@ void TestEncryptDecryptSession()
 
         // Decrypt read data.
         encryptedReadData.t.size = encryptParamSize;
-        decryptedReadData.t.size = sizeof( decryptedReadData ) - 2;
+        INIT_SIMPLE_TPM2B_SIZE( decryptedReadData );
         memcpy( (void *)&encryptedReadData.t.buffer[0],
                 (void *)encryptParamBuffer, encryptParamSize );
         rval = DecryptResponseParam( encryptDecryptSession,
@@ -5515,8 +5518,8 @@ void TestRsaEncryptDecrypt()
     outsideInfo.t.size = 0;
     outPublic.t.size = 0;
     creationData.t.size = 0;
-    outPrivate.t.size = sizeof( outPrivate ) - 2;
-    creationHash.t.size = sizeof( creationHash ) -2;
+    INIT_SIMPLE_TPM2B_SIZE( outPrivate );
+    INIT_SIMPLE_TPM2B_SIZE( creationHash );
     rval = Tss2_Sys_Create( sysContext, handle2048rsa, &sessionsData, &inSensitive, &inPublic,
             &outsideInfo, &creationPCR,
             &outPrivate, &outPublic, &creationData,
@@ -5770,7 +5773,7 @@ void GetSetEncryptParamTests()
     rval = Tss2_Sys_NV_Read_Prepare( sysContext, TPM20_INDEX_PASSWORD_TEST, TPM20_INDEX_PASSWORD_TEST, 4, 0 );
     CheckPassed( rval );
 
-    nvReadData.t.size = sizeof( nvReadData ) - 2;
+    INIT_SIMPLE_TPM2B_SIZE( nvReadData );
     rval = Tss2_Sys_NV_Read( sysContext, TPM20_INDEX_PASSWORD_TEST,
             TPM20_INDEX_PASSWORD_TEST, &sessionsData, 4, 0, &nvReadData, &sessionsDataOut );
     CheckPassed( rval );
@@ -5947,8 +5950,8 @@ void TestRM()
     // This one should fail, because a different context is trying to use the primary object.
     outPublic.t.size = 0;
     creationData.t.size = 0;
-    outPrivate.t.size = sizeof( outPrivate ) - 2;
-    creationHash.t.size = sizeof( creationHash ) -2;
+    INIT_SIMPLE_TPM2B_SIZE( outPrivate );
+    INIT_SIMPLE_TPM2B_SIZE( creationHash );
     rval = Tss2_Sys_Create( otherSysContext, handle2048rsa, &sessionsData, &inSensitive, &inPublic,
             &outsideInfo, &creationPCR,
             &outPrivate, &outPublic, &creationData,
@@ -6223,8 +6226,8 @@ void TestRM()
     // This one should fail, because a different context is trying to use the primary object.
     outPublic.t.size = 0;
     creationData.t.size = 0;
-    outPrivate.t.size = sizeof( outPrivate ) - 2;
-    creationHash.t.size = sizeof( creationHash ) -2;
+    INIT_SIMPLE_TPM2B_SIZE( outPrivate );
+    INIT_SIMPLE_TPM2B_SIZE( creationHash );
     rval = Tss2_Sys_Create( otherSysContext, handle2048rsa, &sessionsData, &inSensitive, &inPublic,
             &outsideInfo, &creationPCR,
             &outPrivate, &outPublic, &creationData,
@@ -6368,7 +6371,7 @@ void TestRM()
     // RM is getting correct hierarchy in it's table.
     // NOTE:  this test can only be verified by looking at RM output.
     //
-	outPublic.t.size = 0;
+    outPublic.t.size = 0;
     creationData.t.size = 0;
     rval = Tss2_Sys_CreatePrimary( sysContext, TPM_RH_ENDORSEMENT, &sessionsData, &inSensitive, &inPublic,
             &outsideInfo, &creationPCR, &newHandleDummy, &outPublic, &creationData, &creationHash,

--- a/test/tpmtest/tpmtest.cpp
+++ b/test/tpmtest/tpmtest.cpp
@@ -630,6 +630,7 @@ void TestSapiApis()
     CheckPassed(rval);
 
     // Get the command results
+    INIT_SIMPLE_TPM2B_SIZE( outData );
     rval = Tss2_Sys_GetTestResult_Complete( sysContext, &outData, &testResult );
     CheckPassed(rval);
 
@@ -649,6 +650,7 @@ void TestSapiApis()
     CheckPassed(rval);
 
     // Get the command results
+    INIT_SIMPLE_TPM2B_SIZE( outData );
     rval = Tss2_Sys_GetTestResult_Complete( sysContext, &outData, &testResult );
     CheckPassed(rval);
 
@@ -1710,6 +1712,7 @@ void TestNV()
     symmetric.algorithm = TPM_ALG_NULL;
     symmetric.keyBits.sym = 0;
     symmetric.mode.sym = 0;
+    INIT_SIMPLE_TPM2B_SIZE( nvSessionNonce );
     rval = Tss2_Sys_StartAuthSession ( sysContext, TPM_RH_NULL, TPM_RH_PLATFORM, 0, &nonceNewer, &salt,
             TPM_SE_TRIAL, &symmetric, TPM_ALG_SHA1, &nvSessionHandle, &nvSessionNonce );
     CheckPassed( rval );
@@ -1719,6 +1722,7 @@ void TestNV()
     rval = Tss2_Sys_PolicyCommandCode ( sysContext, nvSessionHandle, 0, TPM_CC_NV_UndefineSpaceSpecial, 0 );
     CheckPassed( rval );
 
+    INIT_SIMPLE_TPM2B_SIZE( nvAuth1 );
     rval = Tss2_Sys_PolicyGetDigest( sysContext, nvSessionHandle, 0, &nvAuth1, 0 );
     CheckPassed( rval );
 
@@ -1743,6 +1747,7 @@ void TestNV()
     rval = Tss2_Sys_NV_DefineSpace( sysContext, TPM_RH_PLATFORM, &sessionsData, &nvAuth, &publicInfo, &sessionsDataOut );
     CheckPassed( rval );
 
+    INIT_SIMPLE_TPM2B_SIZE( nvSessionNonce );
     rval = Tss2_Sys_StartAuthSession ( sysContext, TPM_RH_NULL, TPM_RH_PLATFORM, 0, &nonceCaller, &salt,
             TPM_SE_POLICY, &symmetric, TPM_ALG_SHA1, &nvSessionHandle, &nvSessionNonce );
     CheckPassed( rval );
@@ -1831,6 +1836,7 @@ void TestHierarchyControl()
 
     // Test SAPI for case where nvPublic.t.size != 0
     nvPublic.t.size = 0xff;
+    INIT_SIMPLE_TPM2B_SIZE( nvName );
     rval = Tss2_Sys_NV_ReadPublic( sysContext, TPM20_INDEX_TEST1, 0, &nvPublic, &nvName, 0 );
     CheckFailed( rval, TSS2_SYS_RC_BAD_VALUE );
 
@@ -2196,6 +2202,8 @@ void TestCreate()
 
     outPublic.t.size = 0;
     creationData.t.size = 0;
+    INIT_SIMPLE_TPM2B_SIZE( creationHash );
+    INIT_SIMPLE_TPM2B_SIZE( name );
     rval = Tss2_Sys_CreatePrimary( sysContext, TPM_RH_NULL, &sessionsData, &inSensitive, &inPublic,
             &outsideInfo, &creationPCR, &handle2048rsa, &outPublic, &creationData, &creationHash,
             &creationTicket, &name, &sessionsDataOut );
@@ -2228,6 +2236,7 @@ void TestCreate()
             &creationHash, &creationTicket, &sessionsDataOut );
     CheckPassed( rval );
 
+    INIT_SIMPLE_TPM2B_SIZE( name );
     rval = Tss2_Sys_Load ( sysContext, handle2048rsa, &sessionsData, &outPrivate, &outPublic,
             &loadedSha1KeyHandle, &name, &sessionsDataOut);
     CheckPassed( rval );
@@ -2313,6 +2322,7 @@ TPM_RC BuildPolicy( TSS2_SYS_CONTEXT *sysContext, SESSION **policySession,
     CheckPassed( rval );
 
     // Get policy hash.
+    INIT_SIMPLE_TPM2B_SIZE( *policyDigest );
     rval = Tss2_Sys_PolicyGetDigest( sysContext, (*policySession)->sessionHandle,
             0, policyDigest, 0 );
     CheckPassed( rval );
@@ -2361,6 +2371,7 @@ TPM_RC CreateNVIndex( TSS2_SYS_CONTEXT *sysContext, SESSION **policySession, TPM
     CheckPassed( rval );
 
     // Read policyHash
+    INIT_SIMPLE_TPM2B_SIZE( *policyDigest );
     rval = Tss2_Sys_PolicyGetDigest( sysContext,
             (*policySession)->sessionHandle, 0, policyDigest, 0 );
     CheckPassed( rval );
@@ -2509,6 +2520,7 @@ TPM_RC BuildPasswordPcrPolicy( TSS2_SYS_CONTEXT *sysContext, SESSION *policySess
     rval = Tss2_Sys_PCR_Read( sysContext, 0, &pcrs, &pcrUpdateCounter, &pcrSelectionOut, &pcrValues, 0 );
     CheckPassed( rval );
     // Hash them together
+    INIT_SIMPLE_TPM2B_SIZE( pcrDigest );
     rval = TpmHashSequence( policySession->authHash, pcrValues.count, &pcrValues.digests[0], &pcrDigest );
 
     rval = Tss2_Sys_PolicyPCR( sysContext, policySession->sessionHandle, 0, &pcrDigest, &pcrs, 0 );
@@ -2939,6 +2951,7 @@ void TestHash()
 
     dataToHash.t.size = sizeof( memoryToHash ) - MAX_DIGEST_BUFFER;
     memcpy( &dataToHash.t.buffer[0], &memoryToHash[MAX_DIGEST_BUFFER], dataToHash.t.size );
+    INIT_SIMPLE_TPM2B_SIZE( result );
     rval = Tss2_Sys_SequenceComplete ( sysContext, sequenceHandle[0], &sessionsData, &dataToHash,
             TPM_RH_PLATFORM, &result, &validation, &sessionsDataOut );
     CheckPassed( rval );
@@ -2963,6 +2976,7 @@ void TestHash()
     for( i = (MAX_TEST_SEQUENCES - 1); i >= 0; i-- )
 //    for( i = 0; i < MAX_TEST_SEQUENCES; i++ )
     {
+        INIT_SIMPLE_TPM2B_SIZE( result );
         rval = Tss2_Sys_SequenceComplete ( sysContext, sequenceHandle[i], &sessionsData, &dataToHash,
                 TPM_RH_PLATFORM, &result, &validation, &sessionsDataOut );
         CheckPassed( rval );
@@ -3331,6 +3345,7 @@ void TpmAuxReadWriteTest()
         rval = SetLocality( sysContext, testLocality );
         CheckPassed( rval );
 
+        INIT_SIMPLE_TPM2B_SIZE( nvData );
         rval = Tss2_Sys_NV_Read( sysContext, INDEX_AUX, INDEX_AUX, &nullSessionsData, 4, 0, &nvData, &nullSessionsDataOut );
         CheckPassed( rval );
 
@@ -3911,6 +3926,7 @@ void SimplePolicyTest()
     CheckPassed( rval );
 
     // Get policy digest.
+    INIT_SIMPLE_TPM2B_SIZE( authPolicy );
     rval = Tss2_Sys_PolicyGetDigest( sysContext, trialPolicySession->sessionHandle,
             0, &authPolicy, 0 );
     CheckPassed( rval );
@@ -3990,6 +4006,7 @@ void SimplePolicyTest()
     CheckPassed( rval );
 
     // Get policy digest.
+    INIT_SIMPLE_TPM2B_SIZE( authPolicy );
     rval = Tss2_Sys_PolicyGetDigest( sysContext, trialPolicySession->sessionHandle,
             0, &authPolicy, 0 );
     CheckPassed( rval );
@@ -4066,6 +4083,7 @@ void SimplePolicyTest()
     // And now read the data back.
     // If the command is successful, the command
     // HMAC was correct.
+    INIT_SIMPLE_TPM2B_SIZE( nvReadData );
     sessionCmdRval = Tss2_Sys_NV_Read( sysContext,
             TPM20_INDEX_PASSWORD_TEST,
             TPM20_INDEX_PASSWORD_TEST,
@@ -4293,6 +4311,7 @@ void SimpleHmacTest()
     // And now read the data back.
     // If the command is successful, the command
     // HMAC was correct.
+    INIT_SIMPLE_TPM2B_SIZE( nvReadData );
     sessionCmdRval = Tss2_Sys_NV_Read( sysContext,
             TPM20_INDEX_PASSWORD_TEST,
             TPM20_INDEX_PASSWORD_TEST,
@@ -4626,6 +4645,7 @@ void SimpleHmacOrPolicyTest( bool hmacTest )
     // And now read the data back.
     // If the command is successful, the command
     // HMAC was correct.
+    INIT_SIMPLE_TPM2B_SIZE( nvReadData );
     sessionCmdRval = Tss2_Sys_NV_Read( simpleTestContext,
             TPM20_INDEX_PASSWORD_TEST,
             TPM20_INDEX_PASSWORD_TEST,
@@ -5431,6 +5451,7 @@ void TestEncryptDecryptSession()
         CheckPassed( rval );
 
         // Get the command results, in this case the read data.
+        INIT_SIMPLE_TPM2B_SIZE( readData );
         rval = Tss2_Sys_NV_Read_Complete( sysContext, &readData );
         CheckPassed( rval );
 
@@ -5528,6 +5549,7 @@ void TestRsaEncryptDecrypt()
     CheckPassed( rval );
 
     // Load private key into TPM
+    INIT_SIMPLE_TPM2B_SIZE( rsaKeyName );
     rval = Tss2_Sys_Load ( sysContext, handle2048rsa, 0, &outPrivate, &outPublic,
             &loadedSha1KeyHandle, &rsaKeyName, &sessionsDataOut);
     CheckPassed( rval );
@@ -6354,6 +6376,8 @@ void TestRM()
 
     outPublic.t.size = 0;
     creationData.t.size = 0;
+    INIT_SIMPLE_TPM2B_SIZE( name );
+    INIT_SIMPLE_TPM2B_SIZE( creationHash );
     rval = Tss2_Sys_CreatePrimary_Complete( sysContext, &newHandle, &outPublic, &creationData,
             &creationHash, &creationTicket, &name );
     CheckPassed( rval );
@@ -6373,6 +6397,8 @@ void TestRM()
     //
     outPublic.t.size = 0;
     creationData.t.size = 0;
+    INIT_SIMPLE_TPM2B_SIZE( name );
+    INIT_SIMPLE_TPM2B_SIZE( creationHash );
     rval = Tss2_Sys_CreatePrimary( sysContext, TPM_RH_ENDORSEMENT, &sessionsData, &inSensitive, &inPublic,
             &outsideInfo, &creationPCR, &newHandleDummy, &outPublic, &creationData, &creationHash,
 			&creationTicket, &name, &sessionsDataOut );

--- a/test/tpmtest/tpmtest.cpp
+++ b/test/tpmtest/tpmtest.cpp
@@ -525,6 +525,7 @@ TSS2_RC StartPolicySession( TPMI_SH_AUTH_SESSION *sessionHandle )
 
     salt.t.size = 0;
     symmetric.algorithm = TPM_ALG_NULL;
+    nonceTpm.t.size = sizeof(nonceTpm) - 2;
 
     // Create policy session
     rval = Tss2_Sys_StartAuthSession ( sysContext, TPM_RH_NULL, TPM_RH_NULL, 0, &nonceCaller, &salt,


### PR DESCRIPTION
fixed one more bug, and updated to use INIT_SIMPLE_TPM2B_SIZE for the initialization.