### PR TITLE
RM: Fix deadloop in physical tpm case

### DIFF
--- a/resourcemgr/resourcemgr.c
+++ b/resourcemgr/resourcemgr.c
@@ -2550,6 +2550,9 @@ UINT8 OtherCmdServer( SERVER_STRUCT *serverStruct )
         {
             rval = CHANGE_ENDIAN_DWORD( TSS2_RC_SUCCESS );
             rmSendBytes( serverStruct->connectSock, (unsigned char *)&rval, 4 );
+            if( command == TPM_SESSION_END )
+                break;
+
             continue;
         }
 


### PR DESCRIPTION
For other cmd server thread, in physical tpm case, just skipped all cmd and give a successful response. this is not enough. Need to handle TPM_SESSION_END cmd to exit the thread, instead of continue to let the thread in a deadloop state.
Fix #221.