### PR TITLE
build: Add -Werror -Wall to default compiler flags.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,8 +29,10 @@
 include src_vars.mk
 
 ACLOCAL_AMFLAGS = -I m4
-AM_CFLAGS = -I$(srcdir)/include
-AM_CPPFLAGS = -I$(srcdir)/include
+AM_CPPFLAGS   = -I$(srcdir)/include
+ERR_FLAGS     = -Wall -Werror
+AM_CFLAGS     = $(ERR_FLAGS)
+AM_CXXFLAGS   = $(ERR_FLAGS)
 
 # stuff to build, what that stuff is, and where/if to install said stuff
 sbin_PROGRAMS   = $(resourcemgr)


### PR DESCRIPTION
I found that we were using CPPFLAGS where we should have been using
CXXFLAGS in the process of working this out. This has been fixed here as
part of pulling in these new compiler flags.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>