### PR TITLE
build: use config.site in place of hard coded flags variables.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -13,10 +13,14 @@ produced an official source release. To obtain the tpm2.0-tss sources you
 must clone them from the 01.org GitHub organization TPM2.0-TSS git repository:
 git clone https://github.com/01org/TPM2.0-TSS
 
-To compile tpm2.0-tss execute the following commands from the root of the
-source directory:
+To configure the tpm2.0-tss source code first define the environment for your
+build using a config.site file. The default for the project is kept at
+lib/config.site. Pass this environment to the build through the CONFIG_SITE
+variable:
 $ ./bootstrap
-$ ./configure
+$ ./configure CONFIG_SITE=$(pwd)/lib/config.site
+
+Then compile the code:
 $ make
 
 We now have basic VPATH support which allows us to separate the source

--- a/Makefile.am
+++ b/Makefile.am
@@ -29,10 +29,8 @@
 include src_vars.mk
 
 ACLOCAL_AMFLAGS = -I m4
-AM_CPPFLAGS     = -I$(srcdir)/include
-ERR_FLAGS       = -Wall -Werror
-AM_CFLAGS       = $(ERR_FLAGS)
-AM_CXXFLAGS     = $(ERR_FLAGS)
+AM_CFLAGS       = -I$(srcdir)/include
+AM_CXXFLAGS     = $(AM_CFLAGS)
 
 # stuff to build, what that stuff is, and where/if to install said stuff
 sbin_PROGRAMS   = $(resourcemgr)

--- a/lib/default_config.site
+++ b/lib/default_config.site
@@ -1,0 +1,2 @@
+CFLAGS="-Wall -Werror"
+CXXFLAGS="-Wall -Werror"


### PR DESCRIPTION
Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>