### PR TITLE
Fixed bug with DEBUG_SOCKETS

### DIFF
--- a/common/debug.c
+++ b/common/debug.c
@@ -212,7 +212,17 @@ const char *commandCodeStrings[] =
     "TPM2_PolicyNvWritten" // 18f
 };
 
+char undefinedCommandString[10] = "";
+
 const char* strTpmCommandCode( TPM_CC code )
 {
-    return commandCodeStrings[ code - TPM_CC_FIRST ];
+    if( code >= TPM_CC_NV_UndefineSpaceSpecial && code <= TPM_CC_PolicyNvWritten )
+    {
+        return commandCodeStrings[ code - TPM_CC_FIRST ];
+    }
+    else
+    {
+        sprintf( &undefinedCommandString[0], "0x%4.4x", code );
+        return &undefinedCommandString[0];
+    }
 }

--- a/tcti/tcti_socket.cpp
+++ b/tcti/tcti_socket.cpp
@@ -138,13 +138,11 @@ TSS2_RC SocketSendTpmCommand(
 #ifdef DEBUG
         TCTI_LOG( tctiContext, NO_PREFIX, "\n" );
 		commandCode = CHANGE_ENDIAN_DWORD( ( (TPM20_Header_In *)command_buffer )->commandCode );
-        if( commandCode >= TPM_CC_NV_UndefineSpaceSpecial && commandCode <= TPM_CC_PolicyNvWritten )     
-            TCTI_LOG( tctiContext, NO_PREFIX, "Cmd sent: %s\n", strTpmCommandCode( commandCode ) );
-        else
-            TCTI_LOG( tctiContext, NO_PREFIX, "Cmd sent: 0x%4.4x\n", CHANGE_ENDIAN_DWORD(commandCode ) );
-#endif
 #ifdef DEBUG_SOCKETS
         TCTI_LOG( tctiContext, NO_PREFIX, "Command sent on socket #0x%x: %s\n", TCTI_CONTEXT_INTEL->tpmSock, strTpmCommandCode( commandCode ) );
+#else
+        TCTI_LOG( tctiContext, NO_PREFIX, "Cmd sent: %s\n", strTpmCommandCode( commandCode ) );
+#endif
 #endif        
     }
     // Size TPM 1.2 and TPM 2.0 headers overlap exactly, we can use


### PR DESCRIPTION
When a command code is not valid, the code could cause a seg fault by looking for a string outside the correct range.  Found this in the first test in TestRM when running on Linux.