### PR TITLE
No sapi client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ ipch/
 test/tpmtest/tpmtest
 test-driver
 test-suite.log
+test/getcommands-malloc-mock_unit
 test/tcti_device
 test/*.log
 test/*.trs

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,7 @@ Changed
 * rename libtcti_socket to libtcti-socket
 * move $(includedir)/tss to $(includedir)/sapi
 * Move default compiler flags to config.site file.
+* Removed SAPI_CLIENT macro tests.
 
 2015-07-28 Will Arthur <will.c.arthur@intel.com>
 * 0.98 release

--- a/Makefile.am
+++ b/Makefile.am
@@ -81,21 +81,21 @@ tcti_libtcti_device_la_LDFLAGS  = $(LIBRARY_LDFLAGS) \
 tcti_libtcti_device_la_SOURCES  = $(TCTIDEVICE_C) \
     sysapi/sysapi_util/changeEndian.c $(TCTICOMMON_C) common/debug.c
 
-tcti_libtcti_socket_la_CFLAGS   = -DSAPI_CLIENT $(TCTISOCKET_INC) $(AM_CFLAGS)
-tcti_libtcti_socket_la_CXXFLAGS = -DSAPI_CLIENT $(TCTISOCKET_INC) $(AM_CXXFLAGS)
+tcti_libtcti_socket_la_CFLAGS   = $(TCTISOCKET_INC) $(AM_CFLAGS)
+tcti_libtcti_socket_la_CXXFLAGS = $(TCTISOCKET_INC) $(AM_CXXFLAGS)
 tcti_libtcti_socket_la_LDFLAGS  = $(LIBRARY_LDFLAGS) \
     -Wl,--version-script=$(srcdir)/tcti/tcti_socket.map
 tcti_libtcti_socket_la_SOURCES  =  $(TCTISOCKET_C) \
     sysapi/sysapi_util/changeEndian.c $(TCTISOCKET_CXX) $(TCTICOMMON_C) \
     common/sockets.cpp common/debug.c
 
-test_tpmclient_tpmclient_CFLAGS   = -DSAPI_CLIENT $(TPMCLIENT_INC) $(AM_CFLAGS)
-test_tpmclient_tpmclient_CXXFLAGS = -DSAPI_CLIENT $(TPMCLIENT_INC) $(TCTICOMMON_INC) $(TCTIDEVICE_INC) $(AM_CXXFLAGS)
+test_tpmclient_tpmclient_CFLAGS   = $(TPMCLIENT_INC) $(AM_CFLAGS)
+test_tpmclient_tpmclient_CXXFLAGS = $(TPMCLIENT_INC) $(TCTICOMMON_INC) $(TCTIDEVICE_INC) $(AM_CXXFLAGS)
 test_tpmclient_tpmclient_LDADD    = $(libsapi) $(libtcti_socket) $(libtcti_device)
 test_tpmclient_tpmclient_SOURCES  = $(TPMCLIENT_CXX) $(COMMON_C) $(SAMPLE_C)
 
-test_tpmtest_tpmtest_CFLAGS   = -DSAPI_CLIENT $(TPMTEST_INC) $(AM_CFLAGS)
-test_tpmtest_tpmtest_CXXFLAGS = -DSAPI_CLIENT $(TPMTEST_INC) $(AM_CXXFLAGS)
+test_tpmtest_tpmtest_CFLAGS   = $(TPMTEST_INC) $(AM_CFLAGS)
+test_tpmtest_tpmtest_CXXFLAGS = $(TPMTEST_INC) $(AM_CXXFLAGS)
 test_tpmtest_tpmtest_LDADD    = $(libsapi) $(libtcti_socket) $(libtcti_device)
 test_tpmtest_tpmtest_SOURCES  = $(TPMTEST_CXX) $(COMMON_C) $(SAMPLE_C)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -37,7 +37,9 @@ sbin_PROGRAMS   = $(resourcemgr)
 noinst_PROGRAMS = $(tpmclient) $(tpmtest)
 lib_LTLIBRARIES = $(libsapi) $(libtcti_device) $(libtcti_socket)
 # unit tests
-check_PROGRAMS  = test/tcti_device
+check_PROGRAMS  = \
+    test/tcti_device \
+    test/getcommands-malloc-mock_unit
 TESTS = $(check_PROGRAMS)
 CLEANFILES = $(nodist_pkgconfig_DATA)
 
@@ -53,6 +55,14 @@ nodist_pkgconfig_DATA = lib/sapi.pc lib/tcti-device.pc lib/tcti-socket.pc
 test_tcti_device_CFLAGS  = $(CMOCKA_CFLAGS) -I$(srcdir) -I$(srcdir)/sysapi/include
 test_tcti_device_LDADD   = $(libsapi) $(libtcti_device) $(CMOCKA_LIBS)
 test_tcti_device_SOURCES = test/tcti_device.c test/tcti_device_test.c
+
+test_getcommands_malloc_mock_unit_CFLAGS  = $(CMOCKA_CFLAGS) \
+    -I$(srcdir)/sysapi/include/
+test_getcommands_malloc_mock_unit_LDADD   = $(CMOCKA_LIBS)
+test_getcommands_malloc_mock_unit_LDFLAGS = -Wl,--wrap=malloc \
+    -Wl,--wrap=Tss2_Sys_GetCapability
+test_getcommands_malloc_mock_unit_SOURCES = \
+    test/getcommands-malloc-mock_unit.c resourcemgr/getcommands.c
 
 # how to build stuff
 resourcemgr_resourcemgr_CFLAGS   = $(RESOURCEMGR_INC) $(PTHREAD_CFLAGS) $(AM_CFLAGS)
@@ -100,7 +110,8 @@ LIBRARY_LDFLAGS = -fPIC -Wl,--no-undefined
 RESOURCEMGR_INC = -I$(srcdir)/include -I$(srcdir)/common \
     -I$(srcdir)/sysapi/include -I$(srcdir)/resourcemgr \
     -I$(srcdir)/test/tpmclient
-RESOURCEMGR_C = resourcemgr/resourcemgr.c resourcemgr/criticalsection_linux.c
+RESOURCEMGR_C = resourcemgr/resourcemgr.c resourcemgr/criticalsection_linux.c \
+    resourcemgr/getcommands.c
 
 TCTICOMMON_INC = -I$(srcdir)/include -I$(srcdir)/common \
     -I$(srcdir)/sysapi/include

--- a/common/getcommands.c
+++ b/common/getcommands.c
@@ -33,7 +33,6 @@
 #ifdef SAPI_CLIENT
 TSS2_RC level = TSS2_ERROR_LEVEL( TSS2_APP_ERROR_LEVEL );
 #else
-extern void *(*rmMalloc)(size_t size);
 TSS2_RC level = TSS2_ERROR_LEVEL( TSS2_RESMGR_ERROR_LEVEL );
 #endif    
 
@@ -46,12 +45,6 @@ TSS2_RC GetCommands( TSS2_SYS_CONTEXT *resMgrSysContext, TPML_CCA **supportedCom
     TPMA_CC *commandPtr;
     TSS2_RC rval = TSS2_RC_SUCCESS;
     UINT32 i;
-    
-#ifdef SAPI_CLIENT
-    void *(*gcMalloc)(size_t size) = malloc;
-#else    
-    void *(*gcMalloc)(size_t size) = rmMalloc;
-#endif
     
     // First get the number of commands
     rval = Tss2_Sys_GetCapability( resMgrSysContext, 0,
@@ -70,7 +63,7 @@ TSS2_RC GetCommands( TSS2_SYS_CONTEXT *resMgrSysContext, TPML_CCA **supportedCom
     }
 
     // Allocate memory for them
-    *supportedCommands = (TPML_CCA *)gcMalloc( numCommands * sizeof( TPMA_CC ) + sizeof( UINT32 ) );
+    *supportedCommands = (TPML_CCA *)malloc( numCommands * sizeof( TPMA_CC ) + sizeof( UINT32 ) );
     if( !*supportedCommands )
     {
         rval = TSS2_BASE_RC_INSUFFICIENT_BUFFER + level;

--- a/resourcemgr/getcommands.c
+++ b/resourcemgr/getcommands.c
@@ -30,12 +30,6 @@
 #include <stdlib.h>
 #include "sysapi_util.h"
 
-#ifdef SAPI_CLIENT
-TSS2_RC level = TSS2_ERROR_LEVEL( TSS2_APP_ERROR_LEVEL );
-#else
-TSS2_RC level = TSS2_ERROR_LEVEL( TSS2_RESMGR_ERROR_LEVEL );
-#endif    
-
 // Get the TPM 2.0 commands supported by the TPM.
 TSS2_RC GetCommands( TSS2_SYS_CONTEXT *resMgrSysContext, TPML_CCA **supportedCommands )
 {
@@ -45,7 +39,7 @@ TSS2_RC GetCommands( TSS2_SYS_CONTEXT *resMgrSysContext, TPML_CCA **supportedCom
     TPMA_CC *commandPtr;
     TSS2_RC rval = TSS2_RC_SUCCESS;
     UINT32 i;
-    
+
     // First get the number of commands
     rval = Tss2_Sys_GetCapability( resMgrSysContext, 0,
             TPM_CAP_TPM_PROPERTIES, TPM_PT_TOTAL_COMMANDS,
@@ -66,7 +60,7 @@ TSS2_RC GetCommands( TSS2_SYS_CONTEXT *resMgrSysContext, TPML_CCA **supportedCom
     *supportedCommands = (TPML_CCA *)malloc( numCommands * sizeof( TPMA_CC ) + sizeof( UINT32 ) );
     if( !*supportedCommands )
     {
-        rval = TSS2_BASE_RC_INSUFFICIENT_BUFFER + level;
+        rval = TSS2_BASE_RC_INSUFFICIENT_BUFFER + TSS2_RESMGR_ERROR_LEVEL;
         goto returnFromGetCommands;
     }
 
@@ -95,7 +89,7 @@ TSS2_RC GetCommands( TSS2_SYS_CONTEXT *resMgrSysContext, TPML_CCA **supportedCom
             break;
         }
     }
-    
+
 returnFromGetCommands:
     return rval;
 }
@@ -113,7 +107,7 @@ UINT8 GetCommandAttributes( TPM_CC commandCode, TPML_CCA *supportedCommands, TPM
 {
     UINT32 i;
     UINT8 rval = 0;
-    
+
     for( i = 0; i < supportedCommands->count; i++ )
     {
         if( (TPM_CC)( supportedCommands->commandAttributes[i].commandIndex ) == commandCode )

--- a/test/getcommands-malloc-mock_unit.c
+++ b/test/getcommands-malloc-mock_unit.c
@@ -1,0 +1,67 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include <sapi/tpm20.h>
+
+extern TSS2_RC GetCommands( TSS2_SYS_CONTEXT *resMgrSysContext, TPML_CCA **supportedCommands );
+
+void*
+__wrap_malloc (size_t size)
+{
+    return (void*) mock ();
+}
+
+TPM_RC
+__wrap_Tss2_Sys_GetCapability (TSS2_SYS_CONTEXT         *sys_ctx,
+                               TSS2_SYS_CMD_AUTHS const *cmdAuthArray,
+                               TPM_CAP                   capability,
+                               UINT32                    property,
+                               UINT32                    propertyCount,
+                               TPMI_YES_NO              *moreData,
+                               TPMS_CAPABILITY_DATA     *capabilityData,
+                               TSS2_SYS_RSP_AUTHS       *rspAuthsArray)
+{
+    capabilityData->capability = TPM_CAP_TPM_PROPERTIES;
+    capabilityData->data.tpmProperties.count = 1;
+    capabilityData->data.tpmProperties.tpmProperty[0].property = TPM_PT_TOTAL_COMMANDS;
+    capabilityData->data.tpmProperties.tpmProperty[0].value = 0;
+
+    return (TSS2_RC) mock ();
+}
+/* This test forces a failure in the call to malloc in GetCommands. To do
+ * this we must mock both Tss2_Sys_GetCapability and malloc. Mocking the
+ * Tss2 function is required to get to the malloc call where we're forcing
+ * the filure. This test ensures that when malloc fails, GetCommands returns
+ * the right error layer / level and the right INSUFFICIENT_BUFFER code.
+ */
+static void
+getcommand_malloc_fail (void **state)
+{
+    TSS2_SYS_CONTEXT *sys_ctx;
+    TPML_CCA *commands;
+    TSS2_RC ret, ret_expected = TSS2_BASE_RC_INSUFFICIENT_BUFFER + TSS2_RESMGR_ERROR_LEVEL;
+
+    /* Return value for Tss2_Sys_GetCapability.
+     * The calling function (GetCommands) will pass it a valid
+     * TPMS_CAPABILITY_DATA structure and that's the only parameter we need.
+     */
+    will_return (__wrap_Tss2_Sys_GetCapability, TPM_RC_SUCCESS);
+    /* Return value for malloc: this causes the error condition we're
+     * testing
+     */
+    will_return (__wrap_malloc, NULL);
+    ret = GetCommands (sys_ctx, &commands);
+    assert_int_equal (ret, ret_expected);
+}
+
+int
+main (int argc, char* argv[])
+{
+    const UnitTest tests[] = {
+        unit_test (getcommand_malloc_fail),
+    };
+    return run_tests (tests);
+}


### PR DESCRIPTION
This patch set removes the last remnants of the SAPI_CLIENT macro.