### PR TITLE
Got debug messages working in RM.

### DIFF
--- a/sysapi/include/tcti_util.h
+++ b/sysapi/include/tcti_util.h
@@ -70,10 +70,12 @@ typedef struct {
               TSS2_TCTI_POLL_HANDLE *handles, size_t *num_handles);
     TSS2_RC (*setLocality) (TSS2_TCTI_CONTEXT *tctiContext, uint8_t locality);
     struct {
-        UINT32 debugMsgLevel: 8;
+        UINT32 debugMsgEnabled: 1;
         UINT32 locality: 8;
         UINT32 commandSent: 1;
-        UINT32 rmDebugPrefix: 1;  // Used to add a prefix to RM debug messages.
+        UINT32 rmDebugPrefix: 1;  // Used to add a prefix to RM debug messages.  This is ONLY used
+                                  // for TPM commands and responses as a way to differentiate
+                                  // RM generated TPM commands from application generated ones.
 
         // Following two fields used to save partial response status in case receive buffer's too small.
         UINT32 tagReceived: 1;
@@ -103,9 +105,5 @@ typedef struct {
 
 #define TCTI_CONTEXT ( (TSS2_TCTI_CONTEXT_COMMON_CURRENT *)(SYS_CONTEXT->tctiContext) )
 #define TCTI_CONTEXT_INTEL ( (TSS2_TCTI_CONTEXT_INTEL *)tctiContext )
-
-// TCTI debug message levels
-#define TSS2_TCTI_DEBUG_MSG_DISABLED 0
-#define TSS2_TCTI_DEBUG_MSG_ENABLED 1
 
 #endif

--- a/test/tpmclient/tpmclient.cpp
+++ b/test/tpmclient/tpmclient.cpp
@@ -2543,7 +2543,7 @@ void TestEvict()
     }
     else
     {
-        (( TSS2_TCTI_CONTEXT_INTEL *)otherResMgrTctiContext )->status.debugMsgLevel = debugLevel;
+        (( TSS2_TCTI_CONTEXT_INTEL *)otherResMgrTctiContext )->status.debugMsgEnabled = debugLevel;
     }
     
     otherSysContext = InitSysContext( 0, otherResMgrTctiContext, &abiVersion );
@@ -6677,7 +6677,7 @@ void TestRM()
     }
     else
     {
-        (( TSS2_TCTI_CONTEXT_INTEL *)otherResMgrTctiContext )->status.debugMsgLevel = debugLevel;
+        (( TSS2_TCTI_CONTEXT_INTEL *)otherResMgrTctiContext )->status.debugMsgEnabled = debugLevel;
     }
     
     otherSysContext = InitSysContext( 0, otherResMgrTctiContext, &abiVersion );
@@ -7167,7 +7167,7 @@ void TestLocalTCTI()
     {
         if( debugLevel == DBG_COMMAND )
         {
-            ((TSS2_TCTI_CONTEXT_INTEL *)downstreamTctiContext )->status.debugMsgLevel = TSS2_TCTI_DEBUG_MSG_ENABLED;
+            ((TSS2_TCTI_CONTEXT_INTEL *)downstreamTctiContext )->status.debugMsgEnabled = debugLevel;
         }
         
         TestTctiApis( downstreamTctiContext, 0 );
@@ -7346,8 +7346,6 @@ void PrintHelp()
             "-dbg specifies level of debug messages:\n"
             "   0 (high level test results)\n"
             "   1 (test app send/receive byte streams)\n"
-            "   2 (resource manager send/receive byte streams)\n"
-            "   3 (resource manager tables)\n"
             "-startAuthSessionTest enables some special tests of the resource manager for starting sessions\n"
 #if __linux || __unix
             "-localTctiTest enables a TCTI interface test against a local TPM.  WARNING:  This test requires no resource manager and a local TPM\n"
@@ -7418,12 +7416,12 @@ int main(int argc, char* argv[])
             else if( 0 == strcmp( argv[count], "-dbg" ) )
             {
                 count++;
-                if( count >= argc || 1 != sscanf_s( argv[count], "%d", &debugLevel ) )
+                if( count >= argc || 1 != sscanf_s( argv[count], "%d", &debugLevel ) || debugLevel > 1 )
                 {
                     PrintHelp();
                     return 1;
                 }
-            }            
+            }
 #if __linux || __unix
             else if( 0 == strcmp( argv[count], "-localTctiTest" ) )
             {
@@ -7458,7 +7456,7 @@ int main(int argc, char* argv[])
     }
     else
     {
-        (( TSS2_TCTI_CONTEXT_INTEL *)resMgrTctiContext )->status.debugMsgLevel = debugLevel;
+        (( TSS2_TCTI_CONTEXT_INTEL *)resMgrTctiContext )->status.debugMsgEnabled = debugLevel;
         resMgrInitialized = 1;
     }
     

--- a/test/tpmtest/tpmtest.cpp
+++ b/test/tpmtest/tpmtest.cpp
@@ -6204,7 +6204,7 @@ void TestRM()
     }
     else
     {
-        (( TSS2_TCTI_CONTEXT_INTEL *)otherResMgrTctiContext )->status.debugMsgLevel = debugLevel;
+        (( TSS2_TCTI_CONTEXT_INTEL *)otherResMgrTctiContext )->status.debugMsgEnabled = debugLevel;
     }
 
     otherSysContext = InitSysContext( 0, otherResMgrTctiContext, &abiVersion );
@@ -7880,7 +7880,7 @@ int main(int argc, char* argv[])
     }
     else
     {
-        (( TSS2_TCTI_CONTEXT_INTEL *)resMgrTctiContext )->status.debugMsgLevel = debugLevel;
+        (( TSS2_TCTI_CONTEXT_INTEL *)resMgrTctiContext )->status.debugMsgEnabled = debugLevel;
     }
 
     sysContext = InitSysContext( 0, resMgrTctiContext, &abiVersion );


### PR DESCRIPTION
Added command line control of debug messages in RM

Cleaned up uses of RM prefix.  This prefix is ONLY to be used for
TPM commands/responses generated by the RM itself.

Added debug level for commands sent from application.

Enabled debug level control over TPM commands issued during RM initialization.

Added RM prefix to debug messages for TPM commands issued during RM initialization.

Added control over RM prefix to both local and socket TCTI layers.