### PR TITLE
tcti: Get parameters to TCTI function macros right.

### DIFF
--- a/include/tss2/tss2_tcti.h
+++ b/include/tss2/tss2_tcti.h
@@ -96,41 +96,41 @@ typedef void TSS2_TCTI_POLL_HANDLE;
     (TSS2_TCTI_TRANSMIT(tctiContext) == NULL) ? \
         TSS2_TCTI_RC_NOT_IMPLEMENTED: \
     TSS2_TCTI_TRANSMIT(tctiContext)(tctiContext, size, command))
-#define tss2_tcti_receive(tctiContext, size, command) \
+#define tss2_tcti_receive(tctiContext, size, response, timeout) \
     ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_CONTEXT: \
     (TSS2_TCTI_VERSION(tctiContext) < 1) ? \
         TSS2_TCTI_RC_ABI_MISMATCH: \
     (TSS2_TCTI_RECEIVE(tctiContext) == NULL) ? \
         TSS2_TCTI_RC_NOT_IMPLEMENTED: \
-    TSS2_TCTI_RECEIVE(tctiContext)(tctiContext, size, command))
-#define tss2_tcti_finalize(tctiContext, size, command) \
+    TSS2_TCTI_RECEIVE(tctiContext)(tctiContext, size, response, timeout))
+#define tss2_tcti_finalize(tctiContext) \
     ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_CONTEXT: \
     (TSS2_TCTI_VERSION(tctiContext) < 1) ? \
         TSS2_TCTI_RC_ABI_MISMATCH: \
     (TSS2_TCTI_FINALIZE(tctiContext) == NULL) ? \
         TSS2_TCTI_RC_NOT_IMPLEMENTED: \
-    TSS2_TCTI_FINALIZE(tctiContext)(tctiContext, size, command))
-#define tss2_tcti_cancel(tctiContext, size, command) \
+    TSS2_TCTI_FINALIZE(tctiContext)(tctiContext))
+#define tss2_tcti_cancel(tctiContext) \
     ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_CONTEXT: \
     (TSS2_TCTI_VERSION(tctiContext) < 1) ? \
         TSS2_TCTI_RC_ABI_MISMATCH: \
     (TSS2_TCTI_CANCEL(tctiContext) == NULL) ? \
         TSS2_TCTI_RC_NOT_IMPLEMENTED: \
-    TSS2_TCTI_CANCEL(tctiContext)(tctiContext, size, command))
-#define tss2_tcti_get_poll_handles(tctiContext, size, command) \
+    TSS2_TCTI_CANCEL(tctiContext)(tctiContext))
+#define tss2_tcti_get_poll_handles(tctiContext, handles, num_handles) \
     ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_CONTEXT: \
     (TSS2_TCTI_VERSION(tctiContext) < 1) ? \
         TSS2_TCTI_RC_ABI_MISMATCH: \
     (TSS2_TCTI_GET_POLL_HANDLES(tctiContext) == NULL) ? \
         TSS2_TCTI_RC_NOT_IMPLEMENTED: \
-    TSS2_TCTI_GET_POLL_HANDLES(tctiContext)(tctiContext, size, command))
-#define tss2_tcti_set_locality(tctiContext, size, command) \
+    TSS2_TCTI_GET_POLL_HANDLES(tctiContext)(tctiContext, handles, num_handles))
+#define tss2_tcti_set_locality(tctiContext, locality) \
     ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_CONTEXT: \
     (TSS2_TCTI_VERSION(tctiContext) < 1) ? \
         TSS2_TCTI_RC_ABI_MISMATCH: \
     (TSS2_TCTI_SET_LOCALITY(tctiContext) == NULL) ? \
         TSS2_TCTI_RC_NOT_IMPLEMENTED: \
-    TSS2_TCTI_SET_LOCALITY(tctiContext)(tctiContext, size, command))
+    TSS2_TCTI_SET_LOCALITY(tctiContext)(tctiContext, locality))
 
 typedef struct TSS2_TCTI_OPAQUE_CONTEXT_BLOB TSS2_TCTI_CONTEXT;
 


### PR DESCRIPTION
The receive, finalize, cancel, getPollHandles and setLocality macros all
had cut / paste errors.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>