### PR TITLE
Tcti helper macros

### DIFF
--- a/include/tss2/tss2_tcti.h
+++ b/include/tss2/tss2_tcti.h
@@ -70,6 +70,68 @@ typedef void TSS2_TCTI_POLL_HANDLE;
 #define  TSS2_TCTI_TIMEOUT_BLOCK    -1
 #define  TSS2_TCTI_TIMEOUT_NONE     0
 
+// Macros to simplify access to values in common TCTI structure
+#define TSS2_TCTI_MAGIC(tctiContext) \
+    ((TSS2_TCTI_CONTEXT_VERSION*)tctiContext)->magic
+#define TSS2_TCTI_VERSION(tctiContext) \
+    ((TSS2_TCTI_CONTEXT_VERSION*)tctiContext)->version
+#define TSS2_TCTI_TRANSMIT(tctiContext) \
+    ((TSS2_TCTI_CONTEXT_COMMON_V1*)tctiContext)->transmit
+#define TSS2_TCTI_RECEIVE(tctiContext) \
+    ((TSS2_TCTI_CONTEXT_COMMON_V1*)tctiContext)->receive
+#define TSS2_TCTI_FINALIZE(tctiContext) \
+    ((TSS2_TCTI_CONTEXT_COMMON_V1*)tctiContext)->finalize
+#define TSS2_TCTI_CANCEL(tctiContext) \
+    ((TSS2_TCTI_CONTEXT_COMMON_V1*)tctiContext)->cancel
+#define TSS2_TCTI_GET_POLL_HANDLES(tctiContext) \
+    ((TSS2_TCTI_CONTEXT_COMMON_V1*)tctiContext)->getPollHandles
+#define TSS2_TCTI_SET_LOCALITY(tctiContext) \
+    ((TSS2_TCTI_CONTEXT_COMMON_V1*)tctiContext)->setLocality
+
+// Macros to simplify invocation of functions from the common TCTI structure
+#define tss2_tcti_transmit(tctiContext, size, command) \
+    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_CONTEXT: \
+    (TSS2_TCTI_VERSION(tctiContext) < 1) ? \
+        TSS2_TCTI_RC_ABI_MISMATCH: \
+    (TSS2_TCTI_TRANSMIT(tctiContext) == NULL) ? \
+        TSS2_TCTI_RC_NOT_IMPLEMENTED: \
+    TSS2_TCTI_TRANSMIT(tctiContext)(tctiContext, size, command))
+#define tss2_tcti_receive(tctiContext, size, command) \
+    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_CONTEXT: \
+    (TSS2_TCTI_VERSION(tctiContext) < 1) ? \
+        TSS2_TCTI_RC_ABI_MISMATCH: \
+    (TSS2_TCTI_RECEIVE(tctiContext) == NULL) ? \
+        TSS2_TCTI_RC_NOT_IMPLEMENTED: \
+    TSS2_TCTI_RECEIVE(tctiContext)(tctiContext, size, command))
+#define tss2_tcti_finalize(tctiContext, size, command) \
+    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_CONTEXT: \
+    (TSS2_TCTI_VERSION(tctiContext) < 1) ? \
+        TSS2_TCTI_RC_ABI_MISMATCH: \
+    (TSS2_TCTI_FINALIZE(tctiContext) == NULL) ? \
+        TSS2_TCTI_RC_NOT_IMPLEMENTED: \
+    TSS2_TCTI_FINALIZE(tctiContext)(tctiContext, size, command))
+#define tss2_tcti_cancel(tctiContext, size, command) \
+    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_CONTEXT: \
+    (TSS2_TCTI_VERSION(tctiContext) < 1) ? \
+        TSS2_TCTI_RC_ABI_MISMATCH: \
+    (TSS2_TCTI_CANCEL(tctiContext) == NULL) ? \
+        TSS2_TCTI_RC_NOT_IMPLEMENTED: \
+    TSS2_TCTI_CANCEL(tctiContext)(tctiContext, size, command))
+#define tss2_tcti_get_poll_handles(tctiContext, size, command) \
+    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_CONTEXT: \
+    (TSS2_TCTI_VERSION(tctiContext) < 1) ? \
+        TSS2_TCTI_RC_ABI_MISMATCH: \
+    (TSS2_TCTI_GET_POLL_HANDLES(tctiContext) == NULL) ? \
+        TSS2_TCTI_RC_NOT_IMPLEMENTED: \
+    TSS2_TCTI_GET_POLL_HANDLES(tctiContext)(tctiContext, size, command))
+#define tss2_tcti_set_locality(tctiContext, size, command) \
+    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_CONTEXT: \
+    (TSS2_TCTI_VERSION(tctiContext) < 1) ? \
+        TSS2_TCTI_RC_ABI_MISMATCH: \
+    (TSS2_TCTI_SET_LOCALITY(tctiContext) == NULL) ? \
+        TSS2_TCTI_RC_NOT_IMPLEMENTED: \
+    TSS2_TCTI_SET_LOCALITY(tctiContext)(tctiContext, size, command))
+
 typedef struct TSS2_TCTI_OPAQUE_CONTEXT_BLOB TSS2_TCTI_CONTEXT;
 
 /* superclass to get the version */
@@ -82,18 +144,18 @@ typedef struct {
 typedef struct {
     uint64_t magic;
     uint32_t version;
-    TSS2_RC (*transmit)( TSS2_TCTI_CONTEXT *tctiContext, size_t size, 
+    TSS2_RC (*transmit)( TSS2_TCTI_CONTEXT *tctiContext, size_t size,
 uint8_t *command);
-    TSS2_RC (*receive) (TSS2_TCTI_CONTEXT *tctiContext, size_t *size, 
+    TSS2_RC (*receive) (TSS2_TCTI_CONTEXT *tctiContext, size_t *size,
 uint8_t *response, int32_t timeout);
     void (*finalize) (TSS2_TCTI_CONTEXT *tctiContext);
     TSS2_RC (*cancel) (TSS2_TCTI_CONTEXT *tctiContext);
-    TSS2_RC (*getPollHandles) (TSS2_TCTI_CONTEXT *tctiContext, 
+    TSS2_RC (*getPollHandles) (TSS2_TCTI_CONTEXT *tctiContext,
 TSS2_TCTI_POLL_HANDLE *handles, size_t *num_handles);
     TSS2_RC (*setLocality) (TSS2_TCTI_CONTEXT *tctiContext, uint8_t locality);
 } TSS2_TCTI_CONTEXT_COMMON_V1;
 
-typedef TSS2_TCTI_CONTEXT_COMMON_V1 TSS2_TCTI_CONTEXT_COMMON_CURRENT; 
+typedef TSS2_TCTI_CONTEXT_COMMON_V1 TSS2_TCTI_CONTEXT_COMMON_CURRENT;
 
 #ifdef __cplusplus
 }

--- a/tcti/tcti_device.c
+++ b/tcti/tcti_device.c
@@ -239,14 +239,14 @@ TSS2_RC InitDeviceTcti (
     else
     {
         // Init TCTI context.
-        ((TSS2_TCTI_CONTEXT_COMMON_V1 *)tctiContext)->magic = TCTI_MAGIC;
-        ((TSS2_TCTI_CONTEXT_COMMON_V1 *)tctiContext)->version = TCTI_VERSION;
-        ((TSS2_TCTI_CONTEXT_COMMON_V1 *)tctiContext)->transmit = LocalTpmSendTpmCommand;
-        ((TSS2_TCTI_CONTEXT_COMMON_V1 *)tctiContext)->receive = LocalTpmReceiveTpmResponse;
-        ((TSS2_TCTI_CONTEXT_COMMON_V1 *)tctiContext)->finalize = LocalTpmFinalize;
-        ((TSS2_TCTI_CONTEXT_COMMON_V1 *)tctiContext)->cancel = LocalTpmCancel;
-        ((TSS2_TCTI_CONTEXT_COMMON_V1 *)tctiContext)->getPollHandles = 0;
-        ((TSS2_TCTI_CONTEXT_COMMON_V1 *)tctiContext)->setLocality = LocalTpmSetLocality;
+        TSS2_TCTI_MAGIC( tctiContext ) = TCTI_MAGIC;
+        TSS2_TCTI_VERSION( tctiContext ) = TCTI_VERSION;
+        TSS2_TCTI_TRANSMIT( tctiContext ) = LocalTpmSendTpmCommand;
+        TSS2_TCTI_RECEIVE( tctiContext ) = LocalTpmReceiveTpmResponse;
+        TSS2_TCTI_FINALIZE( tctiContext ) = LocalTpmFinalize;
+        TSS2_TCTI_CANCEL( tctiContext ) = LocalTpmCancel;
+        TSS2_TCTI_GET_POLL_HANDLES( tctiContext ) = 0;
+        TSS2_TCTI_SET_LOCALITY( tctiContext ) = LocalTpmSetLocality;
         ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->status.locality = 3;
         ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->status.commandSent = 0;
         ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->status.rmDebugPrefix = 0;

--- a/tcti/tcti_socket.cpp
+++ b/tcti/tcti_socket.cpp
@@ -509,14 +509,14 @@ TSS2_RC InitSocketTcti (
     else
     {
         // Init TCTI context.
-        ((TSS2_TCTI_CONTEXT_COMMON_V1 *)tctiContext)->magic = TCTI_MAGIC;
-        ((TSS2_TCTI_CONTEXT_COMMON_V1 *)tctiContext)->version = TCTI_VERSION;
-        ((TSS2_TCTI_CONTEXT_COMMON_V1 *)tctiContext)->transmit = SocketSendTpmCommand;
-        ((TSS2_TCTI_CONTEXT_COMMON_V1 *)tctiContext)->receive = SocketReceiveTpmResponse;
-        ((TSS2_TCTI_CONTEXT_COMMON_V1 *)tctiContext)->finalize = SocketFinalize;
-        ((TSS2_TCTI_CONTEXT_COMMON_V1 *)tctiContext)->cancel = SocketCancel;
-        ((TSS2_TCTI_CONTEXT_COMMON_V1 *)tctiContext)->getPollHandles = 0;
-        ((TSS2_TCTI_CONTEXT_COMMON_V1 *)tctiContext)->setLocality = SocketSetLocality;
+        TSS2_TCTI_MAGIC( tctiContext ) = TCTI_MAGIC;
+        TSS2_TCTI_VERSION( tctiContext ) = TCTI_VERSION;
+        TSS2_TCTI_TRANSMIT( tctiContext ) = SocketSendTpmCommand;
+        TSS2_TCTI_RECEIVE( tctiContext ) = SocketReceiveTpmResponse;
+        TSS2_TCTI_FINALIZE( tctiContext ) = SocketFinalize;
+        TSS2_TCTI_CANCEL( tctiContext ) = SocketCancel;
+        TSS2_TCTI_GET_POLL_HANDLES( tctiContext ) = 0;
+        TSS2_TCTI_SET_LOCALITY( tctiContext ) = SocketSetLocality;
         ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->status.locality = 3;
         ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->status.commandSent = 0;
         ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->status.rmDebugPrefix = 0;


### PR DESCRIPTION
Add macros to ease access to fields in the TSS2_TCTI_COMMON_CONTEXT_V1 structure.
Add macros to simplify the invocation of function pointers in from the same context structure.

If we think this is "the right thing to do" I'll take a pass over the repo putting them into use.