### PR TITLE
tcti_device: Fix build errors when CFLAGS includes DEBUG

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -75,7 +75,7 @@ tcti_libtctisocket_la_LDFLAGS  = $(LIBRARY_LDFLAGS) \
     -Wl,--version-script=$(srcdir)/tcti/tcti_socket.map
 tcti_libtctisocket_la_SOURCES  =  $(TCTISOCKET_C) \
     sysapi/sysapi_util/changeEndian.c $(TCTISOCKET_CXX) $(TCTICOMMON_C) \
-    common/sockets.cpp
+    common/sockets.cpp common/debug.c
 
 test_tpmclient_tpmclient_CFLAGS   = -DSAPI_CLIENT $(TPMCLIENT_INC)
 test_tpmclient_tpmclient_CXXFLAGS = -DSAPI_CLIENT $(TPMCLIENT_INC) $(TCTICOMMON_INC) $(TCTIDEVICE_INC)

--- a/Makefile.am
+++ b/Makefile.am
@@ -67,7 +67,7 @@ tcti_libtctidevice_la_CFLAGS   = $(TCTIDEVICE_INC)
 tcti_libtctidevice_la_LDFLAGS  = $(LIBRARY_LDFLAGS) \
     -Wl,--version-script=$(srcdir)/tcti/tcti_device.map
 tcti_libtctidevice_la_SOURCES  = $(TCTIDEVICE_C) \
-    sysapi/sysapi_util/changeEndian.c $(TCTICOMMON_C)
+    sysapi/sysapi_util/changeEndian.c $(TCTICOMMON_C) common/debug.c
 
 tcti_libtctisocket_la_CFLAGS   = -DSAPI_CLIENT $(TCTISOCKET_INC)
 tcti_libtctisocket_la_CXXFLAGS = -DSAPI_CLIENT $(TCTISOCKET_INC)


### PR DESCRIPTION
The common/debug.c file wasn't being built into the device TCTI. Now
that it's using the strTpmCommandCode function it requires the debug
file to get access to that function. This problem only occurs when the
DEBUG flag is provided.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>