### PR TITLE
build: Make parent directory before generating pkg-config files.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -92,6 +92,7 @@ test_tpmtest_tpmtest_LDADD    = $(libtss2) $(libtctisocket) $(libtctidevice)
 test_tpmtest_tpmtest_SOURCES  = $(TPMTEST_CXX) $(COMMON_C) $(SAMPLE_C)
 
 %.pc : %.pc.in
+	if [ ! -d $(dir $@) ]; then mkdir -p $(dir $@); fi
 	sed -e "s,[@]VERSION[@],$(PACKAGE_VERSION),g; \
 	        s,[@]includedir[@],$(includedir),g;" $^ > $@
 


### PR DESCRIPTION
This fixes broken VPATH builds.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>