### PR TITLE
pkgconfig: Fix bad flags.

### DIFF
--- a/lib/tcti_device.pc.in
+++ b/lib/tcti_device.pc.in
@@ -3,5 +3,5 @@ Description: TCTI library for communicating with a TPM device node.
 URL: https://github.com/01org/TPM2.0-TSS
 Version: @VERSION@
 Requires: tss2
-Cflags: @includedir@/tcti
-Libs: -ltss2
+Cflags: -I@includedir@/tcti
+Libs: -ltctidevice

--- a/lib/tcti_socket.pc.in
+++ b/lib/tcti_socket.pc.in
@@ -3,5 +3,5 @@ Description: TCTI library for communicating with a TPM over a socket.
 URL: https://github.com/01org/TPM2.0-TSS
 Version: @VERSION@
 Requires: tss2
-Cflags: @includedir@/tcti
-Libs: -ltss2
+Cflags: -I@includedir@/tcti
+Libs: -ltctisocket

--- a/lib/tss2.pc.in
+++ b/lib/tss2.pc.in
@@ -2,4 +2,5 @@ Name: tss2
 Description: TPM2 System API library.
 URL: https://github.com/01org/TPM2.0-TSS
 Version: @VERSION@
-Cflags: @includedir@/tss2
+Cflags: -I@includedir@/tss2
+Libs: -ltss2


### PR DESCRIPTION
I've tested this using the tpm2.0-tools as a use case. I've got patches
ready to go for the tpm2.0-tools build use use these in place of the
AC_CHECK_HEADER macros.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>