### PR TITLE
Remove all trailing whitespace.

### DIFF
--- a/common/debug.c
+++ b/common/debug.c
@@ -69,7 +69,7 @@ int DebugPrintfCallback( void *data, printf_type type, const char *format, ...)
 void DebugPrintBuffer( printf_type type, UINT8 *buffer, UINT32 length )
 {
     UINT32  i;
-    
+
     for( i = 0; i < length; i++ )
     {
         if( ( i % 16 ) == 0 )
@@ -78,7 +78,7 @@ void DebugPrintBuffer( printf_type type, UINT8 *buffer, UINT32 length )
             if( type == RM_PREFIX )
                 DebugPrintf(NO_PREFIX,  "||  " );
         }
-        
+
         DebugPrintf(NO_PREFIX,  "%2.2x ", buffer[i] );
     }
     DebugPrintf(NO_PREFIX,  "\n\n" );

--- a/common/syscontext.c
+++ b/common/syscontext.c
@@ -39,7 +39,7 @@
 
 TSS2_SYS_CONTEXT *InitSysContext(
     UINT16 maxCommandSize,
-    TSS2_TCTI_CONTEXT *tctiContext, 
+    TSS2_TCTI_CONTEXT *tctiContext,
     TSS2_ABI_VERSION *abiVersion
  )
 {
@@ -78,4 +78,4 @@ void TeardownSysContext( TSS2_SYS_CONTEXT **sysContext )
         free(*sysContext);
         *sysContext = 0;
     }
-} 
+}

--- a/common/syscontext.h
+++ b/common/syscontext.h
@@ -35,7 +35,7 @@
 
 TSS2_SYS_CONTEXT *InitSysContext(
     UINT16 maxCommandSize,
-    TSS2_TCTI_CONTEXT *tctiContext, 
+    TSS2_TCTI_CONTEXT *tctiContext,
     TSS2_ABI_VERSION *abiVersion
  );
 

--- a/include/sapi/implementation.h
+++ b/include/sapi/implementation.h
@@ -1361,7 +1361,7 @@ typedef  UINT32             TPM_CC;
 #define COMMAND_COUNT							\
     (LIBRARY_COMMAND_ARRAY_SIZE + VENDOR_COMMAND_ARRAY_SIZE)
 
-    
+
 #ifndef MAX
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 #endif

--- a/include/sapi/sys_api_part3.h
+++ b/include/sapi/sys_api_part3.h
@@ -411,7 +411,7 @@ typedef struct {
 	UINT8 otherData;
 } TPM20_NV_ChangeAuth_Out;
 
-   
+
 
 TPM_RC Tss2_Sys_Startup_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -421,7 +421,7 @@ TPM_RC Tss2_Sys_Startup_Prepare(
 TPM_RC Tss2_Sys_Startup(
     TSS2_SYS_CONTEXT *sysContext,
     TPM_SU	startupType
-    );   
+    );
 
 TPM_RC Tss2_Sys_Shutdown_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -433,7 +433,7 @@ TPM_RC Tss2_Sys_Shutdown(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TPM_SU	shutdownType,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_SelfTest_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -445,7 +445,7 @@ TPM_RC Tss2_Sys_SelfTest(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TPMI_YES_NO	fullTest,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_IncrementalSelfTest_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -463,7 +463,7 @@ TPM_RC Tss2_Sys_IncrementalSelfTest(
     TPML_ALG	*toTest,
     TPML_ALG	*toDoList,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_GetTestResult_Prepare(
     TSS2_SYS_CONTEXT *sysContext
@@ -481,7 +481,7 @@ TPM_RC Tss2_Sys_GetTestResult(
     TPM2B_MAX_BUFFER	*outData,
     TPM_RC	*testResult,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_StartAuthSession_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -513,7 +513,7 @@ TPM_RC Tss2_Sys_StartAuthSession(
     TPMI_SH_AUTH_SESSION	*sessionHandle,
     TPM2B_NONCE	*nonceTPM,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_PolicyRestart_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -525,7 +525,7 @@ TPM_RC Tss2_Sys_PolicyRestart(
     TPMI_SH_POLICY	sessionHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_Create_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -559,7 +559,7 @@ TPM_RC Tss2_Sys_Create(
     TPM2B_DIGEST	*creationHash,
     TPMT_TK_CREATION	*creationTicket,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_Load_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -583,7 +583,7 @@ TPM_RC Tss2_Sys_Load(
     TPM_HANDLE	*objectHandle,
     TPM2B_NAME	*name,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_LoadExternal_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -607,7 +607,7 @@ TPM_RC Tss2_Sys_LoadExternal(
     TPM_HANDLE	*objectHandle,
     TPM2B_NAME	*name,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_ReadPublic_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -629,7 +629,7 @@ TPM_RC Tss2_Sys_ReadPublic(
     TPM2B_NAME	*name,
     TPM2B_NAME	*qualifiedName,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_ActivateCredential_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -653,7 +653,7 @@ TPM_RC Tss2_Sys_ActivateCredential(
     TPM2B_ENCRYPTED_SECRET	*secret,
     TPM2B_DIGEST	*certInfo,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_MakeCredential_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -677,7 +677,7 @@ TPM_RC Tss2_Sys_MakeCredential(
     TPM2B_ID_OBJECT	*credentialBlob,
     TPM2B_ENCRYPTED_SECRET	*secret,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_Unseal_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -695,7 +695,7 @@ TPM_RC Tss2_Sys_Unseal(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TPM2B_SENSITIVE_DATA	*outData,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_ObjectChangeAuth_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -717,7 +717,7 @@ TPM_RC Tss2_Sys_ObjectChangeAuth(
     TPM2B_AUTH	*newAuth,
     TPM2B_PRIVATE	*outPrivate,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_Duplicate_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -745,7 +745,7 @@ TPM_RC Tss2_Sys_Duplicate(
     TPM2B_PRIVATE	*duplicate,
     TPM2B_ENCRYPTED_SECRET	*outSymSeed,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_Rewrap_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -773,7 +773,7 @@ TPM_RC Tss2_Sys_Rewrap(
     TPM2B_PRIVATE	*outDuplicate,
     TPM2B_ENCRYPTED_SECRET	*outSymSeed,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_Import_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -801,7 +801,7 @@ TPM_RC Tss2_Sys_Import(
     TPMT_SYM_DEF_OBJECT	*symmetricAlg,
     TPM2B_PRIVATE	*outPrivate,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_RSA_Encrypt_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -825,7 +825,7 @@ TPM_RC Tss2_Sys_RSA_Encrypt(
     TPM2B_DATA	*label,
     TPM2B_PUBLIC_KEY_RSA	*outData,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_RSA_Decrypt_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -849,7 +849,7 @@ TPM_RC Tss2_Sys_RSA_Decrypt(
     TPM2B_DATA	*label,
     TPM2B_PUBLIC_KEY_RSA	*message,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_ECDH_KeyGen_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -869,7 +869,7 @@ TPM_RC Tss2_Sys_ECDH_KeyGen(
     TPM2B_ECC_POINT	*zPoint,
     TPM2B_ECC_POINT	*pubPoint,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_ECDH_ZGen_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -889,7 +889,7 @@ TPM_RC Tss2_Sys_ECDH_ZGen(
     TPM2B_ECC_POINT	*inPoint,
     TPM2B_ECC_POINT	*outPoint,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_ECC_Parameters_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -907,7 +907,7 @@ TPM_RC Tss2_Sys_ECC_Parameters(
     TPMI_ECC_CURVE	curveID,
     TPMS_ALGORITHM_DETAIL_ECC	*parameters,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_ZGen_2Phase_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -935,7 +935,7 @@ TPM_RC Tss2_Sys_ZGen_2Phase(
     TPM2B_ECC_POINT	*outZ1,
     TPM2B_ECC_POINT	*outZ2,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_EncryptDecrypt_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -963,7 +963,7 @@ TPM_RC Tss2_Sys_EncryptDecrypt(
     TPM2B_MAX_BUFFER	*outData,
     TPM2B_IV	*ivOut,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_Hash_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -987,7 +987,7 @@ TPM_RC Tss2_Sys_Hash(
     TPM2B_DIGEST	*outHash,
     TPMT_TK_HASHCHECK	*validation,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_HMAC_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1009,7 +1009,7 @@ TPM_RC Tss2_Sys_HMAC(
     TPMI_ALG_HASH	hashAlg,
     TPM2B_DIGEST	*outHMAC,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_GetRandom_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1027,7 +1027,7 @@ TPM_RC Tss2_Sys_GetRandom(
     UINT16	bytesRequested,
     TPM2B_DIGEST	*randomBytes,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_StirRandom_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1039,7 +1039,7 @@ TPM_RC Tss2_Sys_StirRandom(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TPM2B_SENSITIVE_DATA	*inData,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_HMAC_Start_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1061,7 +1061,7 @@ TPM_RC Tss2_Sys_HMAC_Start(
     TPMI_ALG_HASH	hashAlg,
     TPMI_DH_OBJECT	*sequenceHandle,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_HashSequenceStart_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1081,7 +1081,7 @@ TPM_RC Tss2_Sys_HashSequenceStart(
     TPMI_ALG_HASH	hashAlg,
     TPMI_DH_OBJECT	*sequenceHandle,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_SequenceUpdate_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1095,7 +1095,7 @@ TPM_RC Tss2_Sys_SequenceUpdate(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TPM2B_MAX_BUFFER	*buffer,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_SequenceComplete_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1119,7 +1119,7 @@ TPM_RC Tss2_Sys_SequenceComplete(
     TPM2B_DIGEST	*result,
     TPMT_TK_HASHCHECK	*validation,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_EventSequenceComplete_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1141,7 +1141,7 @@ TPM_RC Tss2_Sys_EventSequenceComplete(
     TPM2B_MAX_BUFFER	*buffer,
     TPML_DIGEST_VALUES	*results,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_Certify_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1167,7 +1167,7 @@ TPM_RC Tss2_Sys_Certify(
     TPM2B_ATTEST	*certifyInfo,
     TPMT_SIGNATURE	*signature,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_CertifyCreation_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1197,7 +1197,7 @@ TPM_RC Tss2_Sys_CertifyCreation(
     TPM2B_ATTEST	*certifyInfo,
     TPMT_SIGNATURE	*signature,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_Quote_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1223,7 +1223,7 @@ TPM_RC Tss2_Sys_Quote(
     TPM2B_ATTEST	*quoted,
     TPMT_SIGNATURE	*signature,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_GetSessionAuditDigest_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1251,7 +1251,7 @@ TPM_RC Tss2_Sys_GetSessionAuditDigest(
     TPM2B_ATTEST	*auditInfo,
     TPMT_SIGNATURE	*signature,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_GetCommandAuditDigest_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1277,7 +1277,7 @@ TPM_RC Tss2_Sys_GetCommandAuditDigest(
     TPM2B_ATTEST	*auditInfo,
     TPMT_SIGNATURE	*signature,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_GetTime_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1303,7 +1303,7 @@ TPM_RC Tss2_Sys_GetTime(
     TPM2B_ATTEST	*timeInfo,
     TPMT_SIGNATURE	*signature,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_Commit_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1333,7 +1333,7 @@ TPM_RC Tss2_Sys_Commit(
     TPM2B_ECC_POINT	*E,
     UINT16	*counter,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_EC_Ephemeral_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1353,7 +1353,7 @@ TPM_RC Tss2_Sys_EC_Ephemeral(
     TPM2B_ECC_POINT	*Q,
     UINT16	*counter,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_VerifySignature_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1375,7 +1375,7 @@ TPM_RC Tss2_Sys_VerifySignature(
     TPMT_SIGNATURE	*signature,
     TPMT_TK_VERIFIED	*validation,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_Sign_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1399,7 +1399,7 @@ TPM_RC Tss2_Sys_Sign(
     TPMT_TK_HASHCHECK	*validation,
     TPMT_SIGNATURE	*signature,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_SetCommandCodeAuditStatus_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1417,7 +1417,7 @@ TPM_RC Tss2_Sys_SetCommandCodeAuditStatus(
     TPML_CC	*setList,
     TPML_CC	*clearList,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_PCR_Extend_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1431,7 +1431,7 @@ TPM_RC Tss2_Sys_PCR_Extend(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TPML_DIGEST_VALUES	*digests,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_PCR_Event_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1451,7 +1451,7 @@ TPM_RC Tss2_Sys_PCR_Event(
     TPM2B_EVENT	*eventData,
     TPML_DIGEST_VALUES	*digests,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_PCR_Read_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1473,7 +1473,7 @@ TPM_RC Tss2_Sys_PCR_Read(
     TPML_PCR_SELECTION	*pcrSelectionOut,
     TPML_DIGEST	*pcrValues,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_PCR_Allocate_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1499,7 +1499,7 @@ TPM_RC Tss2_Sys_PCR_Allocate(
     UINT32	*sizeNeeded,
     UINT32	*sizeAvailable,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_PCR_SetAuthPolicy_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1517,7 +1517,7 @@ TPM_RC Tss2_Sys_PCR_SetAuthPolicy(
     TPMI_ALG_HASH	hashAlg,
     TPMI_DH_PCR	pcrNum,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_PCR_SetAuthValue_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1531,7 +1531,7 @@ TPM_RC Tss2_Sys_PCR_SetAuthValue(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TPM2B_DIGEST	*auth,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_PCR_Reset_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1543,7 +1543,7 @@ TPM_RC Tss2_Sys_PCR_Reset(
     TPMI_DH_PCR	pcrHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_PolicySigned_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1575,7 +1575,7 @@ TPM_RC Tss2_Sys_PolicySigned(
     TPM2B_TIMEOUT	*timeout,
     TPMT_TK_AUTH	*policyTicket,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_PolicySecret_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1605,7 +1605,7 @@ TPM_RC Tss2_Sys_PolicySecret(
     TPM2B_TIMEOUT	*timeout,
     TPMT_TK_AUTH	*policyTicket,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_PolicyTicket_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1627,7 +1627,7 @@ TPM_RC Tss2_Sys_PolicyTicket(
     TPM2B_NAME	*authName,
     TPMT_TK_AUTH	*ticket,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_PolicyOR_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1641,7 +1641,7 @@ TPM_RC Tss2_Sys_PolicyOR(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TPML_DIGEST	*pHashList,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_PolicyPCR_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1657,7 +1657,7 @@ TPM_RC Tss2_Sys_PolicyPCR(
     TPM2B_DIGEST	*pcrDigest,
     TPML_PCR_SELECTION	*pcrs,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_PolicyLocality_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1671,7 +1671,7 @@ TPM_RC Tss2_Sys_PolicyLocality(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TPMA_LOCALITY	locality,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_PolicyNV_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1693,7 +1693,7 @@ TPM_RC Tss2_Sys_PolicyNV(
     UINT16	offset,
     TPM_EO	operation,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_PolicyCounterTimer_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1711,7 +1711,7 @@ TPM_RC Tss2_Sys_PolicyCounterTimer(
     UINT16	offset,
     TPM_EO	operation,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_PolicyCommandCode_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1725,7 +1725,7 @@ TPM_RC Tss2_Sys_PolicyCommandCode(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TPM_CC	code,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_PolicyPhysicalPresence_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1737,7 +1737,7 @@ TPM_RC Tss2_Sys_PolicyPhysicalPresence(
     TPMI_SH_POLICY	policySession,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_PolicyCpHash_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1751,7 +1751,7 @@ TPM_RC Tss2_Sys_PolicyCpHash(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TPM2B_DIGEST	*cpHashA,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_PolicyNameHash_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1765,7 +1765,7 @@ TPM_RC Tss2_Sys_PolicyNameHash(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TPM2B_DIGEST	*nameHash,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_PolicyDuplicationSelect_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1783,7 +1783,7 @@ TPM_RC Tss2_Sys_PolicyDuplicationSelect(
     TPM2B_NAME	*newParentName,
     TPMI_YES_NO	includeObject,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_PolicyAuthorize_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1803,7 +1803,7 @@ TPM_RC Tss2_Sys_PolicyAuthorize(
     TPM2B_NAME	*keySign,
     TPMT_TK_VERIFIED	*checkTicket,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_PolicyAuthValue_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1815,7 +1815,7 @@ TPM_RC Tss2_Sys_PolicyAuthValue(
     TPMI_SH_POLICY	policySession,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_PolicyPassword_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1827,7 +1827,7 @@ TPM_RC Tss2_Sys_PolicyPassword(
     TPMI_SH_POLICY	policySession,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_PolicyGetDigest_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1845,7 +1845,7 @@ TPM_RC Tss2_Sys_PolicyGetDigest(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TPM2B_DIGEST	*policyDigest,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_PolicyNvWritten_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1859,7 +1859,7 @@ TPM_RC Tss2_Sys_PolicyNvWritten(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TPMI_YES_NO	writtenSet,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_CreatePrimary_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1895,7 +1895,7 @@ TPM_RC Tss2_Sys_CreatePrimary(
     TPMT_TK_CREATION	*creationTicket,
     TPM2B_NAME	*name,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_HierarchyControl_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1911,7 +1911,7 @@ TPM_RC Tss2_Sys_HierarchyControl(
     TPMI_RH_ENABLES	enable,
     TPMI_YES_NO	state,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_SetPrimaryPolicy_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1927,7 +1927,7 @@ TPM_RC Tss2_Sys_SetPrimaryPolicy(
     TPM2B_DIGEST	*authPolicy,
     TPMI_ALG_HASH	hashAlg,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_ChangePPS_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1939,7 +1939,7 @@ TPM_RC Tss2_Sys_ChangePPS(
     TPMI_RH_PLATFORM	authHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_ChangeEPS_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1951,7 +1951,7 @@ TPM_RC Tss2_Sys_ChangeEPS(
     TPMI_RH_PLATFORM	authHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_Clear_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1963,7 +1963,7 @@ TPM_RC Tss2_Sys_Clear(
     TPMI_RH_CLEAR	authHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_ClearControl_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1977,7 +1977,7 @@ TPM_RC Tss2_Sys_ClearControl(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TPMI_YES_NO	disable,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_HierarchyChangeAuth_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -1991,7 +1991,7 @@ TPM_RC Tss2_Sys_HierarchyChangeAuth(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TPM2B_AUTH	*newAuth,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_DictionaryAttackLockReset_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -2003,7 +2003,7 @@ TPM_RC Tss2_Sys_DictionaryAttackLockReset(
     TPMI_RH_LOCKOUT	lockHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_DictionaryAttackParameters_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -2021,7 +2021,7 @@ TPM_RC Tss2_Sys_DictionaryAttackParameters(
     UINT32	newRecoveryTime,
     UINT32	lockoutRecovery,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_PP_Commands_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -2037,7 +2037,7 @@ TPM_RC Tss2_Sys_PP_Commands(
     TPML_CC	*setList,
     TPML_CC	*clearList,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_SetAlgorithmSet_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -2051,7 +2051,7 @@ TPM_RC Tss2_Sys_SetAlgorithmSet(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     UINT32	algorithmSet,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_FieldUpgradeStart_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -2069,7 +2069,7 @@ TPM_RC Tss2_Sys_FieldUpgradeStart(
     TPM2B_DIGEST	*fuDigest,
     TPMT_SIGNATURE	*manifestSignature,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_FieldUpgradeData_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -2089,7 +2089,7 @@ TPM_RC Tss2_Sys_FieldUpgradeData(
     TPMT_HA	*nextDigest,
     TPMT_HA	*firstDigest,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_FirmwareRead_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -2107,7 +2107,7 @@ TPM_RC Tss2_Sys_FirmwareRead(
     UINT32	sequenceNumber,
     TPM2B_MAX_BUFFER	*fuData,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_ContextSave_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -2123,7 +2123,7 @@ TPM_RC Tss2_Sys_ContextSave(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_CONTEXT	saveHandle,
     TPMS_CONTEXT	*context
-    );   
+    );
 
 TPM_RC Tss2_Sys_ContextLoad_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -2139,7 +2139,7 @@ TPM_RC Tss2_Sys_ContextLoad(
     TSS2_SYS_CONTEXT *sysContext,
     TPMS_CONTEXT	*context,
     TPMI_DH_CONTEXT	*loadedHandle
-    );   
+    );
 
 TPM_RC Tss2_Sys_FlushContext_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -2149,7 +2149,7 @@ TPM_RC Tss2_Sys_FlushContext_Prepare(
 TPM_RC Tss2_Sys_FlushContext(
     TSS2_SYS_CONTEXT *sysContext,
     TPMI_DH_CONTEXT	flushHandle
-    );   
+    );
 
 TPM_RC Tss2_Sys_EvictControl_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -2165,7 +2165,7 @@ TPM_RC Tss2_Sys_EvictControl(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TPMI_DH_PERSISTENT	persistentHandle,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_ReadClock_Prepare(
     TSS2_SYS_CONTEXT *sysContext
@@ -2179,7 +2179,7 @@ TPM_RC Tss2_Sys_ReadClock_Complete(
 TPM_RC Tss2_Sys_ReadClock(
     TSS2_SYS_CONTEXT *sysContext,
     TPMS_TIME_INFO	*currentTime
-    );   
+    );
 
 TPM_RC Tss2_Sys_ClockSet_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -2193,7 +2193,7 @@ TPM_RC Tss2_Sys_ClockSet(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     UINT64	newTime,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_ClockRateAdjust_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -2207,7 +2207,7 @@ TPM_RC Tss2_Sys_ClockRateAdjust(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TPM_CLOCK_ADJUST	rateAdjust,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_GetCapability_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -2231,7 +2231,7 @@ TPM_RC Tss2_Sys_GetCapability(
     TPMI_YES_NO	*moreData,
     TPMS_CAPABILITY_DATA	*capabilityData,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_TestParms_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -2243,7 +2243,7 @@ TPM_RC Tss2_Sys_TestParms(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TPMT_PUBLIC_PARMS	*parameters,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_NV_DefineSpace_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -2259,7 +2259,7 @@ TPM_RC Tss2_Sys_NV_DefineSpace(
     TPM2B_AUTH	*auth,
     TPM2B_NV_PUBLIC	*publicInfo,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_NV_UndefineSpace_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -2273,7 +2273,7 @@ TPM_RC Tss2_Sys_NV_UndefineSpace(
     TPMI_RH_NV_INDEX	nvIndex,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_NV_UndefineSpaceSpecial_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -2287,7 +2287,7 @@ TPM_RC Tss2_Sys_NV_UndefineSpaceSpecial(
     TPMI_RH_PLATFORM	platform,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_NV_ReadPublic_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -2307,7 +2307,7 @@ TPM_RC Tss2_Sys_NV_ReadPublic(
     TPM2B_NV_PUBLIC	*nvPublic,
     TPM2B_NAME	*nvName,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_NV_Write_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -2325,7 +2325,7 @@ TPM_RC Tss2_Sys_NV_Write(
     TPM2B_MAX_NV_BUFFER	*data,
     UINT16	offset,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_NV_Increment_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -2339,7 +2339,7 @@ TPM_RC Tss2_Sys_NV_Increment(
     TPMI_RH_NV_INDEX	nvIndex,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_NV_Extend_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -2355,7 +2355,7 @@ TPM_RC Tss2_Sys_NV_Extend(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TPM2B_MAX_NV_BUFFER	*data,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_NV_SetBits_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -2371,7 +2371,7 @@ TPM_RC Tss2_Sys_NV_SetBits(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     UINT64	bits,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_NV_WriteLock_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -2385,7 +2385,7 @@ TPM_RC Tss2_Sys_NV_WriteLock(
     TPMI_RH_NV_INDEX	nvIndex,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_NV_GlobalWriteLock_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -2397,7 +2397,7 @@ TPM_RC Tss2_Sys_NV_GlobalWriteLock(
     TPMI_RH_PROVISION	authHandle,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_NV_Read_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -2421,7 +2421,7 @@ TPM_RC Tss2_Sys_NV_Read(
     UINT16	offset,
     TPM2B_MAX_NV_BUFFER	*data,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_NV_ReadLock_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -2435,7 +2435,7 @@ TPM_RC Tss2_Sys_NV_ReadLock(
     TPMI_RH_NV_INDEX	nvIndex,
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_NV_ChangeAuth_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -2449,7 +2449,7 @@ TPM_RC Tss2_Sys_NV_ChangeAuth(
     TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     TPM2B_AUTH	*newAuth,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_NV_Certify_Prepare(
     TSS2_SYS_CONTEXT *sysContext,
@@ -2481,7 +2481,7 @@ TPM_RC Tss2_Sys_NV_Certify(
     TPM2B_ATTEST	*certifyInfo,
     TPMT_SIGNATURE	*signature,
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
-    );   
+    );
 
 TPM_RC Tss2_Sys_Vendor_TCG_Test_Prepare(
     TSS2_SYS_CONTEXT *sysContext,

--- a/include/sapi/tpm20.h
+++ b/include/sapi/tpm20.h
@@ -35,8 +35,8 @@
 
 #include    <stddef.h>
 #include    <stdint.h>
-#include    <stdlib.h> 
-#include    <string.h> 
+#include    <stdlib.h>
+#include    <string.h>
 
 #include    <sapi/tss2_common.h>
 #include    <sapi/tpmb.h>

--- a/include/sapi/tss2_common.h
+++ b/include/sapi/tss2_common.h
@@ -52,7 +52,7 @@ typedef int32_t     INT32;      /* signed, 32-bit integer */
 typedef uint64_t    UINT64;     /* unsigned, 64-bit integer */
 typedef int64_t     INT64;      /* signed, 64-bit integer */
 
-typedef UINT32 TSS2_RC; 
+typedef UINT32 TSS2_RC;
 
 
 /**
@@ -108,7 +108,7 @@ typedef struct {
 // These are not returned directly, but are combined with an ERROR_LEVEL to
 // produce the error codes for each layer.
 //
-#define TSS2_BASE_RC_GENERAL_FAILURE        1 /* Catch all for all errors 
+#define TSS2_BASE_RC_GENERAL_FAILURE        1 /* Catch all for all errors
                                                  not otherwise specifed */
 #define TSS2_BASE_RC_NOT_IMPLEMENTED        2 /* If called functionality isn't implemented */
 #define TSS2_BASE_RC_BAD_CONTEXT            3 /* A context structure is bad */
@@ -130,7 +130,7 @@ typedef struct {
 #define TSS2_BASE_RC_NO_DECRYPT_PARAM      14 /* If function called that uses decrypt
                                                  parameter, but command doesn't support
                                                  crypt parameter. */
-#define TSS2_BASE_RC_NO_ENCRYPT_PARAM      15 /* If function called that uses encrypt 
+#define TSS2_BASE_RC_NO_ENCRYPT_PARAM      15 /* If function called that uses encrypt
                                                  parameter, but command doesn't support
                                                  encrypt parameter. */
 #define TSS2_BASE_RC_BAD_SIZE              16 /* If size of a parameter is incorrect */

--- a/include/sapi/tss2_sys.h
+++ b/include/sapi/tss2_sys.h
@@ -86,9 +86,9 @@ size_t  Tss2_Sys_GetContextSize(
     );
 
 TSS2_RC Tss2_Sys_Initialize(
-    TSS2_SYS_CONTEXT *sysContext, 
+    TSS2_SYS_CONTEXT *sysContext,
     size_t contextSize,
-    TSS2_TCTI_CONTEXT *tctiContext, 
+    TSS2_TCTI_CONTEXT *tctiContext,
     TSS2_ABI_VERSION *abiVersion
     );
 
@@ -105,7 +105,7 @@ TSS2_RC Tss2_Sys_GetTctiContext(
 // Command Preparation Functions
 //
 TSS2_RC Tss2_Sys_GetDecryptParam(
-    TSS2_SYS_CONTEXT *sysContext,   
+    TSS2_SYS_CONTEXT *sysContext,
     size_t *decryptParamSize,
     const uint8_t **decryptParamBuffer
     );
@@ -122,7 +122,7 @@ TPM_RC Tss2_Sys_GetCpBuffer(
     const uint8_t **cpBuffer);
 
 TPM_RC Tss2_Sys_SetCmdAuths(
-    TSS2_SYS_CONTEXT * sysContext,  
+    TSS2_SYS_CONTEXT * sysContext,
     const TSS2_SYS_CMD_AUTHS *cmdAuthsArray
     );
 
@@ -148,7 +148,7 @@ TSS2_RC Tss2_Sys_Execute(
 //
 TSS2_RC Tss2_Sys_GetCommandCode(
     TSS2_SYS_CONTEXT *sysContext,
-    UINT8 (*commandCode)[4]  
+    UINT8 (*commandCode)[4]
     );
 
 TSS2_RC Tss2_Sys_GetRspAuths(
@@ -179,5 +179,5 @@ TPM_RC Tss2_Sys_GetRpBuffer(
 #ifdef __cplusplus
 }
 #endif
-    
+
 #endif

--- a/include/sapi/tss2_tcti.h
+++ b/include/sapi/tss2_tcti.h
@@ -38,7 +38,7 @@
 // defined.
 //
 // The first field of a Context must be the common part
-// (see below). 
+// (see below).
 #ifndef TSS2_TCTI
 #define TSS2_TCTI
 

--- a/include/sapi/tss2_tpm2_types.h
+++ b/include/sapi/tss2_tpm2_types.h
@@ -49,12 +49,12 @@
 #define    MAX_ECC_CURVES       (MAX_CAP_DATA/sizeof(TPM_ECC_CURVE))
 
 /* Table 4  Defines for Logic Values */
-#define	TRUE	1 
-#define	FALSE	0 
-#define	YES	1 
-#define	NO	0 
-#define	SET	1 
-#define	CLEAR	0 
+#define	TRUE	1
+#define	FALSE	0
+#define	YES	1
+#define	NO	0
+#define	SET	1
+#define	CLEAR	0
 
 /* Table 5  Definition of Types for Documentation Clarity */
 typedef	UINT32	TPM_ALGORITHM_ID;	 /* this is the 1.2 compatible form of the TPM_ALG_ID  */

--- a/include/tcti/tcti_socket.h
+++ b/include/tcti/tcti_socket.h
@@ -68,7 +68,7 @@ TSS2_RC InitSocketTcti (
 TSS2_RC TeardownSocketTcti (TSS2_TCTI_CONTEXT *tctiContext);
 
 TSS2_RC SendSessionEndSocketTcti(
-    TSS2_TCTI_CONTEXT *tctiContext,      
+    TSS2_TCTI_CONTEXT *tctiContext,
     UINT8 tpmCmdServer
     );
 

--- a/resourcemgr/resourcemgr.c
+++ b/resourcemgr/resourcemgr.c
@@ -41,7 +41,7 @@
 
 #ifdef _WIN32
 
-typedef HANDLE THREAD_TYPE; 
+typedef HANDLE THREAD_TYPE;
 #define MAX_COMMAND_LINE_ARGS 6
 
 #elif __linux || __unix
@@ -53,7 +53,7 @@ typedef HANDLE THREAD_TYPE;
 #include <pthread.h>
 typedef pthread_t THREAD_TYPE ;
 #define ExitThread pthread_exit
-#define CloseHandle( handle ) 
+#define CloseHandle( handle )
 
 #ifdef DEBUG
 #define MAX_COMMAND_LINE_ARGS 9
@@ -61,13 +61,13 @@ typedef pthread_t THREAD_TYPE ;
 #define MAX_COMMAND_LINE_ARGS 7
 #endif
 
-#else    
-#error Unsupported OS--need to add OS-specific support for threading here.        
-#endif                
+#else
+#error Unsupported OS--need to add OS-specific support for threading here.
+#endif
 
 #include "criticalsection.h"
 
-#define DEBUG_RESMGR_INIT        
+#define DEBUG_RESMGR_INIT
 
 TPM_MUTEX tpmMutex;
 int debugLevel = 0xff;
@@ -102,7 +102,7 @@ int GetNumCmdHandles( TPM_CC commandCode, TPML_CCA *supportedCommands )
 {
     int rval = -1;
     TPMA_CC cmdAttributes;
-    
+
     if( GetCommandAttributes( commandCode, supportedCommands, &cmdAttributes ) )
     {
         if( commandCode == TPM_CC_FlushContext )
@@ -110,7 +110,7 @@ int GetNumCmdHandles( TPM_CC commandCode, TPML_CCA *supportedCommands )
             rval = 1;
         }
         else
-        {                
+        {
             rval = cmdAttributes.cHandles;
         }
     }
@@ -122,7 +122,7 @@ int GetNumRspHandles( TPM_CC commandCode, TPML_CCA *supportedCommands )
 {
     int rval = 0;
     TPMA_CC cmdAttributes;
-    
+
     if( GetCommandAttributes( commandCode, supportedCommands, &cmdAttributes ) )
     {
 		if( cmdAttributes.rHandle == 1 )
@@ -194,27 +194,27 @@ TSS2_RC ResmgrFixupErrorlevel( TSS2_RC errCode )
 #define RESMGR_UNMARSHAL_UINT8( buffer, size, currentPtr, value, rval, exitLoc ) \
     Unmarshal_UINT8( buffer, size, currentPtr, value, rval ); \
     responseRval = ResmgrFixupErrorlevel( *rval ); \
-    if( responseRval != TSS2_RC_SUCCESS ) goto exitLoc; 
+    if( responseRval != TSS2_RC_SUCCESS ) goto exitLoc;
 
 #define RESMGR_UNMARSHAL_UINT16( buffer, size, currentPtr, value, rval, exitLoc ) \
     Unmarshal_UINT16( buffer, size, currentPtr, value, rval ); \
     responseRval = ResmgrFixupErrorlevel( *rval ); \
-    if( responseRval != TSS2_RC_SUCCESS ) goto exitLoc; 
+    if( responseRval != TSS2_RC_SUCCESS ) goto exitLoc;
 
 #define RESMGR_UNMARSHAL_UINT32( buffer, size, currentPtr, value, rval, exitLoc ) \
     Unmarshal_UINT32( buffer, size, currentPtr, value, rval ); \
     responseRval = ResmgrFixupErrorlevel( *rval ); \
-    if( responseRval != TSS2_RC_SUCCESS ) goto exitLoc; 
+    if( responseRval != TSS2_RC_SUCCESS ) goto exitLoc;
 
 #define RESMGR_UNMARSHAL_UINT64( buffer, size, currentPtr, value, rval, exitLoc ) \
     Unmarshal_UINT64( buffer, size, currentPtr, value, rval ); \
     responseRval = ResmgrFixupErrorlevel( *rval ); \
-    if( responseRval != TSS2_RC_SUCCESS ) goto exitLoc; 
+    if( responseRval != TSS2_RC_SUCCESS ) goto exitLoc;
 
 #define RESMGR_UNMARSHAL_SIMPLE_TPM2B( buffer, size, currentPtr, value, rval, exitLoc ) \
     Unmarshal_Simple_TPM2B( buffer, size, currentPtr, value, rval ); \
     responseRval = ResmgrFixupErrorlevel( *rval ); \
-    if( responseRval != TSS2_RC_SUCCESS ) goto exitLoc; 
+    if( responseRval != TSS2_RC_SUCCESS ) goto exitLoc;
 
 #define RESMGR_UNMARSHAL_TPMS_CONTEXT( buffer, size, currentPtr, value, rval, exitLoc ) \
     Unmarshal_UINT64( (buffer), (size), (currentPtr), &( (value)->sequence ), (rval) ); \
@@ -228,7 +228,7 @@ TSS2_RC ResmgrFixupErrorlevel( TSS2_RC errCode )
     if( responseRval != TSS2_RC_SUCCESS ) goto exitLoc; \
     Unmarshal_Simple_TPM2B_NoSizeCheck( (buffer), (size), (currentPtr), (TPM2B *)&( (value)->contextBlob ), (rval) ); \
     responseRval = ResmgrFixupErrorlevel( *rval ); \
-    if( responseRval != TSS2_RC_SUCCESS ) goto exitLoc; 
+    if( responseRval != TSS2_RC_SUCCESS ) goto exitLoc;
 
 //
 // NOTE: these structures are ONLY used for transient objects, sequences, and
@@ -295,8 +295,8 @@ typedef struct RESOURCE_MANAGER_ENTRY_STRUCT {
     // determined by walking up the chain of parents.
     // We chose to add a hierarchy field separate from parentHandle to make the
     // reosurce manager's job easier when change auth commands are done for hiearchies.
-    TPM_HANDLE parentHandle;        // For objects, this is the parent handle. 
-    TPMI_RH_HIERARCHY hierarchy;    // This is the hierarchy for the object. For sessions and 
+    TPM_HANDLE parentHandle;        // For objects, this is the parent handle.
+    TPMI_RH_HIERARCHY hierarchy;    // This is the hierarchy for the object. For sessions and
                                     //  sequences this is set to TPM_RH_NULL.
     TPMS_CONTEXT context;           // For transient objects, this is saved after the object's
                                     //  context is saved.
@@ -349,8 +349,8 @@ static TPMS_CONTEXT cmdObjectContext;
 // shutdownType is saved when Shutdown command is sent.
 // shutdown_state is updated when the Shutdown response is
 //   received if the Shutdown was successful.
-static TPM_SU startupType = 0;  
-static TPM_SU shutdownType = 0;  
+static TPM_SU startupType = 0;
+static TPM_SU shutdownType = 0;
 static BOOL shutdown_state = 0;
 
 static UINT32 maxCmdSize;
@@ -419,7 +419,7 @@ UINT8 IsObjectHandle( TPM_HANDLE handle )
 
     handleType = handle >> 24;
 
-    if( handleType == TPM_HT_TRANSIENT ) 
+    if( handleType == TPM_HT_TRANSIENT )
     {
         return 1;
     }
@@ -459,7 +459,7 @@ void UpdateFreedVirtualHandleCache( TPM_HANDLE virtualHandle )
 {
     TPM_HANDLE *freedHandleArray;
     int i;
-    
+
     if( IsSessionHandle( virtualHandle ) )
     {
         freedHandleArray = freedSessionHandles;
@@ -480,7 +480,7 @@ void UpdateFreedVirtualHandleCache( TPM_HANDLE virtualHandle )
             freedHandleArray[i] = virtualHandle;
             break;
         }
-    } 
+    }
 }
 
 TSS2_RC	GetNewVirtualHandle( TPM_HANDLE realHandle, TPM_HANDLE *newVirtualHandle)
@@ -490,14 +490,14 @@ TSS2_RC	GetNewVirtualHandle( TPM_HANDLE realHandle, TPM_HANDLE *newVirtualHandle
     // This could eventually overrun.  Return an error when that occurs.
     TSS2_RC rval = TSS2_RC_SUCCESS;
     int i;
-    
+
     static UINT32 lastSessionVirtualHandle = 0xffffffff;
     static UINT32 lastObjectVirtualHandle = 0xffffffff;
     UINT8 foundReclaimedHandle = 0;
 
     UINT32 *lastVirtualHandle;
     TPM_HANDLE *freedHandleArray;
-    
+
     if( IsSessionHandle( realHandle ) )
     {
         lastVirtualHandle = &lastSessionVirtualHandle;
@@ -528,7 +528,7 @@ TSS2_RC	GetNewVirtualHandle( TPM_HANDLE realHandle, TPM_HANDLE *newVirtualHandle
     //
     // Didn't choose to do this at this time due to possible performance penalty, but keep in mind for future.
     //
-    
+
     if( !foundReclaimedHandle )
     {
         (*lastVirtualHandle)++;
@@ -594,7 +594,7 @@ TSS2_RC TestForLoadedHandles()
     TSS2_RC rval = TSS2_RC_SUCCESS;
     TPMI_YES_NO moreData;
 	UINT32 i;
-    
+
     ENABLE_RM_TPM_CMD_DEBUG_MSGS;
 
     rval = Tss2_Sys_GetCapability( resMgrSysContext, 0,
@@ -602,7 +602,7 @@ TSS2_RC TestForLoadedHandles()
             20, &moreData, &capabilityData, 0 );
     if( rval != TSS2_RC_SUCCESS )
         goto endTestForLoadedHandles;
-    
+
     if( capabilityData.data.handles.count != 0 )
     {
         DebugPrintf( NO_PREFIX, "Loaded transient object handles: \n" );
@@ -618,7 +618,7 @@ TSS2_RC TestForLoadedHandles()
     if( rval != TSS2_RC_SUCCESS )
         goto endTestForLoadedHandles;
 
-#if 0    
+#if 0
     rval = Tss2_Sys_GetCapability( resMgrSysContext, 0,
             TPM_CAP_HANDLES, TPM_HT_LOADED_SESSION,
             20, &moreData, &capabilityData, 0 );
@@ -637,12 +637,12 @@ TSS2_RC TestForLoadedHandles()
         rval = TSS2_RESMGR_UNLOADED_OBJECTS;
     }
 #endif
-    
+
 endTestForLoadedHandles:
     DISABLE_RM_TPM_CMD_DEBUG_MSGS;
-    
+
     return rval;
-}    
+}
 
 TSS2_RC FlushAllLoadedHandles()
 {
@@ -710,7 +710,7 @@ TSS2_RC AddEntry( TPM_HANDLE virtualHandle, TPM_HANDLE realHandle, TPM_HANDLE pa
     TPMI_RH_HIERARCHY hierarchy, UINT64 connectionId )
 {
     RESOURCE_MANAGER_ENTRY_PTR *entryPtr, newEntry;
-            
+
     // Find end of list
     for( entryPtr = &entryList; *entryPtr != 0; entryPtr = &( (*entryPtr)->nextEntry ) )
         ;
@@ -730,7 +730,7 @@ TSS2_RC AddEntry( TPM_HANDLE virtualHandle, TPM_HANDLE realHandle, TPM_HANDLE pa
     newEntry->status.loaded = 1;
     newEntry->status.stClear = 0;
     newEntry->nextEntry = 0;
-    
+
     return TSS2_RC_SUCCESS;
 }
 
@@ -742,7 +742,7 @@ TSS2_RC RemoveEntry(RESOURCE_MANAGER_ENTRY_PTR entry)
 	{
 	    UpdateFreedVirtualHandleCache( entry->virtualHandle );
 	}
-    
+
     if( entry == entryList )
         entryList = entryList->nextEntry;
     else
@@ -754,7 +754,7 @@ TSS2_RC RemoveEntry(RESOURCE_MANAGER_ENTRY_PTR entry)
 
         (*predEntryPtr)->nextEntry = entry->nextEntry;
     }
-    
+
     (*rmFree)(entry);
 
     return TSS2_RC_SUCCESS;
@@ -774,7 +774,7 @@ TSS2_RC FindEntry(RESOURCE_MANAGER_ENTRY_PTR firstEntry,
     enum findType type, UINT64 matchSpec, RESOURCE_MANAGER_ENTRY_PTR *foundEntryPtr)
 {
     UINT8 foundEntry = 0;
-    
+
     for( *foundEntryPtr = entryList; *foundEntryPtr != 0; *foundEntryPtr = (*foundEntryPtr)->nextEntry )
     {
         if( type == RMFIND_VIRTUAL_HANDLE )
@@ -910,7 +910,7 @@ TSS2_RC EvictContext(TPM_HANDLE virtualHandle)
         if( rval == TSS2_RC_SUCCESS )
         {
             lastSessionSequenceNum = foundEntryPtr->context.sequence;
-        
+
             if( !IsSessionHandle( virtualHandle ) )
             {
                 rval = Tss2_Sys_FlushContext( resMgrSysContext, foundEntryPtr->realHandle );
@@ -947,7 +947,7 @@ TSS2_RC EvictContext(TPM_HANDLE virtualHandle)
 TSS2_RC FindOldestSession(RESOURCE_MANAGER_ENTRY_PTR *oldestSessionEntry)
 {
     TSS2_RC rval = TSS2_RC_SUCCESS;
-    
+
     RESOURCE_MANAGER_ENTRY_PTR currEntry;
 
     *oldestSessionEntry = 0;
@@ -960,7 +960,7 @@ TSS2_RC FindOldestSession(RESOURCE_MANAGER_ENTRY_PTR *oldestSessionEntry)
     {
         if( IsSessionHandle( currEntry->virtualHandle ) )
         {
-            if( ( currEntry->context.sequence & gapMsbBitMask ) == ( lastSessionSequenceNum & gapMsbBitMask ) ) 
+            if( ( currEntry->context.sequence & gapMsbBitMask ) == ( lastSessionSequenceNum & gapMsbBitMask ) )
             {
                 if( currEntry->context.sequence > lastSessionSequenceNum )
                 {
@@ -980,7 +980,7 @@ TSS2_RC FindOldestSession(RESOURCE_MANAGER_ENTRY_PTR *oldestSessionEntry)
         {
             if( IsSessionHandle( currEntry->virtualHandle ) )
             {
-                if( ( currEntry->context.sequence & gapMsbBitMask ) != ( lastSessionSequenceNum & gapMsbBitMask ) ) 
+                if( ( currEntry->context.sequence & gapMsbBitMask ) != ( lastSessionSequenceNum & gapMsbBitMask ) )
                 {
                     if( (*oldestSessionEntry) == 0 || ( currEntry->context.sequence < (*oldestSessionEntry)->context.sequence ) )
                     {
@@ -998,7 +998,7 @@ TSS2_RC FindOldestSession(RESOURCE_MANAGER_ENTRY_PTR *oldestSessionEntry)
         {
             if( IsSessionHandle( currEntry->virtualHandle ) )
             {
-                if( ( currEntry->context.sequence & gapMsbBitMask ) == ( lastSessionSequenceNum & gapMsbBitMask ) ) 
+                if( ( currEntry->context.sequence & gapMsbBitMask ) == ( lastSessionSequenceNum & gapMsbBitMask ) )
                 {
                     if( currEntry->context.sequence < lastSessionSequenceNum )
                     {
@@ -1061,7 +1061,7 @@ TSS2_RC HandleGap()
     // or other logic error.
     if( otherIntervalSessionsCount > gapMaxValue / 2 )
         return TSS2_RESMGR_GAP_HANDLING_FAILED;
-   
+
     // Test to see if gapping actions are needed.
     if( ( otherIntervalSessionsCount != 0 ) &&
             otherIntervalSessionsCount >= currIntervalSequenceNumsLeft )
@@ -1080,10 +1080,10 @@ TSS2_RC HandleGap()
                 {
 #ifdef DEBUG_GAP_HANDLING
                     DebugPrintf( NO_PREFIX, "gap event occurred\n" );
-#endif                
+#endif
                     ENABLE_RM_TPM_CMD_DEBUG_MSGS;
 
-                    // Perform gapping actions 
+                    // Perform gapping actions
                     rval = Tss2_Sys_ContextLoad( resMgrSysContext, &( oldestSessionEntryPtr->context ), &( oldestSessionEntryPtr->realHandle ) );
                     if( rval == TSS2_RC_SUCCESS )
                     {
@@ -1129,7 +1129,7 @@ TSS2_RC LoadContext( TPM_HANDLE virtualHandle, UINT64 connectionId, TPM_HANDLE *
 {
     TSS2_RC rval = 0;
     RESOURCE_MANAGER_ENTRY_PTR foundEntryPtr;
-    
+
     // Find entry corresponding to this virtual handle.
     rval = FindEntry( entryList, RMFIND_VIRTUAL_HANDLE, virtualHandle, &foundEntryPtr );
     if( rval != TSS2_RC_SUCCESS )
@@ -1220,7 +1220,7 @@ void ClearHierarchy( TPMI_RH_HIERARCHY hierarchy )
 {
     RESOURCE_MANAGER_ENTRY_PTR foundEntryPtr, nextEntry;
     TSS2_RC rval;
-    
+
     nextEntry = entryList;
 
     while( nextEntry )
@@ -1261,7 +1261,7 @@ void SendErrorResponse( SOCKET sock )
 void CopyErrorResponse( UINT32 *response_size, uint8_t *response_buffer )
 {
     int i;
-    
+
     for( i = 0; i < sizeof(TPM20_ErrorResponse); i++ )
     {
         response_buffer[i] = ( (UINT8 *)&errorResponse )[i];
@@ -1302,7 +1302,7 @@ TSS2_RC EvictOldestSession()
             DISABLE_RM_TPM_CMD_DEBUG_MSGS;
         }
     }
-    
+
     return rval;
 }
 
@@ -1362,7 +1362,7 @@ TSS2_RC ResourceMgrSendTpmCommand(
     TPM_ST tag;
 	UINT32 authAreaSize;
 	TPM2B_PUBLIC inPublic = { { CHANGE_ENDIAN_DWORD( sizeof( TPM2B_PUBLIC ) - 2), } };
-            
+
     RESMGR_UNMARSHAL_UINT16( command_buffer, command_size, &currentPtr, &tag, &responseRval, SendCommand );
     RESMGR_UNMARSHAL_UINT32( command_buffer, command_size, &currentPtr, 0, &responseRval, SendCommand );
     RESMGR_UNMARSHAL_UINT32( command_buffer, command_size, &currentPtr, &currentCommandCode, &responseRval, SendCommand );
@@ -1372,7 +1372,7 @@ TSS2_RC ResourceMgrSendTpmCommand(
     //
     // DO RESOURCE MGR THINGS.
     //
-    
+
     if( commandDebug == 1 )
     {
         ((TSS2_TCTI_CONTEXT_INTEL *)downstreamTctiContext)->status.debugMsgEnabled = 1;
@@ -1389,20 +1389,20 @@ TSS2_RC ResourceMgrSendTpmCommand(
         // let TPM deal with it.
         goto SendCommand;
     }
-    
+
     for( i = 0; i < numHandles; i++ )
     {
         RESMGR_UNMARSHAL_UINT32( command_buffer, command_size, &currentPtr, &( cmdHandles[i].handle), &responseRval, SendCommand );
         cmdHandles[i].handleNum = i + 1;
     }
-    
+
     // Get list of session handles
     // If sessions are present, record the session handles.
 	i = 0;
     if( tag == TPM_ST_SESSIONS )
     {
         RESMGR_UNMARSHAL_UINT32( command_buffer, command_size, &currentPtr, &authAreaSize, &responseRval, SendCommand );
-        
+
         // Get end of auth area.
         endAuth = (UINT8 *)currentPtr + authAreaSize;
 
@@ -1418,15 +1418,15 @@ TSS2_RC ResourceMgrSendTpmCommand(
 
             RESMGR_UNMARSHAL_UINT8( command_buffer, command_size, &currentPtr, (UINT8 *)&( sessionHandles[i].sessionAttributes ), &responseRval, SendCommand );
             sessionHandles[i].sessionNum = i + 1;
-            
+
             // Skip past auth.
             inPublic.b.size = CHANGE_ENDIAN_WORD( *(UINT16 *)currentPtr );
             RESMGR_UNMARSHAL_SIMPLE_TPM2B( command_buffer, command_size, &currentPtr, 0, &responseRval, SendCommand );
         }
     }
-    
+
     numSessionHandles = i;
-        
+
     responseRval = GetConnectionId( &cmdConnectionId, tctiContext );
     if( responseRval != TSS2_RC_SUCCESS )
         goto SendCommand;
@@ -1446,7 +1446,7 @@ TSS2_RC ResourceMgrSendTpmCommand(
             responseRval = HandleGap();
             if( responseRval != TSS2_RC_SUCCESS )
                 goto SendCommand;
-            
+
             break;
         case TPM_CC_Create:
             cmdParentHandle = cmdHandles[0].handle;
@@ -1507,7 +1507,7 @@ TSS2_RC ResourceMgrSendTpmCommand(
 
             // Skip past inSensitive param.
             RESMGR_UNMARSHAL_SIMPLE_TPM2B( command_buffer, command_size, &currentPtr, 0, &responseRval, SendCommand );
-            
+
             // Unmarshal inPublic and get stClear bit.
             inPublic.b.size = CHANGE_ENDIAN_WORD( *(UINT16 *)currentPtr );
             RESMGR_UNMARSHAL_SIMPLE_TPM2B( command_buffer, command_size, &currentPtr, &( inPublic.b ), &responseRval, SendCommand );
@@ -1592,7 +1592,7 @@ TSS2_RC ResourceMgrSendTpmCommand(
     if( numHandles )
     {
         handlePtr = &( ( (TPM20_Header_In *)command_buffer )->commandCode ) + 1;
-        
+
         for( i = 0; i < numHandles; i ++ )
         {
             if( HandleWeCareAbout( cmdHandles[i].handle ) )
@@ -1625,9 +1625,9 @@ TSS2_RC ResourceMgrSendTpmCommand(
             }
         }
     }
-    
+
 SendCommand:
-  
+
     ((TSS2_TCTI_CONTEXT_INTEL *)downstreamTctiContext )->status.debugMsgEnabled = 0;
 
     if( responseRval == TSS2_RC_SUCCESS )
@@ -1661,7 +1661,7 @@ SendCommand:
         CreateErrorResponse( responseRval );
         rmErrorDuringSend = 1;
     }
-    
+
 #ifdef DEBUG
     PrintRMTables();
 #endif
@@ -1673,7 +1673,7 @@ TSS2_RC EvictEntities( int numHandles, TPM_HANDLE *handles )
 {
     int i;
     TSS2_RC rval = TSS2_RC_SUCCESS;
-    
+
     for( i = 0; i < numHandles; i++ )
     {
         RESOURCE_MANAGER_ENTRY_PTR foundEntryPtr;
@@ -1707,7 +1707,7 @@ TSS2_RC EvictEntities( int numHandles, TPM_HANDLE *handles )
     }
 
 returnFromEvictEntities:
-    
+
     return rval;
 }
 
@@ -1725,8 +1725,8 @@ TSS2_RC ResourceMgrReceiveTpmResponse(
     // exiting if no previous error.
     TPM_RC returnResponseRval = TSS2_RC_SUCCESS;
 
-    TPM_RC testForLoadedSessionsOrObjectsRval = TSS2_RC_SUCCESS; 
-    
+    TPM_RC testForLoadedSessionsOrObjectsRval = TSS2_RC_SUCCESS;
+
     int i;
     TPM_ST tag;
     int numResponseHandles = 0;
@@ -1739,13 +1739,13 @@ TSS2_RC ResourceMgrReceiveTpmResponse(
     TPMA_SESSION sessionAttributes;
 
     currentPtr = response_buffer;
-    
+
     // Evict all objects, sessions, and sequences.  This leaves the TPM
     // in a fresh state, e.g. with none of these things taking up
     // internal RAM.  This means that we never have to react to
     // out of memory errors which makes the resource manager much
     // simpler.
-    
+
     if( *response_size < ( sizeof( TPM20_Header_Out ) - 1 ) )
     {
         responseRval = TSS2_RESMGR_INSUFFICIENT_RESPONSE;
@@ -1778,7 +1778,7 @@ TSS2_RC ResourceMgrReceiveTpmResponse(
         {
             goto returnFromResourceMgrReceiveTpmResponse;
         }
-        
+
         //
         // Get response.
         //
@@ -1805,7 +1805,7 @@ TSS2_RC ResourceMgrReceiveTpmResponse(
             rval = TSS2_TCTI_RC_IO_ERROR;
             goto returnFromResourceMgrReceiveTpmResponse;
         }
-        
+
         ((TSS2_TCTI_CONTEXT_INTEL *)downstreamTctiContext)->status.debugMsgEnabled = 0;
 
         if( rval == TSS2_RC_SUCCESS )
@@ -1813,7 +1813,7 @@ TSS2_RC ResourceMgrReceiveTpmResponse(
             TPM_HANDLE realHandle;
             UINT8 objectContextLoad = 0;
             UINT8 sessionContextLoad = 0;
-            
+
             //
             // Command passed, so do resource manager things.
             //
@@ -1893,7 +1893,7 @@ TSS2_RC ResourceMgrReceiveTpmResponse(
                         {
                             goto returnFromResourceMgrReceiveTpmResponse;
                         }
-                        
+
                         responseRval = FindEntry( entryList, RMFIND_VIRTUAL_HANDLE, newVirtualHandle, &foundEntryPtr);
                         if( responseRval != TSS2_RC_SUCCESS )
                         {
@@ -1901,14 +1901,14 @@ TSS2_RC ResourceMgrReceiveTpmResponse(
                         }
 
                         // Replace real handle with virtual handle in response byte stream.
-                        *( (TPM_HANDLE *) responseHandlePtr ) = 
+                        *( (TPM_HANDLE *) responseHandlePtr ) =
                                 CHANGE_ENDIAN_DWORD( newVirtualHandle );
 
                         if( objectContextLoad )
                         {
                             foundEntryPtr->context = cmdObjectContext;
                         }
-                        
+
                         if( currentCommandCode == TPM_CC_CreatePrimary ||
                                 currentCommandCode == TPM_CC_Load ||
                                 currentCommandCode == TPM_CC_LoadExternal )
@@ -2044,7 +2044,7 @@ TSS2_RC ResourceMgrReceiveTpmResponse(
                 else if( currentCommandCode == TPM_CC_EvictControl )
                 {
                     RESOURCE_MANAGER_ENTRY_PTR foundEntryPtr;
-                    
+
                     if( 0 == PersistentHandle( objectHandle ) )
                     {
                         // Find entry for transient object.
@@ -2070,7 +2070,7 @@ TSS2_RC ResourceMgrReceiveTpmResponse(
                         rval = FindEntry( entryList, RMFIND_REAL_HANDLE, persistentHandle, &foundEntryPtr );
                         if( rval != TSS2_RC_SUCCESS )
                             goto returnFromResourceMgrReceiveTpmResponse;
-                            
+
                         // Need to remove RM entry for persistent copy.
                         rval = RemoveEntry( foundEntryPtr );
                         if( rval != TSS2_RC_SUCCESS )
@@ -2085,9 +2085,9 @@ TSS2_RC ResourceMgrReceiveTpmResponse(
                 if( tag == TPM_ST_SESSIONS )
                 {
                     UINT32 parametersSize;
-                    
+
                     currentPtr = savedCurrentPtr;
-                    
+
                     // Skip past parameters area
                     RESMGR_UNMARSHAL_UINT32( response_buffer, *response_size, &currentPtr, &parametersSize, &responseRval, returnFromResourceMgrReceiveTpmResponse );
                     currentPtr += parametersSize;
@@ -2098,7 +2098,7 @@ TSS2_RC ResourceMgrReceiveTpmResponse(
                     {
                         goto returnFromResourceMgrReceiveTpmResponse;
                     }
-                    
+
                     endAuth = response_buffer + *response_size;
 
                     // Check that we won't run off end of buffer when we get authorizations.
@@ -2107,7 +2107,7 @@ TSS2_RC ResourceMgrReceiveTpmResponse(
                     {
                         goto returnFromResourceMgrReceiveTpmResponse;
                     }
-                    
+
                     // Now walk through sessions and do actions.
                     for( i = 0; currentPtr < endAuth; i++ )
                     {
@@ -2115,14 +2115,14 @@ TSS2_RC ResourceMgrReceiveTpmResponse(
                         RESMGR_UNMARSHAL_SIMPLE_TPM2B( response_buffer, *response_size, &currentPtr, 0, &responseRval, returnFromResourceMgrReceiveTpmResponse );
 
                         RESMGR_UNMARSHAL_UINT8( response_buffer, *response_size, &currentPtr, (UINT8 *)&sessionAttributes, &responseRval, returnFromResourceMgrReceiveTpmResponse );
-                        
+
                         if( HandleWeCareAbout( sessionHandles[i].sessionHandle ) )
                         {
                             if( sessionAttributes.continueSession != sessionHandles[i].sessionAttributes.continueSession )
                                 responseRval = TSS2_RESMGR_CONTINUE_BIT_MISMATCH;
 
                             if( responseRval != TSS2_RC_SUCCESS )
-                                goto returnFromResourceMgrReceiveTpmResponse;   
+                                goto returnFromResourceMgrReceiveTpmResponse;
 
                             responseRval = FindEntry( entryList, RMFIND_VIRTUAL_HANDLE,
                                     sessionHandles[i].sessionHandle, &foundEntryPtr);
@@ -2184,7 +2184,7 @@ returnFromResourceMgrReceiveTpmResponse:
             }
         }
     }
-    
+
     // Now evict the objects, sequences, and sessions used in handles area by the command.
     // If command was FlushContext, the entry was already removed from the list.  No eviction
     // necsssary or possible (because no entry exists for this object or sequence anymore).
@@ -2196,12 +2196,12 @@ returnFromResourceMgrReceiveTpmResponse:
         // Create array of handles.
         TPM_HANDLE usedHandles[3];
         int i;
-        
+
         for( i = 0; i < numHandles; i++ )
         {
             usedHandles[i] = cmdHandles[i].handle;
         }
-        
+
         returnResponseRval = EvictEntities( numHandles, &usedHandles[0] );
 
         if( returnResponseRval != TSS2_RC_SUCCESS )
@@ -2218,7 +2218,7 @@ returnFromResourceMgrReceiveTpmResponse:
 
         // Create a list of virtual handles correpsponding to the real handles returned.
         rspHandles = (TPM_HANDLE *)&( ( (TPM20_Header_Out *)response_buffer )->otherData );
-        
+
         for( i = 0; i < numResponseHandles; i++ )
         {
             returnedHandles[i] = CHANGE_ENDIAN_DWORD( rspHandles[i] );
@@ -2235,15 +2235,15 @@ exitResourceMgrReceiveTpmResponse:
     if( responseRval == TSS2_RC_SUCCESS )
         responseRval = returnResponseRval;
 
-#ifdef DEBUG    
+#ifdef DEBUG
     PrintRMTables();
 #endif
-    
+
     testForLoadedSessionsOrObjectsRval = TestForLoadedHandles();
 
     if( responseRval == TSS2_RC_SUCCESS )
         responseRval = testForLoadedSessionsOrObjectsRval;
-    
+
     if( responseRval != TSS2_RC_SUCCESS )
     {
         // If RM internal error or error from layers below RM occurred,
@@ -2264,7 +2264,7 @@ typedef struct serverStruct
     char *serverName;
     THREAD_TYPE threadHandle;
 } SERVER_STRUCT;
-    
+
 #define MUTEX_DBG_FUNCTION_STR "TpmCmdServer"
 
 UINT8 TpmCmdServer( SERVER_STRUCT *serverStruct )
@@ -2310,7 +2310,7 @@ UINT8 TpmCmdServer( SERVER_STRUCT *serverStruct )
         {
 //            DebugPrintf( NO_PREFIX,  "select passed on socket #0x%x\n", serverStruct->connectSock );
         }
-        
+
         // Receive TPM Send or SESSION end command
         rval = rmRecvBytes( serverStruct->connectSock, (unsigned char*) &sendCmd, 4 );
         if( rval != TSS2_RC_SUCCESS )
@@ -2341,7 +2341,7 @@ UINT8 TpmCmdServer( SERVER_STRUCT *serverStruct )
             if( rval != TSS2_RC_SUCCESS )
             {
                 CreateErrorResponse( TSS2_TCTI_RC_IO_ERROR );
-                SendErrorResponse( serverStruct->connectSock ); 
+                SendErrorResponse( serverStruct->connectSock );
                 continue;
             }
             (( TSS2_TCTI_CONTEXT_INTEL *)downstreamTctiContext )->status.locality = locality;
@@ -2353,7 +2353,7 @@ UINT8 TpmCmdServer( SERVER_STRUCT *serverStruct )
             if( rval != TSS2_RC_SUCCESS )
             {
                 CreateErrorResponse( TSS2_TCTI_RC_IO_ERROR );
-                SendErrorResponse( serverStruct->connectSock ); 
+                SendErrorResponse( serverStruct->connectSock );
                 continue;
             }
 
@@ -2364,7 +2364,7 @@ UINT8 TpmCmdServer( SERVER_STRUCT *serverStruct )
             if( rval != TSS2_RC_SUCCESS )
             {
                 CreateErrorResponse( TSS2_TCTI_RC_IO_ERROR );
-                SendErrorResponse( serverStruct->connectSock ); 
+                SendErrorResponse( serverStruct->connectSock );
                 continue;
             }
 
@@ -2386,7 +2386,7 @@ UINT8 TpmCmdServer( SERVER_STRUCT *serverStruct )
             if( rval != TSS2_RC_SUCCESS )
             {
                 CreateErrorResponse( TSS2_TCTI_RC_IO_ERROR );
-                SendErrorResponse( serverStruct->connectSock ); 
+                SendErrorResponse( serverStruct->connectSock );
             }
             else
             {
@@ -2510,7 +2510,7 @@ UINT8 OtherCmdServer( SERVER_STRUCT *serverStruct )
     int iResult;
     char *functionString = "OtherCmdServer";
     UINT8 criticalSectionEntered;
-    
+
     for(;;)
     {
         FD_ZERO( &readFds );
@@ -2634,7 +2634,7 @@ UINT8 OtherCmdServer( SERVER_STRUCT *serverStruct )
     }
 
 retOtherCmdServer:
-     
+
     printf( "OtherCmdServer died (%s), socket: 0x%x.\n", serverStruct->serverName, serverStruct->connectSock );
 
     if( criticalSectionEntered )
@@ -2649,7 +2649,7 @@ retOtherCmdServer:
     CloseHandle( serverStruct->threadHandle );
    (*rmFree)( serverStruct );
     ExitThread( 0 );
-    
+
     return returnValue;
 }
 
@@ -2662,11 +2662,11 @@ UINT32 WINAPI SockServer( LPVOID servStruct )
 #ifdef  _WIN32
     // do nothing.
 #elif __linux || __unix
-    
+
     int rval = 0;
-#endif    
+#endif
     printf( "Starting SockServer (%s), socket: 0x%x.\n", serverStruct->serverName, serverStruct->connectSock );
-    
+
     do
     {
         cmdServerStruct = (*rmMalloc)( sizeof( SERVER_STRUCT ) );
@@ -2716,7 +2716,7 @@ UINT32 WINAPI SockServer( LPVOID servStruct )
             printf( "Resource Mgr failed to detach a server thread, error #%d.  Warning and continue...\n", rval );
         }
 #else
-#error Unsupported OS--need to add OS-specific support for threading here.        
+#error Unsupported OS--need to add OS-specific support for threading here.
 #endif
     }
     while( continueServer );
@@ -2726,7 +2726,7 @@ UINT32 WINAPI SockServer( LPVOID servStruct )
         printf( "SockServer died (%s), socket: 0x%x.\n", serverStruct->serverName, serverStruct->connectSock );
         ExitThread( 0 );
     }
-    
+
     return continueServer;
 }
 
@@ -2748,13 +2748,13 @@ SOCKET simTpmSock;
 TSS2_RC InitSimulatorTctiContext( TCTI_SOCKET_CONF *tcti_conf, TSS2_TCTI_CONTEXT **tctiContext )
 {
     size_t size;
-    
+
     TSS2_RC rval = TSS2_RC_SUCCESS;
 
     rval = InitSocketTcti(NULL, &size, tcti_conf, 1 );
     if( rval != TSS2_RC_SUCCESS )
         return rval;
-    
+
     *tctiContext = malloc(size);
 
     DebugPrintf( NO_PREFIX, "Initializing %s Interface\n", resSocketTctiName );
@@ -2767,7 +2767,7 @@ TSS2_RC InitResourceMgr( int debugLevel)
     TSS2_RC rval = TSS2_RC_SUCCESS;
     TPMS_CAPABILITY_DATA capabilityData;
     int i;
-    
+
     SetDebug( DBG_COMMAND_RM_TABLES );
 
     DebugPrintf( NO_PREFIX, "Initializing Resource Manager\n" );
@@ -2798,7 +2798,7 @@ TSS2_RC InitResourceMgr( int debugLevel)
             SetRmErrorLevel( &rval, TSS2_RESMGR_ERROR_LEVEL );
             goto returnFromInitResourceMgr;
         }
-    
+
         rval = PlatformCommand( downstreamTctiContext, MS_SIM_NV_ON );
         if( rval != TPM_RC_SUCCESS )
         {
@@ -2806,7 +2806,7 @@ TSS2_RC InitResourceMgr( int debugLevel)
             goto returnFromInitResourceMgr;
         }
     }
-    
+
     // This one should pass.
     rval = Tss2_Sys_Startup( resMgrSysContext, TPM_SU_CLEAR );
     if( rval != TPM_RC_SUCCESS && rval != TPM_RC_INITIALIZE )
@@ -2816,7 +2816,7 @@ TSS2_RC InitResourceMgr( int debugLevel)
     }
 
     // Need to get some capabilities.
-    
+
     // Get max command size.
     rval = Tss2_Sys_GetCapability( resMgrSysContext, 0,
             TPM_CAP_TPM_PROPERTIES, TPM_PT_MAX_COMMAND_SIZE,
@@ -2828,7 +2828,7 @@ TSS2_RC InitResourceMgr( int debugLevel)
         goto returnFromInitResourceMgr;
     }
 
-    if( capabilityData.data.tpmProperties.count == 1 && 
+    if( capabilityData.data.tpmProperties.count == 1 &&
             (capabilityData.data.tpmProperties.tpmProperty[0].property == TPM_PT_MAX_COMMAND_SIZE) )
     {
         maxCmdSize = capabilityData.data.tpmProperties.tpmProperty[0].value;
@@ -2850,7 +2850,7 @@ TSS2_RC InitResourceMgr( int debugLevel)
         goto returnFromInitResourceMgr;
     }
 
-    if( capabilityData.data.tpmProperties.count == 1 && 
+    if( capabilityData.data.tpmProperties.count == 1 &&
             (capabilityData.data.tpmProperties.tpmProperty[0].property == TPM_PT_MAX_RESPONSE_SIZE) )
     {
         maxRspSize = capabilityData.data.tpmProperties.tpmProperty[0].value;
@@ -2872,7 +2872,7 @@ TSS2_RC InitResourceMgr( int debugLevel)
         goto returnFromInitResourceMgr;
     }
 
-    if( capabilityData.data.tpmProperties.count == 1 && 
+    if( capabilityData.data.tpmProperties.count == 1 &&
             (capabilityData.data.tpmProperties.tpmProperty[0].property == TPM_PT_ACTIVE_SESSIONS_MAX) )
     {
         maxActiveSessions = capabilityData.data.tpmProperties.tpmProperty[0].value;
@@ -2893,10 +2893,10 @@ TSS2_RC InitResourceMgr( int debugLevel)
         goto returnFromInitResourceMgr;
     }
 
-    if( capabilityData.data.tpmProperties.count == 1 && 
+    if( capabilityData.data.tpmProperties.count == 1 &&
             (capabilityData.data.tpmProperties.tpmProperty[0].property == TPM_PT_HR_LOADED) )
     {
-#ifndef DEBUG_GAP_HANDLING        
+#ifndef DEBUG_GAP_HANDLING
         maxActiveSessions += capabilityData.data.tpmProperties.tpmProperty[0].value;
 #else
         maxActiveSessions = DEBUG_MAX_ACTIVE_SESSIONS;
@@ -2919,14 +2919,14 @@ TSS2_RC InitResourceMgr( int debugLevel)
         goto returnFromInitResourceMgr;
     }
 
-    if( capabilityData.data.tpmProperties.count == 1 && 
+    if( capabilityData.data.tpmProperties.count == 1 &&
             (capabilityData.data.tpmProperties.tpmProperty[0].property == TPM_PT_CONTEXT_GAP_MAX))
     {
-#ifndef DEBUG_GAP_HANDLING        
+#ifndef DEBUG_GAP_HANDLING
         gapMaxValue = capabilityData.data.tpmProperties.tpmProperty[0].value;
 #else
         gapMaxValue = DEBUG_GAP_MAX;
-#endif        
+#endif
         DebugPrintf( NO_PREFIX, "gapMaxValue = %d\n", gapMaxValue );
     }
     else
@@ -2942,7 +2942,7 @@ TSS2_RC InitResourceMgr( int debugLevel)
         SetRmErrorLevel( &rval, TSS2_RESMGR_ERROR_LEVEL );
         goto returnFromInitResourceMgr;
     }
-    
+
     // Allocate memory for command/response buffers.
     cmdBuffer = (*rmMalloc)( maxCmdSize );
     if( cmdBuffer == 0 )
@@ -2956,9 +2956,9 @@ TSS2_RC InitResourceMgr( int debugLevel)
     lastSessionSequenceNum = 0xffffffffffffffff;
     gapMsbBitMask = (gapMaxValue + 1) >> 1;
     activeSessionCount = 0;
-    
+
 returnFromInitResourceMgr:
-    
+
     DISABLE_RM_TPM_CMD_DEBUG_MSGS;
 
     return rval;
@@ -2971,23 +2971,23 @@ void PrintHelp()
     printf( "Resource manager daemon, Version %s\nUsage:  resourcemgr "
 #if __linux || __unix
             "[-sim] "
-#endif            
+#endif
             "[-tpmhost hostname|ip_addr] [-tpmport port] [-apport port]\n"
             "\n"
             "where:\n"
             "\n"
 #if __linux || __unix
             "-sim tells resource manager to communicate with TPM 2.0 simulator (default: communicates with local TPM; must be specified for running on Windows)\n"
-#endif            
+#endif
             "-tpmhost specifies the host IP address for communicating with the TPM (default: %s; only valid if -sim used)\n"
             "-tpmport specifies the port number for communicating with the TPM (default: %d; only valid if -sim used)\n"
             "-apport specifies the port number for communicating with the calling application (default: %d)\n"
-#ifdef DEBUG            
+#ifdef DEBUG
             "-dbg specifies level of debug messages:\n"
             "   0 (application TPM command send/receive byte streams)\n"
             "   1 (resource manager internal TPM command send/receive byte streams)\n"
             "   2 (resource manager tables)\n"
-#endif            
+#endif
             , version, DEFAULT_HOSTNAME, DEFAULT_SIMULATOR_TPM_PORT, DEFAULT_RESMGR_TPM_PORT );
 }
 
@@ -3011,7 +3011,7 @@ int main(int argc, char* argv[])
 #ifdef  _WIN32
 	SECURITY_ATTRIBUTES mutexAttributes = { sizeof( SECURITY_ATTRIBUTES ), NULL, TRUE };
 #endif
-    
+
     setvbuf (stdout, NULL, _IONBF, BUFSIZ);
     if( argc > MAX_COMMAND_LINE_ARGS )
     {
@@ -3028,7 +3028,7 @@ int main(int argc, char* argv[])
                 simulator = 1;
             }
             else
-#endif                
+#endif
             if( 0 == strcmp( argv[count], "-tpmhost" ) )
             {
                 count++;
@@ -3061,7 +3061,7 @@ int main(int argc, char* argv[])
                     return 1;
                 }
             }
-#ifdef DEBUG            
+#ifdef DEBUG
             else if( 0 == strcmp( argv[count], "-dbg" ) )
             {
                 count++;
@@ -3072,7 +3072,7 @@ int main(int argc, char* argv[])
                     return 1;
                 }
             }
-#endif            
+#endif
             else
             {
                 PrintHelp();
@@ -3086,7 +3086,7 @@ int main(int argc, char* argv[])
             PrintHelp();
             return 1;
         }
-#endif        
+#endif
     }
 #if __linux || __unix
     if( !simulator )
@@ -3106,7 +3106,7 @@ int main(int argc, char* argv[])
         }
     }
     else
-#endif        
+#endif
     {
         rval = InitSimulatorTctiContext( &simInterfaceConfig, &downstreamTctiContext );
         if( rval != TSS2_RC_SUCCESS )
@@ -3122,7 +3122,7 @@ int main(int argc, char* argv[])
         InitSysContextFailure();
         goto initDone;
     }
-    
+
     // Init sysContext for use by marshalling and unmarshalling functions in RM.
     tempSysContext = InitSysContext( 0, downstreamTctiContext, &abiVersion );
     if( tempSysContext == 0 )
@@ -3166,9 +3166,9 @@ int main(int argc, char* argv[])
         return( 1 );
     }
 
-#ifdef DEBUG_RESMGR_INIT        
+#ifdef DEBUG_RESMGR_INIT
     ((TSS2_TCTI_CONTEXT_INTEL *)downstreamTctiContext )->status.debugMsgEnabled = 0;
-#endif        
+#endif
 
     if( 0 != InitSockets( appHostName, appPort, 1, &appOtherSock, &appTpmSock, DebugPrintfCallback, NULL ) )
     {
@@ -3179,7 +3179,7 @@ int main(int argc, char* argv[])
 
     otherCmdServerStruct.connectSock = appOtherSock;
     tpmCmdServerStruct.connectSock = appTpmSock;
-    
+
     // Start socket servers for upstream interface.
 
 #ifdef  _WIN32
@@ -3196,8 +3196,8 @@ int main(int argc, char* argv[])
         printf( "Resource Mgr failed to create OTHER command server thread, error #%d.  Exiting...\n", rval );
     }
 #else
-#error Unsupported OS--need to add OS-specific support for threading here.        
-#endif        
+#error Unsupported OS--need to add OS-specific support for threading here.
+#endif
     else
     {
         SockServer( (LPVOID)&tpmCmdServerStruct );
@@ -3206,11 +3206,11 @@ int main(int argc, char* argv[])
     CloseHandle( sockServerThread );
 
     CloseSockets( appOtherSock, appTpmSock );
-    
+
     CloseHandle( tpmMutex );
 
     TeardownSysContext( &resMgrSysContext );
-    
+
 initDone:
 
     return 0;

--- a/sysapi/include/sysapi_util.h
+++ b/sysapi/include/sysapi_util.h
@@ -57,11 +57,11 @@ typedef struct {
     // rpHash, and for auditing.
     //
     TPM_CC commandCodeSwapped;
-    UINT32 cpBufferUsedSize;        
+    UINT32 cpBufferUsedSize;
     UINT8 *cpBuffer;
     UINT32 *rspParamsSize;  // Points to response paramsSize.
-    UINT32 rpBufferUsedSize;        
-    UINT8 *rpBuffer;  
+    UINT32 rpBufferUsedSize;
+    UINT8 *rpBuffer;
     UINT8 previousStage;            // Used to check for sequencing errors.
     TPM_RC responseCode;
     UINT8 authsCount;
@@ -69,7 +69,7 @@ typedef struct {
     struct
     {
         UINT16 tpmVersionInfoValid:1;  // Identifies whether the TPM version info fields are valid; if not valid
-                                      // this info can't be used for TPM version-specific workarounds.  
+                                      // this info can't be used for TPM version-specific workarounds.
         UINT16 decryptAllowed:1;  // Identifies whether this command supports an encrypted command parameter.
         UINT16 encryptAllowed:1;  // Identifies whether this command supports an encrypted response parameter.
 
@@ -91,7 +91,7 @@ typedef struct {
 
     // Location for next data in command/response buffer.
     UINT8 *nextData;
-    
+
 } _TSS2_SYS_CONTEXT_BLOB;
 
 
@@ -106,7 +106,7 @@ typedef struct _TPM20_Header_In {
   UINT32 commandSize;
   UINT32 commandCode;
 } TPM20_Header_In;
-                              
+
 typedef struct _TPM20_Header_Out {
   TPM_ST tag;
   UINT32 responseSize;
@@ -125,7 +125,7 @@ typedef struct {
   UINT32 commandSize;
   UINT32 commandCode;
 } TPM20_Cmd_Header;
-                              
+
 typedef struct {
   TPM_ST tag;
   UINT32 responseSize;
@@ -147,7 +147,7 @@ typedef struct {
 
 // Utility functions.
 void CopyCommandHeader( _TSS2_SYS_CONTEXT_BLOB *sysContext, TPM_CC commandCode );
-TPM_RC FinishCommand( _TSS2_SYS_CONTEXT_BLOB *sysContext,  
+TPM_RC FinishCommand( _TSS2_SYS_CONTEXT_BLOB *sysContext,
     const TSS2_SYS_CMD_AUTHS *cmdAuthsArray, UINT32 *responseSize );
 
 UINT16 GetDigestSize( TPM_ALG_ID authHash );
@@ -196,7 +196,7 @@ int GetNumResponseHandles( TPM_CC commandCode );
 
 TSS2_SYS_CONTEXT *InitSysContext(
     UINT16 maxCommandSize,
-    TSS2_TCTI_CONTEXT *tctiContext, 
+    TSS2_TCTI_CONTEXT *tctiContext,
     TSS2_ABI_VERSION *abiVersion
  );
 

--- a/sysapi/include/tcti_util.h
+++ b/sysapi/include/tcti_util.h
@@ -35,7 +35,7 @@
 // defined.
 //
 // The first field of a Context must be the common part
-// (see below). 
+// (see below).
 #ifndef TSS2_TCTI_UTIL_H
 #define TSS2_TCTI_UTIL_H
 
@@ -66,7 +66,7 @@ typedef struct {
     TCTI_RECEIVE_PTR receive;
     TSS2_RC (*finalize) (TSS2_TCTI_CONTEXT *tctiContext);
     TSS2_RC (*cancel) (TSS2_TCTI_CONTEXT *tctiContext);
-    TSS2_RC (*getPollHandles) (TSS2_TCTI_CONTEXT *tctiContext, 
+    TSS2_RC (*getPollHandles) (TSS2_TCTI_CONTEXT *tctiContext,
               TSS2_TCTI_POLL_HANDLE *handles, size_t *num_handles);
     TSS2_RC (*setLocality) (TSS2_TCTI_CONTEXT *tctiContext, uint8_t locality);
     struct {
@@ -84,9 +84,9 @@ typedef struct {
     } status;
 
     // Following two fields used to save partial response in case receive buffer's too small.
-    TPM_ST tag;         
+    TPM_ST tag;
     TPM_RC responseSize;
-    
+
     TSS2_TCTI_CONTEXT *currentTctiContext;
 
     // Sockets if socket interface is being used.
@@ -95,7 +95,7 @@ typedef struct {
     SOCKET currentConnectSock;
 
     // File descriptor for device file if real TPM is being used.
-    int devFile;  
+    int devFile;
     UINT8 previousStage;            // Used to check for sequencing errors.
     unsigned char responseBuffer[4096];
     TCTI_LOG_CALLBACK logCallback;

--- a/sysapi/sysapi/ContextManagement.c
+++ b/sysapi/sysapi/ContextManagement.c
@@ -44,12 +44,12 @@ size_t Tss2_Sys_GetContextSize(size_t maxCommandSize)
 TSS2_RC Tss2_Sys_Initialize(
     TSS2_SYS_CONTEXT *sysContext,
     size_t contextSize,
-    TSS2_TCTI_CONTEXT *tctiContext, 
+    TSS2_TCTI_CONTEXT *tctiContext,
     TSS2_ABI_VERSION *abiVersion
     )
 {
     TSS2_RC rval = TSS2_RC_SUCCESS;
-    
+
     if( sysContext == NULL || tctiContext == NULL || abiVersion == NULL )
     {
         rval = TSS2_SYS_RC_BAD_REFERENCE;
@@ -68,11 +68,11 @@ TSS2_RC Tss2_Sys_Initialize(
         rval = TSS2_SYS_RC_BAD_TCTI_STRUCTURE;
         goto end_Tss2_Sys_Initialize;
     }
-    
+
     // Checks for ABI negotiation.
     if( abiVersion->tssCreator != TSSWG_INTEROP ||
-        abiVersion->tssFamily != TSS_SAPI_FIRST_FAMILY ||     
-        abiVersion->tssLevel != TSS_SAPI_FIRST_LEVEL ||     
+        abiVersion->tssFamily != TSS_SAPI_FIRST_FAMILY ||
+        abiVersion->tssLevel != TSS_SAPI_FIRST_LEVEL ||
         abiVersion->tssVersion != TSS_SAPI_FIRST_LEVEL )
     {
         rval = TSS2_SYS_RC_ABI_MISMATCH;
@@ -94,8 +94,8 @@ TSS2_RC Tss2_Sys_Initialize(
 
         SYS_CONTEXT->previousStage = CMD_STAGE_INITIALIZE;
     }
-        
-end_Tss2_Sys_Initialize:    
+
+end_Tss2_Sys_Initialize:
     return rval;
 }
 

--- a/sysapi/sysapi/DecryptParam.c
+++ b/sysapi/sysapi/DecryptParam.c
@@ -36,7 +36,7 @@ TSS2_RC Tss2_Sys_GetDecryptParam(
 {
     TSS2_RC rval = TSS2_RC_SUCCESS;
     TPM2B *decryptParam;
-    
+
     if( decryptParamSize == 0 || decryptParamBuffer == 0 || sysContext == 0 )
     {
         rval = TSS2_SYS_RC_BAD_REFERENCE;
@@ -62,7 +62,7 @@ TSS2_RC Tss2_Sys_GetDecryptParam(
 
 
 TSS2_RC Tss2_Sys_SetDecryptParam(
-	TSS2_SYS_CONTEXT 		*sysContext, 
+	TSS2_SYS_CONTEXT 		*sysContext,
 	size_t                  decryptParamSize,
 	const uint8_t			*decryptParamBuffer
 )
@@ -72,7 +72,7 @@ TSS2_RC Tss2_Sys_SetDecryptParam(
     TSS2_RC         rval = TSS2_RC_SUCCESS;
     UINT32          sizeToBeUsed;
     UINT32          currCommandSize;
-    
+
     if( decryptParamBuffer == 0 || sysContext == 0 )
     {
         rval = TSS2_SYS_RC_BAD_REFERENCE;
@@ -139,6 +139,6 @@ TSS2_RC Tss2_Sys_SetDecryptParam(
         }
     }
 
-exitTss2_Sys_SetDecryptParam:    
+exitTss2_Sys_SetDecryptParam:
     return rval;
 }

--- a/sysapi/sysapi/EncryptParam.c
+++ b/sysapi/sysapi/EncryptParam.c
@@ -37,7 +37,7 @@ TSS2_RC Tss2_Sys_GetEncryptParam(
     TSS2_RC rval = TSS2_RC_SUCCESS;
     TPM2B *encryptParam;
     void *otherData;
-    
+
     if( encryptParamSize == 0 || encryptParamBuffer == 0 || sysContext == 0 )
     {
         rval = TSS2_SYS_RC_BAD_REFERENCE;
@@ -55,7 +55,7 @@ TSS2_RC Tss2_Sys_GetEncryptParam(
     {
         // Get first parameter and return its
         // size and a pointer to it.
-        otherData = SYS_CONTEXT->rspParamsSize;        
+        otherData = SYS_CONTEXT->rspParamsSize;
         SYS_CONTEXT->rpBuffer = otherData;
         SYS_CONTEXT->rpBuffer += 4; // Skip over params size field.
         encryptParam = (TPM2B *)( SYS_CONTEXT->rpBuffer );
@@ -98,6 +98,6 @@ TSS2_RC Tss2_Sys_SetEncryptParam(
             }
         }
     }
-    
+
     return rval;
 }

--- a/sysapi/sysapi/GetCommandCode.c
+++ b/sysapi/sysapi/GetCommandCode.c
@@ -30,11 +30,11 @@
 
 TSS2_RC Tss2_Sys_GetCommandCode(
     TSS2_SYS_CONTEXT *sysContext,
-    UINT8 (*commandCode)[4]  
+    UINT8 (*commandCode)[4]
     )
 {
     TSS2_RC rval = TSS2_RC_SUCCESS;
-    
+
     if( sysContext == NULL || commandCode == NULL )
     {
         rval = TSS2_SYS_RC_BAD_REFERENCE;
@@ -47,6 +47,6 @@ TSS2_RC Tss2_Sys_GetCommandCode(
     {
         *(UINT32 *)*commandCode = CHANGE_ENDIAN_DWORD( SYS_CONTEXT->commandCodeSwapped );
     }
-    
+
     return( rval );
 }

--- a/sysapi/sysapi/GetTctiContext.c
+++ b/sysapi/sysapi/GetTctiContext.c
@@ -34,7 +34,7 @@ TSS2_RC Tss2_Sys_GetTctiContext(
     )
 {
     TSS2_RC rval = TSS2_RC_SUCCESS;
-    
+
     if( sysContext == 0 || tctiContext == 0 )
     {
         rval = TSS2_SYS_RC_BAD_REFERENCE;

--- a/sysapi/sysapi/Tss2_Sys_ActivateCredential.c
+++ b/sysapi/sysapi/Tss2_Sys_ActivateCredential.c
@@ -41,7 +41,7 @@ TPM_RC Tss2_Sys_ActivateCredential_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_ActivateCredential );
 
@@ -53,7 +53,7 @@ TPM_RC Tss2_Sys_ActivateCredential_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( credentialBlob->b ) );
 
     MARSHAL_SIMPLE_TPM2B( sysContext, &( secret->b ) );
@@ -97,10 +97,10 @@ TPM_RC Tss2_Sys_ActivateCredential(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_ActivateCredential_Prepare( sysContext, activateHandle, keyHandle, credentialBlob, secret );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -110,7 +110,7 @@ TPM_RC Tss2_Sys_ActivateCredential(
             rval = Tss2_Sys_ActivateCredential_Complete( sysContext, certInfo );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_Certify.c
+++ b/sysapi/sysapi/Tss2_Sys_Certify.c
@@ -44,7 +44,7 @@ TPM_RC Tss2_Sys_Certify_Prepare(
     if( inScheme == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     CommonPreparePrologue( sysContext, TPM_CC_Certify );
 
@@ -56,7 +56,7 @@ TPM_RC Tss2_Sys_Certify_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( qualifyingData->b ) );
 
     Marshal_TPMT_SIG_SCHEME( sysContext, inScheme );
@@ -107,10 +107,10 @@ TPM_RC Tss2_Sys_Certify(
     if( inScheme == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     rval = Tss2_Sys_Certify_Prepare( sysContext, objectHandle, signHandle, qualifyingData, inScheme );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -120,7 +120,7 @@ TPM_RC Tss2_Sys_Certify(
             rval = Tss2_Sys_Certify_Complete( sysContext, certifyInfo, signature );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_CertifyCreation.c
+++ b/sysapi/sysapi/Tss2_Sys_CertifyCreation.c
@@ -46,7 +46,7 @@ TPM_RC Tss2_Sys_CertifyCreation_Prepare(
     if( inScheme == NULL  || creationTicket == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     CommonPreparePrologue( sysContext, TPM_CC_CertifyCreation );
 
@@ -58,7 +58,7 @@ TPM_RC Tss2_Sys_CertifyCreation_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( qualifyingData->b ) );
 
     MARSHAL_SIMPLE_TPM2B( sysContext, &( creationHash->b ) );
@@ -115,10 +115,10 @@ TPM_RC Tss2_Sys_CertifyCreation(
     if( inScheme == NULL  || creationTicket == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     rval = Tss2_Sys_CertifyCreation_Prepare( sysContext, signHandle, objectHandle, qualifyingData, creationHash, inScheme, creationTicket );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -128,7 +128,7 @@ TPM_RC Tss2_Sys_CertifyCreation(
             rval = Tss2_Sys_CertifyCreation_Complete( sysContext, certifyInfo, signature );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_ChangeEPS.c
+++ b/sysapi/sysapi/Tss2_Sys_ChangeEPS.c
@@ -38,14 +38,14 @@ TPM_RC Tss2_Sys_ChangeEPS_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_ChangeEPS );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), authHandle, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     SYS_CONTEXT->decryptAllowed = 0;
     SYS_CONTEXT->encryptAllowed = 0;
     SYS_CONTEXT->authAllowed = 1;
@@ -65,15 +65,15 @@ TPM_RC Tss2_Sys_ChangeEPS(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_ChangeEPS_Prepare( sysContext, authHandle );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_ChangePPS.c
+++ b/sysapi/sysapi/Tss2_Sys_ChangePPS.c
@@ -38,14 +38,14 @@ TPM_RC Tss2_Sys_ChangePPS_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_ChangePPS );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), authHandle, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     SYS_CONTEXT->decryptAllowed = 0;
     SYS_CONTEXT->encryptAllowed = 0;
     SYS_CONTEXT->authAllowed = 1;
@@ -65,15 +65,15 @@ TPM_RC Tss2_Sys_ChangePPS(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_ChangePPS_Prepare( sysContext, authHandle );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_Clear.c
+++ b/sysapi/sysapi/Tss2_Sys_Clear.c
@@ -38,14 +38,14 @@ TPM_RC Tss2_Sys_Clear_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_Clear );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), authHandle, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     SYS_CONTEXT->decryptAllowed = 0;
     SYS_CONTEXT->encryptAllowed = 0;
     SYS_CONTEXT->authAllowed = 1;
@@ -65,15 +65,15 @@ TPM_RC Tss2_Sys_Clear(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_Clear_Prepare( sysContext, authHandle );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_ClearControl.c
+++ b/sysapi/sysapi/Tss2_Sys_ClearControl.c
@@ -39,14 +39,14 @@ TPM_RC Tss2_Sys_ClearControl_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_ClearControl );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), auth, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     Marshal_UINT8( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), disable, &(SYS_CONTEXT->rval) );
 
     SYS_CONTEXT->decryptAllowed = 0;
@@ -69,15 +69,15 @@ TPM_RC Tss2_Sys_ClearControl(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_ClearControl_Prepare( sysContext, auth, disable );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_ClockRateAdjust.c
+++ b/sysapi/sysapi/Tss2_Sys_ClockRateAdjust.c
@@ -39,14 +39,14 @@ TPM_RC Tss2_Sys_ClockRateAdjust_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_ClockRateAdjust );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), auth, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     Marshal_UINT8( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), rateAdjust, &(SYS_CONTEXT->rval) );
 
     SYS_CONTEXT->decryptAllowed = 0;
@@ -69,15 +69,15 @@ TPM_RC Tss2_Sys_ClockRateAdjust(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_ClockRateAdjust_Prepare( sysContext, auth, rateAdjust );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_ClockSet.c
+++ b/sysapi/sysapi/Tss2_Sys_ClockSet.c
@@ -39,14 +39,14 @@ TPM_RC Tss2_Sys_ClockSet_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_ClockSet );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), auth, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     Marshal_UINT64( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), newTime, &(SYS_CONTEXT->rval) );
 
     SYS_CONTEXT->decryptAllowed = 0;
@@ -69,15 +69,15 @@ TPM_RC Tss2_Sys_ClockSet(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_ClockSet_Prepare( sysContext, auth, newTime );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_Commit.c
+++ b/sysapi/sysapi/Tss2_Sys_Commit.c
@@ -41,7 +41,7 @@ TPM_RC Tss2_Sys_Commit_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_Commit );
 
@@ -51,7 +51,7 @@ TPM_RC Tss2_Sys_Commit_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     Marshal_TPM2B_ECC_POINT( sysContext, P1 );
 
     MARSHAL_SIMPLE_TPM2B( sysContext, &( s2->b ) );
@@ -109,10 +109,10 @@ TPM_RC Tss2_Sys_Commit(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_Commit_Prepare( sysContext, signHandle, P1, s2, y2 );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -122,7 +122,7 @@ TPM_RC Tss2_Sys_Commit(
             rval = Tss2_Sys_Commit_Complete( sysContext, K, L, E, counter );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_ContextLoad.c
+++ b/sysapi/sysapi/Tss2_Sys_ContextLoad.c
@@ -41,12 +41,12 @@ TPM_RC Tss2_Sys_ContextLoad_Prepare(
     if( context == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     CommonPreparePrologue( sysContext, TPM_CC_ContextLoad );
 
-    
-            
+
+
     Marshal_TPMS_CONTEXT( sysContext, context );
 
     SYS_CONTEXT->decryptAllowed = 0;
@@ -86,10 +86,10 @@ TPM_RC Tss2_Sys_ContextLoad(
     if( context == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     rval = Tss2_Sys_ContextLoad_Prepare( sysContext, context );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, 0, 0 );
@@ -99,7 +99,7 @@ TPM_RC Tss2_Sys_ContextLoad(
             rval = Tss2_Sys_ContextLoad_Complete( sysContext, loadedHandle );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_ContextSave.c
+++ b/sysapi/sysapi/Tss2_Sys_ContextSave.c
@@ -38,14 +38,14 @@ TPM_RC Tss2_Sys_ContextSave_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_ContextSave );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), saveHandle, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     SYS_CONTEXT->decryptAllowed = 0;
     SYS_CONTEXT->encryptAllowed = 0;
     SYS_CONTEXT->authAllowed = 0;
@@ -80,10 +80,10 @@ TPM_RC Tss2_Sys_ContextSave(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_ContextSave_Prepare( sysContext, saveHandle );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, 0, 0 );
@@ -93,7 +93,7 @@ TPM_RC Tss2_Sys_ContextSave(
             rval = Tss2_Sys_ContextSave_Complete( sysContext, context );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_Create.c
+++ b/sysapi/sysapi/Tss2_Sys_Create.c
@@ -45,7 +45,7 @@ TPM_RC Tss2_Sys_Create_Prepare(
     if( creationPCR == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     CommonPreparePrologue( sysContext, TPM_CC_Create );
 
@@ -55,7 +55,7 @@ TPM_RC Tss2_Sys_Create_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     Marshal_TPM2B_SENSITIVE_CREATE( sysContext, inSensitive );
 
     Marshal_TPM2B_PUBLIC( sysContext, inPublic );
@@ -123,10 +123,10 @@ TPM_RC Tss2_Sys_Create(
     if( creationPCR == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     rval = Tss2_Sys_Create_Prepare( sysContext, parentHandle, inSensitive, inPublic, outsideInfo, creationPCR );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -136,7 +136,7 @@ TPM_RC Tss2_Sys_Create(
             rval = Tss2_Sys_Create_Complete( sysContext, outPrivate, outPublic, creationData, creationHash, creationTicket );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_CreatePrimary.c
+++ b/sysapi/sysapi/Tss2_Sys_CreatePrimary.c
@@ -45,7 +45,7 @@ TPM_RC Tss2_Sys_CreatePrimary_Prepare(
     if( creationPCR == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     CommonPreparePrologue( sysContext, TPM_CC_CreatePrimary );
 
@@ -55,7 +55,7 @@ TPM_RC Tss2_Sys_CreatePrimary_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     Marshal_TPM2B_SENSITIVE_CREATE( sysContext, inSensitive );
 
     Marshal_TPM2B_PUBLIC( sysContext, inPublic );
@@ -127,10 +127,10 @@ TPM_RC Tss2_Sys_CreatePrimary(
     if( creationPCR == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     rval = Tss2_Sys_CreatePrimary_Prepare( sysContext, primaryHandle, inSensitive, inPublic, outsideInfo, creationPCR );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -140,7 +140,7 @@ TPM_RC Tss2_Sys_CreatePrimary(
             rval = Tss2_Sys_CreatePrimary_Complete( sysContext, objectHandle, outPublic, creationData, creationHash, creationTicket, name );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_DictionaryAttackLockReset.c
+++ b/sysapi/sysapi/Tss2_Sys_DictionaryAttackLockReset.c
@@ -38,14 +38,14 @@ TPM_RC Tss2_Sys_DictionaryAttackLockReset_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_DictionaryAttackLockReset );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), lockHandle, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     SYS_CONTEXT->decryptAllowed = 0;
     SYS_CONTEXT->encryptAllowed = 0;
     SYS_CONTEXT->authAllowed = 1;
@@ -65,15 +65,15 @@ TPM_RC Tss2_Sys_DictionaryAttackLockReset(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_DictionaryAttackLockReset_Prepare( sysContext, lockHandle );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_DictionaryAttackParameters.c
+++ b/sysapi/sysapi/Tss2_Sys_DictionaryAttackParameters.c
@@ -41,14 +41,14 @@ TPM_RC Tss2_Sys_DictionaryAttackParameters_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_DictionaryAttackParameters );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), lockHandle, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), newMaxTries, &(SYS_CONTEXT->rval) );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), newRecoveryTime, &(SYS_CONTEXT->rval) );
@@ -77,15 +77,15 @@ TPM_RC Tss2_Sys_DictionaryAttackParameters(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_DictionaryAttackParameters_Prepare( sysContext, lockHandle, newMaxTries, newRecoveryTime, lockoutRecovery );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_Duplicate.c
+++ b/sysapi/sysapi/Tss2_Sys_Duplicate.c
@@ -44,7 +44,7 @@ TPM_RC Tss2_Sys_Duplicate_Prepare(
     if( symmetricAlg == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     CommonPreparePrologue( sysContext, TPM_CC_Duplicate );
 
@@ -56,7 +56,7 @@ TPM_RC Tss2_Sys_Duplicate_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( encryptionKeyIn->b ) );
 
     Marshal_TPMT_SYM_DEF_OBJECT( sysContext, symmetricAlg );
@@ -111,10 +111,10 @@ TPM_RC Tss2_Sys_Duplicate(
     if( symmetricAlg == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     rval = Tss2_Sys_Duplicate_Prepare( sysContext, objectHandle, newParentHandle, encryptionKeyIn, symmetricAlg );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -124,7 +124,7 @@ TPM_RC Tss2_Sys_Duplicate(
             rval = Tss2_Sys_Duplicate_Complete( sysContext, encryptionKeyOut, duplicate, outSymSeed );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_ECC_Parameters.c
+++ b/sysapi/sysapi/Tss2_Sys_ECC_Parameters.c
@@ -38,12 +38,12 @@ TPM_RC Tss2_Sys_ECC_Parameters_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_ECC_Parameters );
 
-    
-            
+
+
     Marshal_UINT16( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), curveID, &(SYS_CONTEXT->rval) );
 
     SYS_CONTEXT->decryptAllowed = 0;
@@ -82,10 +82,10 @@ TPM_RC Tss2_Sys_ECC_Parameters(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_ECC_Parameters_Prepare( sysContext, curveID );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -95,7 +95,7 @@ TPM_RC Tss2_Sys_ECC_Parameters(
             rval = Tss2_Sys_ECC_Parameters_Complete( sysContext, parameters );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_ECDH_KeyGen.c
+++ b/sysapi/sysapi/Tss2_Sys_ECDH_KeyGen.c
@@ -38,14 +38,14 @@ TPM_RC Tss2_Sys_ECDH_KeyGen_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_ECDH_KeyGen );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), keyHandle, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     SYS_CONTEXT->decryptAllowed = 0;
     SYS_CONTEXT->encryptAllowed = 1;
     SYS_CONTEXT->authAllowed = 1;
@@ -86,10 +86,10 @@ TPM_RC Tss2_Sys_ECDH_KeyGen(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_ECDH_KeyGen_Prepare( sysContext, keyHandle );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -99,7 +99,7 @@ TPM_RC Tss2_Sys_ECDH_KeyGen(
             rval = Tss2_Sys_ECDH_KeyGen_Complete( sysContext, zPoint, pubPoint );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_ECDH_ZGen.c
+++ b/sysapi/sysapi/Tss2_Sys_ECDH_ZGen.c
@@ -39,14 +39,14 @@ TPM_RC Tss2_Sys_ECDH_ZGen_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_ECDH_ZGen );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), keyHandle, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     Marshal_TPM2B_ECC_POINT( sysContext, inPoint );
 
     SYS_CONTEXT->decryptAllowed = 1;
@@ -86,10 +86,10 @@ TPM_RC Tss2_Sys_ECDH_ZGen(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_ECDH_ZGen_Prepare( sysContext, keyHandle, inPoint );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -99,7 +99,7 @@ TPM_RC Tss2_Sys_ECDH_ZGen(
             rval = Tss2_Sys_ECDH_ZGen_Complete( sysContext, outPoint );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_EC_Ephemeral.c
+++ b/sysapi/sysapi/Tss2_Sys_EC_Ephemeral.c
@@ -38,12 +38,12 @@ TPM_RC Tss2_Sys_EC_Ephemeral_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_EC_Ephemeral );
 
-    
-            
+
+
     Marshal_UINT16( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), curveID, &(SYS_CONTEXT->rval) );
 
     SYS_CONTEXT->decryptAllowed = 0;
@@ -86,10 +86,10 @@ TPM_RC Tss2_Sys_EC_Ephemeral(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_EC_Ephemeral_Prepare( sysContext, curveID );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -99,7 +99,7 @@ TPM_RC Tss2_Sys_EC_Ephemeral(
             rval = Tss2_Sys_EC_Ephemeral_Complete( sysContext, Q, counter );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_EncryptDecrypt.c
+++ b/sysapi/sysapi/Tss2_Sys_EncryptDecrypt.c
@@ -42,14 +42,14 @@ TPM_RC Tss2_Sys_EncryptDecrypt_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_EncryptDecrypt );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), keyHandle, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     Marshal_UINT8( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), decrypt, &(SYS_CONTEXT->rval) );
 
     Marshal_UINT16( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), mode, &(SYS_CONTEXT->rval) );
@@ -102,10 +102,10 @@ TPM_RC Tss2_Sys_EncryptDecrypt(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_EncryptDecrypt_Prepare( sysContext, keyHandle, decrypt, mode, ivIn, inData );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -115,7 +115,7 @@ TPM_RC Tss2_Sys_EncryptDecrypt(
             rval = Tss2_Sys_EncryptDecrypt_Complete( sysContext, outData, ivOut );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_EventSequenceComplete.c
+++ b/sysapi/sysapi/Tss2_Sys_EventSequenceComplete.c
@@ -40,7 +40,7 @@ TPM_RC Tss2_Sys_EventSequenceComplete_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_EventSequenceComplete );
 
@@ -48,8 +48,8 @@ TPM_RC Tss2_Sys_EventSequenceComplete_Prepare(
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), sequenceHandle, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( buffer->b ) );
 
     SYS_CONTEXT->decryptAllowed = 1;
@@ -90,10 +90,10 @@ TPM_RC Tss2_Sys_EventSequenceComplete(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_EventSequenceComplete_Prepare( sysContext, pcrHandle, sequenceHandle, buffer );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -103,7 +103,7 @@ TPM_RC Tss2_Sys_EventSequenceComplete(
             rval = Tss2_Sys_EventSequenceComplete_Complete( sysContext, results );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_EvictControl.c
+++ b/sysapi/sysapi/Tss2_Sys_EvictControl.c
@@ -40,7 +40,7 @@ TPM_RC Tss2_Sys_EvictControl_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_EvictControl );
 
@@ -48,8 +48,8 @@ TPM_RC Tss2_Sys_EvictControl_Prepare(
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), objectHandle, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), persistentHandle, &(SYS_CONTEXT->rval) );
 
     SYS_CONTEXT->decryptAllowed = 0;
@@ -73,15 +73,15 @@ TPM_RC Tss2_Sys_EvictControl(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_EvictControl_Prepare( sysContext, auth, objectHandle, persistentHandle );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_FieldUpgradeData.c
+++ b/sysapi/sysapi/Tss2_Sys_FieldUpgradeData.c
@@ -38,12 +38,12 @@ TPM_RC Tss2_Sys_FieldUpgradeData_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_FieldUpgradeData );
 
-    
-            
+
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( fuData->b ) );
 
     SYS_CONTEXT->decryptAllowed = 1;
@@ -86,10 +86,10 @@ TPM_RC Tss2_Sys_FieldUpgradeData(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_FieldUpgradeData_Prepare( sysContext, fuData );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -99,7 +99,7 @@ TPM_RC Tss2_Sys_FieldUpgradeData(
             rval = Tss2_Sys_FieldUpgradeData_Complete( sysContext, nextDigest, firstDigest );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_FieldUpgradeStart.c
+++ b/sysapi/sysapi/Tss2_Sys_FieldUpgradeStart.c
@@ -44,7 +44,7 @@ TPM_RC Tss2_Sys_FieldUpgradeStart_Prepare(
     if( manifestSignature == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     CommonPreparePrologue( sysContext, TPM_CC_FieldUpgradeStart );
 
@@ -56,7 +56,7 @@ TPM_RC Tss2_Sys_FieldUpgradeStart_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( fuDigest->b ) );
 
     Marshal_TPMT_SIGNATURE( sysContext, manifestSignature );
@@ -86,15 +86,15 @@ TPM_RC Tss2_Sys_FieldUpgradeStart(
     if( manifestSignature == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     rval = Tss2_Sys_FieldUpgradeStart_Prepare( sysContext, authorization, keyHandle, fuDigest, manifestSignature );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_FirmwareRead.c
+++ b/sysapi/sysapi/Tss2_Sys_FirmwareRead.c
@@ -38,12 +38,12 @@ TPM_RC Tss2_Sys_FirmwareRead_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_FirmwareRead );
 
-    
-            
+
+
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), sequenceNumber, &(SYS_CONTEXT->rval) );
 
     SYS_CONTEXT->decryptAllowed = 0;
@@ -82,10 +82,10 @@ TPM_RC Tss2_Sys_FirmwareRead(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_FirmwareRead_Prepare( sysContext, sequenceNumber );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -95,7 +95,7 @@ TPM_RC Tss2_Sys_FirmwareRead(
             rval = Tss2_Sys_FirmwareRead_Complete( sysContext, fuData );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_FlushContext.c
+++ b/sysapi/sysapi/Tss2_Sys_FlushContext.c
@@ -38,14 +38,14 @@ TPM_RC Tss2_Sys_FlushContext_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_FlushContext );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), flushHandle, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     SYS_CONTEXT->decryptAllowed = 0;
     SYS_CONTEXT->encryptAllowed = 0;
     SYS_CONTEXT->authAllowed = 0;
@@ -63,15 +63,15 @@ TPM_RC Tss2_Sys_FlushContext(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_FlushContext_Prepare( sysContext, flushHandle );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, 0, 0 );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_GetCapability.c
+++ b/sysapi/sysapi/Tss2_Sys_GetCapability.c
@@ -40,12 +40,12 @@ TPM_RC Tss2_Sys_GetCapability_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_GetCapability );
 
-    
-            
+
+
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), capability, &(SYS_CONTEXT->rval) );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), property, &(SYS_CONTEXT->rval) );
@@ -94,10 +94,10 @@ TPM_RC Tss2_Sys_GetCapability(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_GetCapability_Prepare( sysContext, capability, property, propertyCount );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -107,7 +107,7 @@ TPM_RC Tss2_Sys_GetCapability(
             rval = Tss2_Sys_GetCapability_Complete( sysContext, moreData, capabilityData );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_GetCommandAuditDigest.c
+++ b/sysapi/sysapi/Tss2_Sys_GetCommandAuditDigest.c
@@ -44,7 +44,7 @@ TPM_RC Tss2_Sys_GetCommandAuditDigest_Prepare(
     if( inScheme == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     CommonPreparePrologue( sysContext, TPM_CC_GetCommandAuditDigest );
 
@@ -56,7 +56,7 @@ TPM_RC Tss2_Sys_GetCommandAuditDigest_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( qualifyingData->b ) );
 
     Marshal_TPMT_SIG_SCHEME( sysContext, inScheme );
@@ -107,10 +107,10 @@ TPM_RC Tss2_Sys_GetCommandAuditDigest(
     if( inScheme == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     rval = Tss2_Sys_GetCommandAuditDigest_Prepare( sysContext, privacyHandle, signHandle, qualifyingData, inScheme );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -120,7 +120,7 @@ TPM_RC Tss2_Sys_GetCommandAuditDigest(
             rval = Tss2_Sys_GetCommandAuditDigest_Complete( sysContext, auditInfo, signature );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_GetRandom.c
+++ b/sysapi/sysapi/Tss2_Sys_GetRandom.c
@@ -38,12 +38,12 @@ TPM_RC Tss2_Sys_GetRandom_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_GetRandom );
 
-    
-            
+
+
     Marshal_UINT16( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), bytesRequested, &(SYS_CONTEXT->rval) );
 
     SYS_CONTEXT->decryptAllowed = 0;
@@ -82,10 +82,10 @@ TPM_RC Tss2_Sys_GetRandom(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_GetRandom_Prepare( sysContext, bytesRequested );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -95,7 +95,7 @@ TPM_RC Tss2_Sys_GetRandom(
             rval = Tss2_Sys_GetRandom_Complete( sysContext, randomBytes );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_GetSessionAuditDigest.c
+++ b/sysapi/sysapi/Tss2_Sys_GetSessionAuditDigest.c
@@ -45,7 +45,7 @@ TPM_RC Tss2_Sys_GetSessionAuditDigest_Prepare(
     if( inScheme == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     CommonPreparePrologue( sysContext, TPM_CC_GetSessionAuditDigest );
 
@@ -59,7 +59,7 @@ TPM_RC Tss2_Sys_GetSessionAuditDigest_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( qualifyingData->b ) );
 
     Marshal_TPMT_SIG_SCHEME( sysContext, inScheme );
@@ -111,10 +111,10 @@ TPM_RC Tss2_Sys_GetSessionAuditDigest(
     if( inScheme == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     rval = Tss2_Sys_GetSessionAuditDigest_Prepare( sysContext, privacyAdminHandle, signHandle, sessionHandle, qualifyingData, inScheme );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -124,7 +124,7 @@ TPM_RC Tss2_Sys_GetSessionAuditDigest(
             rval = Tss2_Sys_GetSessionAuditDigest_Complete( sysContext, auditInfo, signature );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_GetTestResult.c
+++ b/sysapi/sysapi/Tss2_Sys_GetTestResult.c
@@ -37,12 +37,12 @@ TPM_RC Tss2_Sys_GetTestResult_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_GetTestResult );
 
-    
-            
+
+
     SYS_CONTEXT->decryptAllowed = 0;
     SYS_CONTEXT->encryptAllowed = 1;
     SYS_CONTEXT->authAllowed = 1;
@@ -82,10 +82,10 @@ TPM_RC Tss2_Sys_GetTestResult(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_GetTestResult_Prepare( sysContext );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -95,7 +95,7 @@ TPM_RC Tss2_Sys_GetTestResult(
             rval = Tss2_Sys_GetTestResult_Complete( sysContext, outData, testResult );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_GetTime.c
+++ b/sysapi/sysapi/Tss2_Sys_GetTime.c
@@ -44,7 +44,7 @@ TPM_RC Tss2_Sys_GetTime_Prepare(
     if( inScheme == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     CommonPreparePrologue( sysContext, TPM_CC_GetTime );
 
@@ -56,7 +56,7 @@ TPM_RC Tss2_Sys_GetTime_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( qualifyingData->b ) );
 
     Marshal_TPMT_SIG_SCHEME( sysContext, inScheme );
@@ -107,10 +107,10 @@ TPM_RC Tss2_Sys_GetTime(
     if( inScheme == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     rval = Tss2_Sys_GetTime_Prepare( sysContext, privacyAdminHandle, signHandle, qualifyingData, inScheme );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -120,7 +120,7 @@ TPM_RC Tss2_Sys_GetTime(
             rval = Tss2_Sys_GetTime_Complete( sysContext, timeInfo, signature );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_HMAC.c
+++ b/sysapi/sysapi/Tss2_Sys_HMAC.c
@@ -40,7 +40,7 @@ TPM_RC Tss2_Sys_HMAC_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_HMAC );
 
@@ -50,7 +50,7 @@ TPM_RC Tss2_Sys_HMAC_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( buffer->b ) );
 
     Marshal_UINT16( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), hashAlg, &(SYS_CONTEXT->rval) );
@@ -93,10 +93,10 @@ TPM_RC Tss2_Sys_HMAC(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_HMAC_Prepare( sysContext, handle, buffer, hashAlg );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -106,7 +106,7 @@ TPM_RC Tss2_Sys_HMAC(
             rval = Tss2_Sys_HMAC_Complete( sysContext, outHMAC );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_HMAC_Start.c
+++ b/sysapi/sysapi/Tss2_Sys_HMAC_Start.c
@@ -40,7 +40,7 @@ TPM_RC Tss2_Sys_HMAC_Start_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_HMAC_Start );
 
@@ -50,7 +50,7 @@ TPM_RC Tss2_Sys_HMAC_Start_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( auth->b ) );
 
     Marshal_UINT16( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), hashAlg, &(SYS_CONTEXT->rval) );
@@ -93,10 +93,10 @@ TPM_RC Tss2_Sys_HMAC_Start(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_HMAC_Start_Prepare( sysContext, handle, auth, hashAlg );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -106,7 +106,7 @@ TPM_RC Tss2_Sys_HMAC_Start(
             rval = Tss2_Sys_HMAC_Start_Complete( sysContext, sequenceHandle );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_Hash.c
+++ b/sysapi/sysapi/Tss2_Sys_Hash.c
@@ -40,7 +40,7 @@ TPM_RC Tss2_Sys_Hash_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_Hash );
 
@@ -48,7 +48,7 @@ TPM_RC Tss2_Sys_Hash_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( data->b ) );
 
     Marshal_UINT16( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), hashAlg, &(SYS_CONTEXT->rval) );
@@ -97,10 +97,10 @@ TPM_RC Tss2_Sys_Hash(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_Hash_Prepare( sysContext, data, hashAlg, hierarchy );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -110,7 +110,7 @@ TPM_RC Tss2_Sys_Hash(
             rval = Tss2_Sys_Hash_Complete( sysContext, outHash, validation );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_HashSequenceStart.c
+++ b/sysapi/sysapi/Tss2_Sys_HashSequenceStart.c
@@ -39,7 +39,7 @@ TPM_RC Tss2_Sys_HashSequenceStart_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_HashSequenceStart );
 
@@ -47,7 +47,7 @@ TPM_RC Tss2_Sys_HashSequenceStart_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( auth->b ) );
 
     Marshal_UINT16( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), hashAlg, &(SYS_CONTEXT->rval) );
@@ -89,10 +89,10 @@ TPM_RC Tss2_Sys_HashSequenceStart(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_HashSequenceStart_Prepare( sysContext, auth, hashAlg );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -102,7 +102,7 @@ TPM_RC Tss2_Sys_HashSequenceStart(
             rval = Tss2_Sys_HashSequenceStart_Complete( sysContext, sequenceHandle );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_HierarchyChangeAuth.c
+++ b/sysapi/sysapi/Tss2_Sys_HierarchyChangeAuth.c
@@ -39,14 +39,14 @@ TPM_RC Tss2_Sys_HierarchyChangeAuth_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_HierarchyChangeAuth );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), authHandle, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( newAuth->b ) );
 
     SYS_CONTEXT->decryptAllowed = 1;
@@ -69,15 +69,15 @@ TPM_RC Tss2_Sys_HierarchyChangeAuth(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_HierarchyChangeAuth_Prepare( sysContext, authHandle, newAuth );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_HierarchyControl.c
+++ b/sysapi/sysapi/Tss2_Sys_HierarchyControl.c
@@ -40,14 +40,14 @@ TPM_RC Tss2_Sys_HierarchyControl_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_HierarchyControl );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), authHandle, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), enable, &(SYS_CONTEXT->rval) );
 
     Marshal_UINT8( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), state, &(SYS_CONTEXT->rval) );
@@ -73,15 +73,15 @@ TPM_RC Tss2_Sys_HierarchyControl(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_HierarchyControl_Prepare( sysContext, authHandle, enable, state );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_Import.c
+++ b/sysapi/sysapi/Tss2_Sys_Import.c
@@ -46,7 +46,7 @@ TPM_RC Tss2_Sys_Import_Prepare(
     if( symmetricAlg == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     CommonPreparePrologue( sysContext, TPM_CC_Import );
 
@@ -56,7 +56,7 @@ TPM_RC Tss2_Sys_Import_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( encryptionKey->b ) );
 
     Marshal_TPM2B_PUBLIC( sysContext, objectPublic );
@@ -111,10 +111,10 @@ TPM_RC Tss2_Sys_Import(
     if( symmetricAlg == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     rval = Tss2_Sys_Import_Prepare( sysContext, parentHandle, encryptionKey, objectPublic, duplicate, inSymSeed, symmetricAlg );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -124,7 +124,7 @@ TPM_RC Tss2_Sys_Import(
             rval = Tss2_Sys_Import_Complete( sysContext, outPrivate );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_IncrementalSelfTest.c
+++ b/sysapi/sysapi/Tss2_Sys_IncrementalSelfTest.c
@@ -41,12 +41,12 @@ TPM_RC Tss2_Sys_IncrementalSelfTest_Prepare(
     if( toTest == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     CommonPreparePrologue( sysContext, TPM_CC_IncrementalSelfTest );
 
-    
-            
+
+
     Marshal_TPML_ALG( sysContext, toTest );
 
     SYS_CONTEXT->decryptAllowed = 0;
@@ -88,10 +88,10 @@ TPM_RC Tss2_Sys_IncrementalSelfTest(
     if( toTest == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     rval = Tss2_Sys_IncrementalSelfTest_Prepare( sysContext, toTest );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -101,7 +101,7 @@ TPM_RC Tss2_Sys_IncrementalSelfTest(
             rval = Tss2_Sys_IncrementalSelfTest_Complete( sysContext, toDoList );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_Load.c
+++ b/sysapi/sysapi/Tss2_Sys_Load.c
@@ -40,7 +40,7 @@ TPM_RC Tss2_Sys_Load_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_Load );
 
@@ -50,7 +50,7 @@ TPM_RC Tss2_Sys_Load_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( inPrivate->b ) );
 
     Marshal_TPM2B_PUBLIC( sysContext, inPublic );
@@ -97,10 +97,10 @@ TPM_RC Tss2_Sys_Load(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_Load_Prepare( sysContext, parentHandle, inPrivate, inPublic );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -110,7 +110,7 @@ TPM_RC Tss2_Sys_Load(
             rval = Tss2_Sys_Load_Complete( sysContext, objectHandle, name );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_LoadExternal.c
+++ b/sysapi/sysapi/Tss2_Sys_LoadExternal.c
@@ -40,7 +40,7 @@ TPM_RC Tss2_Sys_LoadExternal_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_LoadExternal );
 
@@ -48,7 +48,7 @@ TPM_RC Tss2_Sys_LoadExternal_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     Marshal_TPM2B_SENSITIVE( sysContext, inPrivate );
 
     Marshal_TPM2B_PUBLIC( sysContext, inPublic );
@@ -97,10 +97,10 @@ TPM_RC Tss2_Sys_LoadExternal(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_LoadExternal_Prepare( sysContext, inPrivate, inPublic, hierarchy );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -110,7 +110,7 @@ TPM_RC Tss2_Sys_LoadExternal(
             rval = Tss2_Sys_LoadExternal_Complete( sysContext, objectHandle, name );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_MakeCredential.c
+++ b/sysapi/sysapi/Tss2_Sys_MakeCredential.c
@@ -40,7 +40,7 @@ TPM_RC Tss2_Sys_MakeCredential_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_MakeCredential );
 
@@ -50,7 +50,7 @@ TPM_RC Tss2_Sys_MakeCredential_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( credential->b ) );
 
     MARSHAL_SIMPLE_TPM2B( sysContext, &( objectName->b ) );
@@ -97,10 +97,10 @@ TPM_RC Tss2_Sys_MakeCredential(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_MakeCredential_Prepare( sysContext, handle, credential, objectName );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -110,7 +110,7 @@ TPM_RC Tss2_Sys_MakeCredential(
             rval = Tss2_Sys_MakeCredential_Complete( sysContext, credentialBlob, secret );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_NV_Certify.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_Certify.c
@@ -47,7 +47,7 @@ TPM_RC Tss2_Sys_NV_Certify_Prepare(
     if( inScheme == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     CommonPreparePrologue( sysContext, TPM_CC_NV_Certify );
 
@@ -61,7 +61,7 @@ TPM_RC Tss2_Sys_NV_Certify_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( qualifyingData->b ) );
 
     Marshal_TPMT_SIG_SCHEME( sysContext, inScheme );
@@ -119,10 +119,10 @@ TPM_RC Tss2_Sys_NV_Certify(
     if( inScheme == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     rval = Tss2_Sys_NV_Certify_Prepare( sysContext, signHandle, authHandle, nvIndex, qualifyingData, inScheme, size, offset );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -132,7 +132,7 @@ TPM_RC Tss2_Sys_NV_Certify(
             rval = Tss2_Sys_NV_Certify_Complete( sysContext, certifyInfo, signature );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_NV_ChangeAuth.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_ChangeAuth.c
@@ -39,14 +39,14 @@ TPM_RC Tss2_Sys_NV_ChangeAuth_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_NV_ChangeAuth );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), nvIndex, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( newAuth->b ) );
 
     SYS_CONTEXT->decryptAllowed = 1;
@@ -69,15 +69,15 @@ TPM_RC Tss2_Sys_NV_ChangeAuth(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_NV_ChangeAuth_Prepare( sysContext, nvIndex, newAuth );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_NV_DefineSpace.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_DefineSpace.c
@@ -40,7 +40,7 @@ TPM_RC Tss2_Sys_NV_DefineSpace_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_NV_DefineSpace );
 
@@ -50,7 +50,7 @@ TPM_RC Tss2_Sys_NV_DefineSpace_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( auth->b ) );
 
     Marshal_TPM2B_NV_PUBLIC( sysContext, publicInfo );
@@ -76,15 +76,15 @@ TPM_RC Tss2_Sys_NV_DefineSpace(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_NV_DefineSpace_Prepare( sysContext, authHandle, auth, publicInfo );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_NV_Extend.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_Extend.c
@@ -40,7 +40,7 @@ TPM_RC Tss2_Sys_NV_Extend_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_NV_Extend );
 
@@ -48,8 +48,8 @@ TPM_RC Tss2_Sys_NV_Extend_Prepare(
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), nvIndex, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( data->b ) );
 
     SYS_CONTEXT->decryptAllowed = 1;
@@ -73,15 +73,15 @@ TPM_RC Tss2_Sys_NV_Extend(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_NV_Extend_Prepare( sysContext, authHandle, nvIndex, data );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_NV_GlobalWriteLock.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_GlobalWriteLock.c
@@ -38,14 +38,14 @@ TPM_RC Tss2_Sys_NV_GlobalWriteLock_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_NV_GlobalWriteLock );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), authHandle, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     SYS_CONTEXT->decryptAllowed = 0;
     SYS_CONTEXT->encryptAllowed = 0;
     SYS_CONTEXT->authAllowed = 1;
@@ -65,15 +65,15 @@ TPM_RC Tss2_Sys_NV_GlobalWriteLock(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_NV_GlobalWriteLock_Prepare( sysContext, authHandle );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_NV_Increment.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_Increment.c
@@ -39,7 +39,7 @@ TPM_RC Tss2_Sys_NV_Increment_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_NV_Increment );
 
@@ -47,8 +47,8 @@ TPM_RC Tss2_Sys_NV_Increment_Prepare(
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), nvIndex, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     SYS_CONTEXT->decryptAllowed = 0;
     SYS_CONTEXT->encryptAllowed = 0;
     SYS_CONTEXT->authAllowed = 1;
@@ -69,15 +69,15 @@ TPM_RC Tss2_Sys_NV_Increment(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_NV_Increment_Prepare( sysContext, authHandle, nvIndex );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_NV_Read.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_Read.c
@@ -41,7 +41,7 @@ TPM_RC Tss2_Sys_NV_Read_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_NV_Read );
 
@@ -49,8 +49,8 @@ TPM_RC Tss2_Sys_NV_Read_Prepare(
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), nvIndex, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     Marshal_UINT16( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), size, &(SYS_CONTEXT->rval) );
 
     Marshal_UINT16( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), offset, &(SYS_CONTEXT->rval) );
@@ -94,10 +94,10 @@ TPM_RC Tss2_Sys_NV_Read(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_NV_Read_Prepare( sysContext, authHandle, nvIndex, size, offset );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -107,7 +107,7 @@ TPM_RC Tss2_Sys_NV_Read(
             rval = Tss2_Sys_NV_Read_Complete( sysContext, data );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_NV_ReadLock.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_ReadLock.c
@@ -39,7 +39,7 @@ TPM_RC Tss2_Sys_NV_ReadLock_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_NV_ReadLock );
 
@@ -47,8 +47,8 @@ TPM_RC Tss2_Sys_NV_ReadLock_Prepare(
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), nvIndex, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     SYS_CONTEXT->decryptAllowed = 0;
     SYS_CONTEXT->encryptAllowed = 0;
     SYS_CONTEXT->authAllowed = 1;
@@ -69,15 +69,15 @@ TPM_RC Tss2_Sys_NV_ReadLock(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_NV_ReadLock_Prepare( sysContext, authHandle, nvIndex );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_NV_ReadPublic.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_ReadPublic.c
@@ -38,14 +38,14 @@ TPM_RC Tss2_Sys_NV_ReadPublic_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_NV_ReadPublic );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), nvIndex, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     SYS_CONTEXT->decryptAllowed = 0;
     SYS_CONTEXT->encryptAllowed = 1;
     SYS_CONTEXT->authAllowed = 1;
@@ -86,10 +86,10 @@ TPM_RC Tss2_Sys_NV_ReadPublic(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_NV_ReadPublic_Prepare( sysContext, nvIndex );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -99,7 +99,7 @@ TPM_RC Tss2_Sys_NV_ReadPublic(
             rval = Tss2_Sys_NV_ReadPublic_Complete( sysContext, nvPublic, nvName );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_NV_SetBits.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_SetBits.c
@@ -40,7 +40,7 @@ TPM_RC Tss2_Sys_NV_SetBits_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_NV_SetBits );
 
@@ -48,8 +48,8 @@ TPM_RC Tss2_Sys_NV_SetBits_Prepare(
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), nvIndex, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     Marshal_UINT64( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), bits, &(SYS_CONTEXT->rval) );
 
     SYS_CONTEXT->decryptAllowed = 0;
@@ -73,15 +73,15 @@ TPM_RC Tss2_Sys_NV_SetBits(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_NV_SetBits_Prepare( sysContext, authHandle, nvIndex, bits );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_NV_UndefineSpace.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_UndefineSpace.c
@@ -39,7 +39,7 @@ TPM_RC Tss2_Sys_NV_UndefineSpace_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_NV_UndefineSpace );
 
@@ -47,8 +47,8 @@ TPM_RC Tss2_Sys_NV_UndefineSpace_Prepare(
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), nvIndex, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     SYS_CONTEXT->decryptAllowed = 0;
     SYS_CONTEXT->encryptAllowed = 0;
     SYS_CONTEXT->authAllowed = 1;
@@ -69,15 +69,15 @@ TPM_RC Tss2_Sys_NV_UndefineSpace(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_NV_UndefineSpace_Prepare( sysContext, authHandle, nvIndex );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_NV_UndefineSpaceSpecial.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_UndefineSpaceSpecial.c
@@ -39,7 +39,7 @@ TPM_RC Tss2_Sys_NV_UndefineSpaceSpecial_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_NV_UndefineSpaceSpecial );
 
@@ -47,8 +47,8 @@ TPM_RC Tss2_Sys_NV_UndefineSpaceSpecial_Prepare(
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), platform, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     SYS_CONTEXT->decryptAllowed = 0;
     SYS_CONTEXT->encryptAllowed = 0;
     SYS_CONTEXT->authAllowed = 1;
@@ -69,15 +69,15 @@ TPM_RC Tss2_Sys_NV_UndefineSpaceSpecial(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_NV_UndefineSpaceSpecial_Prepare( sysContext, nvIndex, platform );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_NV_Write.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_Write.c
@@ -41,7 +41,7 @@ TPM_RC Tss2_Sys_NV_Write_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_NV_Write );
 
@@ -53,7 +53,7 @@ TPM_RC Tss2_Sys_NV_Write_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( data->b ) );
 
     Marshal_UINT16( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), offset, &(SYS_CONTEXT->rval) );
@@ -80,15 +80,15 @@ TPM_RC Tss2_Sys_NV_Write(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_NV_Write_Prepare( sysContext, authHandle, nvIndex, data, offset );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_NV_WriteLock.c
+++ b/sysapi/sysapi/Tss2_Sys_NV_WriteLock.c
@@ -39,7 +39,7 @@ TPM_RC Tss2_Sys_NV_WriteLock_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_NV_WriteLock );
 
@@ -47,8 +47,8 @@ TPM_RC Tss2_Sys_NV_WriteLock_Prepare(
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), nvIndex, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     SYS_CONTEXT->decryptAllowed = 0;
     SYS_CONTEXT->encryptAllowed = 0;
     SYS_CONTEXT->authAllowed = 1;
@@ -69,15 +69,15 @@ TPM_RC Tss2_Sys_NV_WriteLock(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_NV_WriteLock_Prepare( sysContext, authHandle, nvIndex );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_ObjectChangeAuth.c
+++ b/sysapi/sysapi/Tss2_Sys_ObjectChangeAuth.c
@@ -40,7 +40,7 @@ TPM_RC Tss2_Sys_ObjectChangeAuth_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_ObjectChangeAuth );
 
@@ -48,8 +48,8 @@ TPM_RC Tss2_Sys_ObjectChangeAuth_Prepare(
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), parentHandle, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( newAuth->b ) );
 
     SYS_CONTEXT->decryptAllowed = 1;
@@ -90,10 +90,10 @@ TPM_RC Tss2_Sys_ObjectChangeAuth(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_ObjectChangeAuth_Prepare( sysContext, objectHandle, parentHandle, newAuth );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -103,7 +103,7 @@ TPM_RC Tss2_Sys_ObjectChangeAuth(
             rval = Tss2_Sys_ObjectChangeAuth_Complete( sysContext, outPrivate );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_PCR_Allocate.c
+++ b/sysapi/sysapi/Tss2_Sys_PCR_Allocate.c
@@ -42,14 +42,14 @@ TPM_RC Tss2_Sys_PCR_Allocate_Prepare(
     if( pcrAllocation == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     CommonPreparePrologue( sysContext, TPM_CC_PCR_Allocate );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), authHandle, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     Marshal_TPML_PCR_SELECTION( sysContext, pcrAllocation );
 
     SYS_CONTEXT->decryptAllowed = 0;
@@ -104,10 +104,10 @@ TPM_RC Tss2_Sys_PCR_Allocate(
     if( pcrAllocation == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     rval = Tss2_Sys_PCR_Allocate_Prepare( sysContext, authHandle, pcrAllocation );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -117,7 +117,7 @@ TPM_RC Tss2_Sys_PCR_Allocate(
             rval = Tss2_Sys_PCR_Allocate_Complete( sysContext, allocationSuccess, maxPCR, sizeNeeded, sizeAvailable );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_PCR_Event.c
+++ b/sysapi/sysapi/Tss2_Sys_PCR_Event.c
@@ -39,14 +39,14 @@ TPM_RC Tss2_Sys_PCR_Event_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_PCR_Event );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), pcrHandle, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( eventData->b ) );
 
     SYS_CONTEXT->decryptAllowed = 1;
@@ -86,10 +86,10 @@ TPM_RC Tss2_Sys_PCR_Event(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_PCR_Event_Prepare( sysContext, pcrHandle, eventData );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -99,7 +99,7 @@ TPM_RC Tss2_Sys_PCR_Event(
             rval = Tss2_Sys_PCR_Event_Complete( sysContext, digests );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_PCR_Extend.c
+++ b/sysapi/sysapi/Tss2_Sys_PCR_Extend.c
@@ -42,14 +42,14 @@ TPM_RC Tss2_Sys_PCR_Extend_Prepare(
     if( digests == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     CommonPreparePrologue( sysContext, TPM_CC_PCR_Extend );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), pcrHandle, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     Marshal_TPML_DIGEST_VALUES( sysContext, digests );
 
     SYS_CONTEXT->decryptAllowed = 0;
@@ -75,15 +75,15 @@ TPM_RC Tss2_Sys_PCR_Extend(
     if( digests == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     rval = Tss2_Sys_PCR_Extend_Prepare( sysContext, pcrHandle, digests );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_PCR_Read.c
+++ b/sysapi/sysapi/Tss2_Sys_PCR_Read.c
@@ -41,12 +41,12 @@ TPM_RC Tss2_Sys_PCR_Read_Prepare(
     if( pcrSelectionIn == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     CommonPreparePrologue( sysContext, TPM_CC_PCR_Read );
 
-    
-            
+
+
     Marshal_TPML_PCR_SELECTION( sysContext, pcrSelectionIn );
 
     SYS_CONTEXT->decryptAllowed = 0;
@@ -96,10 +96,10 @@ TPM_RC Tss2_Sys_PCR_Read(
     if( pcrSelectionIn == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     rval = Tss2_Sys_PCR_Read_Prepare( sysContext, pcrSelectionIn );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -109,7 +109,7 @@ TPM_RC Tss2_Sys_PCR_Read(
             rval = Tss2_Sys_PCR_Read_Complete( sysContext, pcrUpdateCounter, pcrSelectionOut, pcrValues );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_PCR_Reset.c
+++ b/sysapi/sysapi/Tss2_Sys_PCR_Reset.c
@@ -38,14 +38,14 @@ TPM_RC Tss2_Sys_PCR_Reset_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_PCR_Reset );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), pcrHandle, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     SYS_CONTEXT->decryptAllowed = 0;
     SYS_CONTEXT->encryptAllowed = 0;
     SYS_CONTEXT->authAllowed = 1;
@@ -65,15 +65,15 @@ TPM_RC Tss2_Sys_PCR_Reset(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_PCR_Reset_Prepare( sysContext, pcrHandle );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_PCR_SetAuthPolicy.c
+++ b/sysapi/sysapi/Tss2_Sys_PCR_SetAuthPolicy.c
@@ -41,7 +41,7 @@ TPM_RC Tss2_Sys_PCR_SetAuthPolicy_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_PCR_SetAuthPolicy );
 
@@ -51,7 +51,7 @@ TPM_RC Tss2_Sys_PCR_SetAuthPolicy_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( authPolicy->b ) );
 
     Marshal_UINT16( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), hashAlg, &(SYS_CONTEXT->rval) );
@@ -80,15 +80,15 @@ TPM_RC Tss2_Sys_PCR_SetAuthPolicy(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_PCR_SetAuthPolicy_Prepare( sysContext, authHandle, authPolicy, hashAlg, pcrNum );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_PCR_SetAuthValue.c
+++ b/sysapi/sysapi/Tss2_Sys_PCR_SetAuthValue.c
@@ -39,14 +39,14 @@ TPM_RC Tss2_Sys_PCR_SetAuthValue_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_PCR_SetAuthValue );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), pcrHandle, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( auth->b ) );
 
     SYS_CONTEXT->decryptAllowed = 1;
@@ -69,15 +69,15 @@ TPM_RC Tss2_Sys_PCR_SetAuthValue(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_PCR_SetAuthValue_Prepare( sysContext, pcrHandle, auth );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_PP_Commands.c
+++ b/sysapi/sysapi/Tss2_Sys_PP_Commands.c
@@ -43,14 +43,14 @@ TPM_RC Tss2_Sys_PP_Commands_Prepare(
     if( setList == NULL  || clearList == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     CommonPreparePrologue( sysContext, TPM_CC_PP_Commands );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), auth, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     Marshal_TPML_CC( sysContext, setList );
 
     Marshal_TPML_CC( sysContext, clearList );
@@ -79,15 +79,15 @@ TPM_RC Tss2_Sys_PP_Commands(
     if( setList == NULL  || clearList == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     rval = Tss2_Sys_PP_Commands_Prepare( sysContext, auth, setList, clearList );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_PolicyAuthValue.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyAuthValue.c
@@ -38,14 +38,14 @@ TPM_RC Tss2_Sys_PolicyAuthValue_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_PolicyAuthValue );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), policySession, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     SYS_CONTEXT->decryptAllowed = 0;
     SYS_CONTEXT->encryptAllowed = 0;
     SYS_CONTEXT->authAllowed = 1;
@@ -65,15 +65,15 @@ TPM_RC Tss2_Sys_PolicyAuthValue(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_PolicyAuthValue_Prepare( sysContext, policySession );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_PolicyAuthorize.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyAuthorize.c
@@ -45,7 +45,7 @@ TPM_RC Tss2_Sys_PolicyAuthorize_Prepare(
     if( checkTicket == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     CommonPreparePrologue( sysContext, TPM_CC_PolicyAuthorize );
 
@@ -55,7 +55,7 @@ TPM_RC Tss2_Sys_PolicyAuthorize_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( approvedPolicy->b ) );
 
     MARSHAL_SIMPLE_TPM2B( sysContext, &( policyRef->b ) );
@@ -90,15 +90,15 @@ TPM_RC Tss2_Sys_PolicyAuthorize(
     if( checkTicket == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     rval = Tss2_Sys_PolicyAuthorize_Prepare( sysContext, policySession, approvedPolicy, policyRef, keySign, checkTicket );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_PolicyCommandCode.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyCommandCode.c
@@ -39,14 +39,14 @@ TPM_RC Tss2_Sys_PolicyCommandCode_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_PolicyCommandCode );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), policySession, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), code, &(SYS_CONTEXT->rval) );
 
     SYS_CONTEXT->decryptAllowed = 0;
@@ -69,15 +69,15 @@ TPM_RC Tss2_Sys_PolicyCommandCode(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_PolicyCommandCode_Prepare( sysContext, policySession, code );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_PolicyCounterTimer.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyCounterTimer.c
@@ -41,7 +41,7 @@ TPM_RC Tss2_Sys_PolicyCounterTimer_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_PolicyCounterTimer );
 
@@ -51,7 +51,7 @@ TPM_RC Tss2_Sys_PolicyCounterTimer_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( operandB->b ) );
 
     Marshal_UINT16( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), offset, &(SYS_CONTEXT->rval) );
@@ -80,15 +80,15 @@ TPM_RC Tss2_Sys_PolicyCounterTimer(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_PolicyCounterTimer_Prepare( sysContext, policySession, operandB, offset, operation );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_PolicyCpHash.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyCpHash.c
@@ -39,14 +39,14 @@ TPM_RC Tss2_Sys_PolicyCpHash_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_PolicyCpHash );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), policySession, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( cpHashA->b ) );
 
     SYS_CONTEXT->decryptAllowed = 1;
@@ -69,15 +69,15 @@ TPM_RC Tss2_Sys_PolicyCpHash(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_PolicyCpHash_Prepare( sysContext, policySession, cpHashA );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_PolicyDuplicationSelect.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyDuplicationSelect.c
@@ -41,7 +41,7 @@ TPM_RC Tss2_Sys_PolicyDuplicationSelect_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_PolicyDuplicationSelect );
 
@@ -51,7 +51,7 @@ TPM_RC Tss2_Sys_PolicyDuplicationSelect_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( objectName->b ) );
 
     MARSHAL_SIMPLE_TPM2B( sysContext, &( newParentName->b ) );
@@ -80,15 +80,15 @@ TPM_RC Tss2_Sys_PolicyDuplicationSelect(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_PolicyDuplicationSelect_Prepare( sysContext, policySession, objectName, newParentName, includeObject );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_PolicyGetDigest.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyGetDigest.c
@@ -38,14 +38,14 @@ TPM_RC Tss2_Sys_PolicyGetDigest_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_PolicyGetDigest );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), policySession, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     SYS_CONTEXT->decryptAllowed = 0;
     SYS_CONTEXT->encryptAllowed = 1;
     SYS_CONTEXT->authAllowed = 1;
@@ -82,10 +82,10 @@ TPM_RC Tss2_Sys_PolicyGetDigest(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_PolicyGetDigest_Prepare( sysContext, policySession );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -95,7 +95,7 @@ TPM_RC Tss2_Sys_PolicyGetDigest(
             rval = Tss2_Sys_PolicyGetDigest_Complete( sysContext, policyDigest );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_PolicyLocality.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyLocality.c
@@ -39,14 +39,14 @@ TPM_RC Tss2_Sys_PolicyLocality_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_PolicyLocality );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), policySession, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     Marshal_TPMA_LOCALITY( sysContext, locality );
 
     SYS_CONTEXT->decryptAllowed = 0;
@@ -69,15 +69,15 @@ TPM_RC Tss2_Sys_PolicyLocality(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_PolicyLocality_Prepare( sysContext, policySession, locality );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_PolicyNV.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyNV.c
@@ -43,7 +43,7 @@ TPM_RC Tss2_Sys_PolicyNV_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_PolicyNV );
 
@@ -57,7 +57,7 @@ TPM_RC Tss2_Sys_PolicyNV_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( operandB->b ) );
 
     Marshal_UINT16( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), offset, &(SYS_CONTEXT->rval) );
@@ -88,15 +88,15 @@ TPM_RC Tss2_Sys_PolicyNV(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_PolicyNV_Prepare( sysContext, authHandle, nvIndex, policySession, operandB, offset, operation );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_PolicyNVWritten.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyNVWritten.c
@@ -39,14 +39,14 @@ TPM_RC Tss2_Sys_PolicyNvWritten_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_PolicyNvWritten );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), policySession, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     Marshal_UINT8( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), writtenSet, &(SYS_CONTEXT->rval) );
 
     SYS_CONTEXT->decryptAllowed = 0;
@@ -69,15 +69,15 @@ TPM_RC Tss2_Sys_PolicyNvWritten(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_PolicyNvWritten_Prepare( sysContext, policySession, writtenSet );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_PolicyNameHash.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyNameHash.c
@@ -39,14 +39,14 @@ TPM_RC Tss2_Sys_PolicyNameHash_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_PolicyNameHash );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), policySession, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( nameHash->b ) );
 
     SYS_CONTEXT->decryptAllowed = 1;
@@ -69,15 +69,15 @@ TPM_RC Tss2_Sys_PolicyNameHash(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_PolicyNameHash_Prepare( sysContext, policySession, nameHash );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_PolicyOR.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyOR.c
@@ -42,14 +42,14 @@ TPM_RC Tss2_Sys_PolicyOR_Prepare(
     if( pHashList == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     CommonPreparePrologue( sysContext, TPM_CC_PolicyOR );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), policySession, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     Marshal_TPML_DIGEST( sysContext, pHashList );
 
     SYS_CONTEXT->decryptAllowed = 0;
@@ -75,15 +75,15 @@ TPM_RC Tss2_Sys_PolicyOR(
     if( pHashList == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     rval = Tss2_Sys_PolicyOR_Prepare( sysContext, policySession, pHashList );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_PolicyPCR.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyPCR.c
@@ -43,7 +43,7 @@ TPM_RC Tss2_Sys_PolicyPCR_Prepare(
     if( pcrs == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     CommonPreparePrologue( sysContext, TPM_CC_PolicyPCR );
 
@@ -53,7 +53,7 @@ TPM_RC Tss2_Sys_PolicyPCR_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( pcrDigest->b ) );
 
     Marshal_TPML_PCR_SELECTION( sysContext, pcrs );
@@ -82,15 +82,15 @@ TPM_RC Tss2_Sys_PolicyPCR(
     if( pcrs == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     rval = Tss2_Sys_PolicyPCR_Prepare( sysContext, policySession, pcrDigest, pcrs );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_PolicyPassword.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyPassword.c
@@ -38,14 +38,14 @@ TPM_RC Tss2_Sys_PolicyPassword_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_PolicyPassword );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), policySession, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     SYS_CONTEXT->decryptAllowed = 0;
     SYS_CONTEXT->encryptAllowed = 0;
     SYS_CONTEXT->authAllowed = 1;
@@ -65,15 +65,15 @@ TPM_RC Tss2_Sys_PolicyPassword(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_PolicyPassword_Prepare( sysContext, policySession );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_PolicyPhysicalPresence.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyPhysicalPresence.c
@@ -38,14 +38,14 @@ TPM_RC Tss2_Sys_PolicyPhysicalPresence_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_PolicyPhysicalPresence );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), policySession, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     SYS_CONTEXT->decryptAllowed = 0;
     SYS_CONTEXT->encryptAllowed = 0;
     SYS_CONTEXT->authAllowed = 1;
@@ -65,15 +65,15 @@ TPM_RC Tss2_Sys_PolicyPhysicalPresence(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_PolicyPhysicalPresence_Prepare( sysContext, policySession );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_PolicyRestart.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyRestart.c
@@ -38,14 +38,14 @@ TPM_RC Tss2_Sys_PolicyRestart_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_PolicyRestart );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), sessionHandle, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     SYS_CONTEXT->decryptAllowed = 0;
     SYS_CONTEXT->encryptAllowed = 0;
     SYS_CONTEXT->authAllowed = 1;
@@ -65,15 +65,15 @@ TPM_RC Tss2_Sys_PolicyRestart(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_PolicyRestart_Prepare( sysContext, sessionHandle );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_PolicySecret.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicySecret.c
@@ -43,7 +43,7 @@ TPM_RC Tss2_Sys_PolicySecret_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_PolicySecret );
 
@@ -55,7 +55,7 @@ TPM_RC Tss2_Sys_PolicySecret_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( nonceTPM->b ) );
 
     MARSHAL_SIMPLE_TPM2B( sysContext, &( cpHashA->b ) );
@@ -109,10 +109,10 @@ TPM_RC Tss2_Sys_PolicySecret(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_PolicySecret_Prepare( sysContext, authHandle, policySession, nonceTPM, cpHashA, policyRef, expiration );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -122,7 +122,7 @@ TPM_RC Tss2_Sys_PolicySecret(
             rval = Tss2_Sys_PolicySecret_Complete( sysContext, timeout, policyTicket );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_PolicySigned.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicySigned.c
@@ -47,7 +47,7 @@ TPM_RC Tss2_Sys_PolicySigned_Prepare(
     if( auth == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     CommonPreparePrologue( sysContext, TPM_CC_PolicySigned );
 
@@ -59,7 +59,7 @@ TPM_RC Tss2_Sys_PolicySigned_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( nonceTPM->b ) );
 
     MARSHAL_SIMPLE_TPM2B( sysContext, &( cpHashA->b ) );
@@ -119,10 +119,10 @@ TPM_RC Tss2_Sys_PolicySigned(
     if( auth == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     rval = Tss2_Sys_PolicySigned_Prepare( sysContext, authObject, policySession, nonceTPM, cpHashA, policyRef, expiration, auth );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -132,7 +132,7 @@ TPM_RC Tss2_Sys_PolicySigned(
             rval = Tss2_Sys_PolicySigned_Complete( sysContext, timeout, policyTicket );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_PolicyTicket.c
+++ b/sysapi/sysapi/Tss2_Sys_PolicyTicket.c
@@ -46,7 +46,7 @@ TPM_RC Tss2_Sys_PolicyTicket_Prepare(
     if( ticket == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     CommonPreparePrologue( sysContext, TPM_CC_PolicyTicket );
 
@@ -56,7 +56,7 @@ TPM_RC Tss2_Sys_PolicyTicket_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( timeout->b ) );
 
     MARSHAL_SIMPLE_TPM2B( sysContext, &( cpHashA->b ) );
@@ -94,15 +94,15 @@ TPM_RC Tss2_Sys_PolicyTicket(
     if( ticket == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     rval = Tss2_Sys_PolicyTicket_Prepare( sysContext, policySession, timeout, cpHashA, policyRef, authName, ticket );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_Quote.c
+++ b/sysapi/sysapi/Tss2_Sys_Quote.c
@@ -44,7 +44,7 @@ TPM_RC Tss2_Sys_Quote_Prepare(
     if( inScheme == NULL  || PCRselect == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     CommonPreparePrologue( sysContext, TPM_CC_Quote );
 
@@ -54,7 +54,7 @@ TPM_RC Tss2_Sys_Quote_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( qualifyingData->b ) );
 
     Marshal_TPMT_SIG_SCHEME( sysContext, inScheme );
@@ -107,10 +107,10 @@ TPM_RC Tss2_Sys_Quote(
     if( inScheme == NULL  || PCRselect == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     rval = Tss2_Sys_Quote_Prepare( sysContext, signHandle, qualifyingData, inScheme, PCRselect );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -120,7 +120,7 @@ TPM_RC Tss2_Sys_Quote(
             rval = Tss2_Sys_Quote_Complete( sysContext, quoted, signature );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_RSA_Decrypt.c
+++ b/sysapi/sysapi/Tss2_Sys_RSA_Decrypt.c
@@ -44,7 +44,7 @@ TPM_RC Tss2_Sys_RSA_Decrypt_Prepare(
     if( inScheme == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     CommonPreparePrologue( sysContext, TPM_CC_RSA_Decrypt );
 
@@ -54,7 +54,7 @@ TPM_RC Tss2_Sys_RSA_Decrypt_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( cipherText->b ) );
 
     Marshal_TPMT_RSA_DECRYPT( sysContext, inScheme );
@@ -103,10 +103,10 @@ TPM_RC Tss2_Sys_RSA_Decrypt(
     if( inScheme == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     rval = Tss2_Sys_RSA_Decrypt_Prepare( sysContext, keyHandle, cipherText, inScheme, label );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -116,7 +116,7 @@ TPM_RC Tss2_Sys_RSA_Decrypt(
             rval = Tss2_Sys_RSA_Decrypt_Complete( sysContext, message );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_RSA_Encrypt.c
+++ b/sysapi/sysapi/Tss2_Sys_RSA_Encrypt.c
@@ -44,7 +44,7 @@ TPM_RC Tss2_Sys_RSA_Encrypt_Prepare(
     if( inScheme == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     CommonPreparePrologue( sysContext, TPM_CC_RSA_Encrypt );
 
@@ -54,7 +54,7 @@ TPM_RC Tss2_Sys_RSA_Encrypt_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( message->b ) );
 
     Marshal_TPMT_RSA_DECRYPT( sysContext, inScheme );
@@ -103,10 +103,10 @@ TPM_RC Tss2_Sys_RSA_Encrypt(
     if( inScheme == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     rval = Tss2_Sys_RSA_Encrypt_Prepare( sysContext, keyHandle, message, inScheme, label );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -116,7 +116,7 @@ TPM_RC Tss2_Sys_RSA_Encrypt(
             rval = Tss2_Sys_RSA_Encrypt_Complete( sysContext, outData );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_ReadClock.c
+++ b/sysapi/sysapi/Tss2_Sys_ReadClock.c
@@ -37,12 +37,12 @@ TPM_RC Tss2_Sys_ReadClock_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_ReadClock );
 
-    
-            
+
+
     SYS_CONTEXT->decryptAllowed = 0;
     SYS_CONTEXT->encryptAllowed = 0;
     SYS_CONTEXT->authAllowed = 0;
@@ -76,10 +76,10 @@ TPM_RC Tss2_Sys_ReadClock(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_ReadClock_Prepare( sysContext );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, 0, 0 );
@@ -89,7 +89,7 @@ TPM_RC Tss2_Sys_ReadClock(
             rval = Tss2_Sys_ReadClock_Complete( sysContext, currentTime );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_ReadPublic.c
+++ b/sysapi/sysapi/Tss2_Sys_ReadPublic.c
@@ -38,14 +38,14 @@ TPM_RC Tss2_Sys_ReadPublic_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_ReadPublic );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), objectHandle, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     SYS_CONTEXT->decryptAllowed = 0;
     SYS_CONTEXT->encryptAllowed = 1;
     SYS_CONTEXT->authAllowed = 1;
@@ -90,10 +90,10 @@ TPM_RC Tss2_Sys_ReadPublic(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_ReadPublic_Prepare( sysContext, objectHandle );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -103,7 +103,7 @@ TPM_RC Tss2_Sys_ReadPublic(
             rval = Tss2_Sys_ReadPublic_Complete( sysContext, outPublic, name, qualifiedName );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_Rewrap.c
+++ b/sysapi/sysapi/Tss2_Sys_Rewrap.c
@@ -42,7 +42,7 @@ TPM_RC Tss2_Sys_Rewrap_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_Rewrap );
 
@@ -54,7 +54,7 @@ TPM_RC Tss2_Sys_Rewrap_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( inDuplicate->b ) );
 
     MARSHAL_SIMPLE_TPM2B( sysContext, &( name->b ) );
@@ -105,10 +105,10 @@ TPM_RC Tss2_Sys_Rewrap(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_Rewrap_Prepare( sysContext, oldParent, newParent, inDuplicate, name, inSymSeed );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -118,7 +118,7 @@ TPM_RC Tss2_Sys_Rewrap(
             rval = Tss2_Sys_Rewrap_Complete( sysContext, outDuplicate, outSymSeed );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_SelfTest.c
+++ b/sysapi/sysapi/Tss2_Sys_SelfTest.c
@@ -38,12 +38,12 @@ TPM_RC Tss2_Sys_SelfTest_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_SelfTest );
 
-    
-            
+
+
     Marshal_UINT8( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), fullTest, &(SYS_CONTEXT->rval) );
 
     SYS_CONTEXT->decryptAllowed = 0;
@@ -65,15 +65,15 @@ TPM_RC Tss2_Sys_SelfTest(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_SelfTest_Prepare( sysContext, fullTest );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_SequenceComplete.c
+++ b/sysapi/sysapi/Tss2_Sys_SequenceComplete.c
@@ -40,7 +40,7 @@ TPM_RC Tss2_Sys_SequenceComplete_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_SequenceComplete );
 
@@ -50,7 +50,7 @@ TPM_RC Tss2_Sys_SequenceComplete_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( buffer->b ) );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), hierarchy, &(SYS_CONTEXT->rval) );
@@ -97,10 +97,10 @@ TPM_RC Tss2_Sys_SequenceComplete(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_SequenceComplete_Prepare( sysContext, sequenceHandle, buffer, hierarchy );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -110,7 +110,7 @@ TPM_RC Tss2_Sys_SequenceComplete(
             rval = Tss2_Sys_SequenceComplete_Complete( sysContext, result, validation );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_SequenceUpdate.c
+++ b/sysapi/sysapi/Tss2_Sys_SequenceUpdate.c
@@ -39,14 +39,14 @@ TPM_RC Tss2_Sys_SequenceUpdate_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_SequenceUpdate );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), sequenceHandle, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( buffer->b ) );
 
     SYS_CONTEXT->decryptAllowed = 1;
@@ -69,15 +69,15 @@ TPM_RC Tss2_Sys_SequenceUpdate(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_SequenceUpdate_Prepare( sysContext, sequenceHandle, buffer );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_SetAlgorithmSet.c
+++ b/sysapi/sysapi/Tss2_Sys_SetAlgorithmSet.c
@@ -39,14 +39,14 @@ TPM_RC Tss2_Sys_SetAlgorithmSet_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_SetAlgorithmSet );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), authHandle, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), algorithmSet, &(SYS_CONTEXT->rval) );
 
     SYS_CONTEXT->decryptAllowed = 0;
@@ -69,15 +69,15 @@ TPM_RC Tss2_Sys_SetAlgorithmSet(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_SetAlgorithmSet_Prepare( sysContext, authHandle, algorithmSet );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_SetCommandCodeAuditStatus.c
+++ b/sysapi/sysapi/Tss2_Sys_SetCommandCodeAuditStatus.c
@@ -44,14 +44,14 @@ TPM_RC Tss2_Sys_SetCommandCodeAuditStatus_Prepare(
     if( setList == NULL  || clearList == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     CommonPreparePrologue( sysContext, TPM_CC_SetCommandCodeAuditStatus );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), auth, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     Marshal_UINT16( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), auditAlg, &(SYS_CONTEXT->rval) );
 
     Marshal_TPML_CC( sysContext, setList );
@@ -83,15 +83,15 @@ TPM_RC Tss2_Sys_SetCommandCodeAuditStatus(
     if( setList == NULL  || clearList == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     rval = Tss2_Sys_SetCommandCodeAuditStatus_Prepare( sysContext, auth, auditAlg, setList, clearList );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_SetPrimaryPolicy.c
+++ b/sysapi/sysapi/Tss2_Sys_SetPrimaryPolicy.c
@@ -40,7 +40,7 @@ TPM_RC Tss2_Sys_SetPrimaryPolicy_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_SetPrimaryPolicy );
 
@@ -50,7 +50,7 @@ TPM_RC Tss2_Sys_SetPrimaryPolicy_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( authPolicy->b ) );
 
     Marshal_UINT16( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), hashAlg, &(SYS_CONTEXT->rval) );
@@ -76,15 +76,15 @@ TPM_RC Tss2_Sys_SetPrimaryPolicy(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_SetPrimaryPolicy_Prepare( sysContext, authHandle, authPolicy, hashAlg );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_Shutdown.c
+++ b/sysapi/sysapi/Tss2_Sys_Shutdown.c
@@ -38,12 +38,12 @@ TPM_RC Tss2_Sys_Shutdown_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_Shutdown );
 
-    
-            
+
+
     Marshal_UINT16( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), shutdownType, &(SYS_CONTEXT->rval) );
 
     SYS_CONTEXT->decryptAllowed = 0;
@@ -65,15 +65,15 @@ TPM_RC Tss2_Sys_Shutdown(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_Shutdown_Prepare( sysContext, shutdownType );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_Sign.c
+++ b/sysapi/sysapi/Tss2_Sys_Sign.c
@@ -44,7 +44,7 @@ TPM_RC Tss2_Sys_Sign_Prepare(
     if( inScheme == NULL  || validation == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     CommonPreparePrologue( sysContext, TPM_CC_Sign );
 
@@ -54,7 +54,7 @@ TPM_RC Tss2_Sys_Sign_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( digest->b ) );
 
     Marshal_TPMT_SIG_SCHEME( sysContext, inScheme );
@@ -103,10 +103,10 @@ TPM_RC Tss2_Sys_Sign(
     if( inScheme == NULL  || validation == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     rval = Tss2_Sys_Sign_Prepare( sysContext, keyHandle, digest, inScheme, validation );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -116,7 +116,7 @@ TPM_RC Tss2_Sys_Sign(
             rval = Tss2_Sys_Sign_Complete( sysContext, signature );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_StartAuthSession.c
+++ b/sysapi/sysapi/Tss2_Sys_StartAuthSession.c
@@ -47,7 +47,7 @@ TPM_RC Tss2_Sys_StartAuthSession_Prepare(
     if( symmetric == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     CommonPreparePrologue( sysContext, TPM_CC_StartAuthSession );
 
@@ -59,7 +59,7 @@ TPM_RC Tss2_Sys_StartAuthSession_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( nonceCaller->b ) );
 
     MARSHAL_SIMPLE_TPM2B( sysContext, &( encryptedSalt->b ) );
@@ -119,10 +119,10 @@ TPM_RC Tss2_Sys_StartAuthSession(
     if( symmetric == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     rval = Tss2_Sys_StartAuthSession_Prepare( sysContext, tpmKey, bind, nonceCaller, encryptedSalt, sessionType, symmetric, authHash );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -132,7 +132,7 @@ TPM_RC Tss2_Sys_StartAuthSession(
             rval = Tss2_Sys_StartAuthSession_Complete( sysContext, sessionHandle, nonceTPM );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_Startup.c
+++ b/sysapi/sysapi/Tss2_Sys_Startup.c
@@ -38,12 +38,12 @@ TPM_RC Tss2_Sys_Startup_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_Startup );
 
-    
-            
+
+
     Marshal_UINT16( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), startupType, &(SYS_CONTEXT->rval) );
 
     SYS_CONTEXT->decryptAllowed = 0;
@@ -63,15 +63,15 @@ TPM_RC Tss2_Sys_Startup(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_Startup_Prepare( sysContext, startupType );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, 0, 0 );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_StirRandom.c
+++ b/sysapi/sysapi/Tss2_Sys_StirRandom.c
@@ -38,12 +38,12 @@ TPM_RC Tss2_Sys_StirRandom_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_StirRandom );
 
-    
-            
+
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( inData->b ) );
 
     SYS_CONTEXT->decryptAllowed = 1;
@@ -65,15 +65,15 @@ TPM_RC Tss2_Sys_StirRandom(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_StirRandom_Prepare( sysContext, inData );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_TestParms.c
+++ b/sysapi/sysapi/Tss2_Sys_TestParms.c
@@ -41,12 +41,12 @@ TPM_RC Tss2_Sys_TestParms_Prepare(
     if( parameters == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     CommonPreparePrologue( sysContext, TPM_CC_TestParms );
 
-    
-            
+
+
     Marshal_TPMT_PUBLIC_PARMS( sysContext, parameters );
 
     SYS_CONTEXT->decryptAllowed = 0;
@@ -71,15 +71,15 @@ TPM_RC Tss2_Sys_TestParms(
     if( parameters == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     rval = Tss2_Sys_TestParms_Prepare( sysContext, parameters );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCallForNoResponseCmds( sysContext, cmdAuthsArray, rspAuthsArray );
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_Unseal.c
+++ b/sysapi/sysapi/Tss2_Sys_Unseal.c
@@ -38,14 +38,14 @@ TPM_RC Tss2_Sys_Unseal_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_Unseal );
 
     Marshal_UINT32( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), itemHandle, &(SYS_CONTEXT->rval) );
 
-    
-            
+
+
     SYS_CONTEXT->decryptAllowed = 0;
     SYS_CONTEXT->encryptAllowed = 1;
     SYS_CONTEXT->authAllowed = 1;
@@ -82,10 +82,10 @@ TPM_RC Tss2_Sys_Unseal(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_Unseal_Prepare( sysContext, itemHandle );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -95,7 +95,7 @@ TPM_RC Tss2_Sys_Unseal(
             rval = Tss2_Sys_Unseal_Complete( sysContext, outData );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_Vendor_TCG_Test.c
+++ b/sysapi/sysapi/Tss2_Sys_Vendor_TCG_Test.c
@@ -38,12 +38,12 @@ TPM_RC Tss2_Sys_Vendor_TCG_Test_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_Vendor_TCG_Test );
 
-    
-            
+
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( inputData->b ) );
 
     SYS_CONTEXT->decryptAllowed = 1;
@@ -82,10 +82,10 @@ TPM_RC Tss2_Sys_Vendor_TCG_Test(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_Vendor_TCG_Test_Prepare( sysContext, inputData );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -95,7 +95,7 @@ TPM_RC Tss2_Sys_Vendor_TCG_Test(
             rval = Tss2_Sys_Vendor_TCG_Test_Complete( sysContext, outputData );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_VerifySignature.c
+++ b/sysapi/sysapi/Tss2_Sys_VerifySignature.c
@@ -43,7 +43,7 @@ TPM_RC Tss2_Sys_VerifySignature_Prepare(
     if( signature == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     CommonPreparePrologue( sysContext, TPM_CC_VerifySignature );
 
@@ -53,7 +53,7 @@ TPM_RC Tss2_Sys_VerifySignature_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     MARSHAL_SIMPLE_TPM2B( sysContext, &( digest->b ) );
 
     Marshal_TPMT_SIGNATURE( sysContext, signature );
@@ -99,10 +99,10 @@ TPM_RC Tss2_Sys_VerifySignature(
     if( signature == NULL  )
 	{
 		return TSS2_SYS_RC_BAD_REFERENCE;
-	} 
+	}
 
     rval = Tss2_Sys_VerifySignature_Prepare( sysContext, keyHandle, digest, signature );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -112,7 +112,7 @@ TPM_RC Tss2_Sys_VerifySignature(
             rval = Tss2_Sys_VerifySignature_Complete( sysContext, validation );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/Tss2_Sys_ZGen_2Phase.c
+++ b/sysapi/sysapi/Tss2_Sys_ZGen_2Phase.c
@@ -42,7 +42,7 @@ TPM_RC Tss2_Sys_ZGen_2Phase_Prepare(
         return( TSS2_SYS_RC_BAD_REFERENCE );
     }
 
-     
+
 
     CommonPreparePrologue( sysContext, TPM_CC_ZGen_2Phase );
 
@@ -52,7 +52,7 @@ TPM_RC Tss2_Sys_ZGen_2Phase_Prepare(
 	{
 		SYS_CONTEXT->decryptNull = 1;
 	}
-            
+
     Marshal_TPM2B_ECC_POINT( sysContext, inQsB );
 
     Marshal_TPM2B_ECC_POINT( sysContext, inQeB );
@@ -105,10 +105,10 @@ TPM_RC Tss2_Sys_ZGen_2Phase(
 {
     TSS2_RC     rval = TPM_RC_SUCCESS;
 
-     
+
 
     rval = Tss2_Sys_ZGen_2Phase_Prepare( sysContext, keyA, inQsB, inQeB, inScheme, counter );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
@@ -118,7 +118,7 @@ TPM_RC Tss2_Sys_ZGen_2Phase(
             rval = Tss2_Sys_ZGen_2Phase_Complete( sysContext, outZ1, outZ2 );
         }
     }
-    
+
     return rval;
 }
 

--- a/sysapi/sysapi/authorizations.c
+++ b/sysapi/sysapi/authorizations.c
@@ -34,7 +34,7 @@ TSS2_RC Tss2_Sys_SetCmdAuths(
     )
 {
     TSS2_RC rval = TSS2_RC_SUCCESS;
-    
+
     if( sysContext == NULL || cmdAuthsArray == 0 )
     {
         rval = TSS2_SYS_RC_BAD_REFERENCE;
@@ -116,7 +116,7 @@ TSS2_RC Tss2_Sys_SetCmdAuths(
                             otherData = SYS_CONTEXT->cpBuffer;
                             rval = CopySessionsDataIn( &otherData, cmdAuthsArray );
 
-                            // Update cpBuffer        
+                            // Update cpBuffer
                             SYS_CONTEXT->cpBuffer += authSize;
 
                             // Now update the command size.
@@ -153,7 +153,7 @@ TSS2_RC Tss2_Sys_GetRspAuths(
     else
     {
         int i = 0;
-    
+
         SYS_CONTEXT->rval = TSS2_RC_SUCCESS;
 
         if( rspAuthsArray->rspAuthsCount == 0 )
@@ -172,7 +172,7 @@ TSS2_RC Tss2_Sys_GetRspAuths(
                 otherData = SYS_CONTEXT->tpmOutBuffPtr;
                 otherData = (UINT8 *)otherData + sizeof( TPM20_Header_Out ) - 1;
                 otherData = (UINT8 *)otherData + SYS_CONTEXT->numResponseHandles * sizeof( TPM_HANDLE );
-                otherData = (UINT8 *)otherData + CHANGE_ENDIAN_DWORD( *( SYS_CONTEXT->rspParamsSize ) ); 
+                otherData = (UINT8 *)otherData + CHANGE_ENDIAN_DWORD( *( SYS_CONTEXT->rspParamsSize ) );
                 otherData = (UINT8 *)otherData + sizeof( UINT32 );
 
                 otherDataSaved = otherData;

--- a/sysapi/sysapi/execute.c
+++ b/sysapi/sysapi/execute.c
@@ -51,7 +51,7 @@ TSS2_RC Tss2_Sys_ExecuteAsync(
 
     if( rval == TSS2_RC_SUCCESS )
     {
-        SYS_CONTEXT->previousStage = CMD_STAGE_SEND_COMMAND;    
+        SYS_CONTEXT->previousStage = CMD_STAGE_SEND_COMMAND;
     }
     return rval;
 }
@@ -64,7 +64,7 @@ TSS2_RC Tss2_Sys_ExecuteFinish(
     TSS2_RC  rval = TSS2_RC_SUCCESS;
     size_t responseSize = 0;
     UINT8 tpmError = 0;
-    
+
     if( sysContext == 0 )
     {
         rval = TSS2_SYS_RC_BAD_REFERENCE;
@@ -76,7 +76,7 @@ TSS2_RC Tss2_Sys_ExecuteFinish(
     else
     {
         responseSize = SYS_CONTEXT->maxResponseSize;
-        
+
         rval = (*( TCTI_CONTEXT )->receive)
                 ( SYS_CONTEXT->tctiContext, (size_t *)&responseSize, SYS_CONTEXT->tpmOutBuffPtr, timeout );
     }
@@ -100,8 +100,8 @@ TSS2_RC Tss2_Sys_ExecuteFinish(
             // in each Part 3 command's Complete function for this.
             SYS_CONTEXT->nextData = SYS_CONTEXT->tpmOutBuffPtr;
 
-            Unmarshal_UINT16( SYS_CONTEXT->tpmOutBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), 0, &(SYS_CONTEXT->rval) ); 
-            Unmarshal_UINT32( SYS_CONTEXT->tpmOutBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), (UINT32 *)&responseSize, &(SYS_CONTEXT->rval) ); 
+            Unmarshal_UINT16( SYS_CONTEXT->tpmOutBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), 0, &(SYS_CONTEXT->rval) );
+            Unmarshal_UINT32( SYS_CONTEXT->tpmOutBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), (UINT32 *)&responseSize, &(SYS_CONTEXT->rval) );
 
             if( responseSize < ( sizeof( TPM20_Header_Out ) - 1 ) )
             {
@@ -113,7 +113,7 @@ TSS2_RC Tss2_Sys_ExecuteFinish(
 
                 // Return TPM return code if no other errors have occured.
                 if( rval == TSS2_RC_SUCCESS )
-                {   
+                {
                     if( SYS_CONTEXT->rval != TPM_RC_SUCCESS )
                     {
                         tpmError = 1;
@@ -145,11 +145,11 @@ TSS2_RC Tss2_Sys_ExecuteFinish(
         // Changed error code to what it should be.
         rval = TSS2_SYS_RC_INSUFFICIENT_CONTEXT;
     }
-        
+
     return rval;
 }
 
- 
+
 
 TSS2_RC Tss2_Sys_Execute(
     TSS2_SYS_CONTEXT 		*sysContext

--- a/sysapi/sysapi_util/CommandUtil.c
+++ b/sysapi/sysapi_util/CommandUtil.c
@@ -36,7 +36,7 @@
 //
 //  Output:	None
 //
-//  Description:	
+//  Description:
 //
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
@@ -67,7 +67,7 @@ UINT32 GetCommandSize( TSS2_SYS_CONTEXT *sysContext )
 void CopyCommandHeader( _TSS2_SYS_CONTEXT_BLOB *sysContext, TPM_CC commandCode )
 {
    SYS_CONTEXT->rval = TSS2_RC_SUCCESS;
-  
+
   ((TPM20_Header_In *) sysContext->tpmInBuffPtr)->tag = CHANGE_ENDIAN_WORD( TPM_ST_NO_SESSIONS );
 
   ((TPM20_Header_In *) sysContext->tpmInBuffPtr)->commandCode = CHANGE_ENDIAN_DWORD( commandCode );
@@ -78,9 +78,9 @@ void CopyCommandHeader( _TSS2_SYS_CONTEXT_BLOB *sysContext, TPM_CC commandCode )
 }
 
 TPM_RC FinishCommand( _TSS2_SYS_CONTEXT_BLOB *sysContext,
-    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray, 
+    TSS2_SYS_CMD_AUTHS const *cmdAuthsArray,
     UINT32 *responseSize )
-{  
+{
     if( SYS_CONTEXT->rval != TSS2_RC_SUCCESS )
         return SYS_CONTEXT->rval;
 
@@ -98,7 +98,7 @@ TPM_RC FinishCommand( _TSS2_SYS_CONTEXT_BLOB *sysContext,
 // Common to all _Prepare
 TSS2_RC CommonPreparePrologue(
     TSS2_SYS_CONTEXT *sysContext,
-    TPM_CC commandCode 
+    TPM_CC commandCode
 )
 {
 	int numCommandHandles;
@@ -159,7 +159,7 @@ TSS2_RC CommonPrepareEpilogue(
 TSS2_RC CommonComplete( TSS2_SYS_CONTEXT *sysContext )
 {
     UINT32 rspSize = CHANGE_ENDIAN_DWORD( ( (TPM20_Header_Out *)( SYS_CONTEXT->tpmOutBuffPtr )  )->responseSize );
-            
+
     if( sysContext == NULL )
     {
         return TSS2_SYS_RC_BAD_REFERENCE;
@@ -216,7 +216,7 @@ TSS2_RC CommonOneCall(
     {
         SYS_CONTEXT->rval = FinishCommand( SYS_CONTEXT, cmdAuthsArray, &responseSize );
 
-        if ( SYS_CONTEXT->rval == TSS2_RC_SUCCESS ) 
+        if ( SYS_CONTEXT->rval == TSS2_RC_SUCCESS )
         {
             if( SYS_CONTEXT->responseCode == TPM_RC_SUCCESS )
             {
@@ -239,7 +239,7 @@ TSS2_RC  CommonOneCallForNoResponseCmds(
     )
 {
     TSS2_RC rval = TSS2_RC_SUCCESS;
-    
+
     rval = CommonOneCall( sysContext, cmdAuthsArray, rspAuthsArray );
 
     if( rval == TSS2_RC_SUCCESS )

--- a/sysapi/sysapi_util/CompareSizedByteBuffer.c
+++ b/sysapi/sysapi_util/CompareSizedByteBuffer.c
@@ -48,5 +48,5 @@ TPM_RC CompareSizedByteBuffer( TPM2B *buffer1, TPM2B *buffer2 )
         }
     }
     return rval;
-}   
+}
 

--- a/sysapi/sysapi_util/ConcatSizedByteBuffer.c
+++ b/sysapi/sysapi_util/ConcatSizedByteBuffer.c
@@ -58,7 +58,7 @@ TPM_RC ConcatSizedByteBuffer( TPM2B_MAX_BUFFER *result, TPM2B *addBuffer )
             result->t.buffer[i + result->t.size] = addBuffer->buffer[i];
 
         result->t.size += addBuffer->size;
-        
+
         return TPM_RC_SUCCESS;
     }
 }

--- a/sysapi/sysapi_util/CopySessionData.c
+++ b/sysapi/sysapi_util/CopySessionData.c
@@ -74,7 +74,7 @@ TSS2_RC CopySessionDataIn( void **otherData, TPMS_AUTH_COMMAND const *sessionDat
     TSS2_RC rval = TSS2_RC_SUCCESS;
     UINT8 *inBuffPtr = *otherData;
     TPMS_AUTH_COMMAND *sessionDataCopy = (TPMS_AUTH_COMMAND *)sessionData;
-    
+
 	if( sessionData == 0 )
 	{
 		rval = TSS2_SYS_RC_BAD_VALUE;
@@ -82,10 +82,10 @@ TSS2_RC CopySessionDataIn( void **otherData, TPMS_AUTH_COMMAND const *sessionDat
 	}
 
     // Size of session data
-    *sessionSizePtr += CHANGE_ENDIAN_DWORD(  
+    *sessionSizePtr += CHANGE_ENDIAN_DWORD(
             sizeof( TPMI_SH_AUTH_SESSION ) + sizeof( UINT16 ) +
             sessionData->nonce.t.size + sizeof( UINT8 ) +
-            sizeof( UINT16 ) + sessionData->hmac.t.size );  
+            sizeof( UINT16 ) + sessionData->hmac.t.size );
 
     // copy session handle
     SESSION_MARSHAL_UINT32( inBuffPtr, *sessionSizePtr, (UINT8 **)otherData, sessionDataCopy->sessionHandle, &rval, exitCopySessionDataIn );
@@ -117,23 +117,23 @@ exitCopySessionDataIn:
 //      sessionData points to returned session data.
 //
 //      otherData points to next byte after the sessions data in the output data stream.
-//          This allows subsequent calls to this function to get the next session data.		*nextData	CXX0017: Error: symbol "nextData" not found	
+//          This allows subsequent calls to this function to get the next session data.		*nextData	CXX0017: Error: symbol "nextData" not found
 
 //
 TSS2_RC CopySessionDataOut( TPMS_AUTH_RESPONSE *sessionData, void **otherData, UINT8* outBuffPtr, UINT32 outBuffSize )
 {
     TSS2_RC rval = TSS2_RC_SUCCESS;
     TPMS_AUTH_RESPONSE *sessionDataCopy = (TPMS_AUTH_RESPONSE *)sessionData;
-    
+
     if( sessionData == 0 )
         return rval;
 
     outBuffSize -= ((UINT8 *)*otherData - outBuffPtr + 1 );
     outBuffPtr = *otherData;
-    
+
     // Copy nonceTpm
     SESSION_UNMARSHAL_SIMPLE_TPM2B( outBuffPtr, outBuffSize, (UINT8 **)otherData, &(sessionDataCopy->nonce.b), &rval, exitCopySessionDataOut );
-    
+
     // Copy sessionAttributes
     SESSION_UNMARSHAL_UINT8( outBuffPtr, outBuffSize, (UINT8 **)otherData, (UINT8 *)&( sessionDataCopy->sessionAttributes ), &rval, exitCopySessionDataOut );
 
@@ -174,7 +174,7 @@ TSS2_RC CopySessionsDataIn( void **otherData, TSS2_SYS_CMD_AUTHS const *sessions
 }
 
 TSS2_RC CopySessionsDataOut(
-    TSS2_SYS_RSP_AUTHS *rspAuthsArray, 
+    TSS2_SYS_RSP_AUTHS *rspAuthsArray,
     void *otherData,
     TPM_ST tag,
     UINT8* outBuffPtr,

--- a/sysapi/sysapi_util/GetDigestSize.c
+++ b/sysapi/sysapi_util/GetDigestSize.c
@@ -30,7 +30,7 @@
 
 
 typedef struct {
-    TPM_ALG_ID  algId; 
+    TPM_ALG_ID  algId;
     UINT16      size;  // Size of digest
 } HASH_SIZE_INFO;
 
@@ -39,10 +39,10 @@ HASH_SIZE_INFO   hashSizes[] = {
     {TPM_ALG_SHA256,        SHA256_DIGEST_SIZE},
 #ifdef TPM_ALG_SHA384
     {TPM_ALG_SHA384,        SHA384_DIGEST_SIZE},
-#endif            
+#endif
 #ifdef TPM_ALG_SHA512
     {TPM_ALG_SHA512,        SHA512_DIGEST_SIZE},
-#endif            
+#endif
     {TPM_ALG_SM3_256,       SM3_256_DIGEST_SIZE},
     {TPM_ALG_NULL,0}
 };

--- a/sysapi/sysapi_util/Marshal_TPMS_NV_PIN_COUNTER_PARAMETERS.c
+++ b/sysapi/sysapi_util/Marshal_TPMS_NV_PIN_COUNTER_PARAMETERS.c
@@ -1,27 +1,27 @@
 /***********************************************************************;
  * Copyright (c) 2015, Intel Corporation
  * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
+ *
+ * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
- * 1. Redistributions of source code must retain the above copyright notice, 
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
- * 
- * 2. Redistributions in binary form must reproduce the above copyright notice, 
- * this list of conditions and the following disclaimer in the documentation 
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
  ***********************************************************************/
 

--- a/sysapi/sysapi_util/Marshal_TPMU_HA.c
+++ b/sysapi/sysapi_util/Marshal_TPMU_HA.c
@@ -43,7 +43,7 @@ void Marshal_TPMU_HA(
 	{
 #ifdef TPM_ALG_SHA
 	case TPM_ALG_SHA:
-		
+
 	for( i = 0; i < SHA_DIGEST_SIZE; i++ )
 	{
 		Marshal_UINT8( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), ha->sha[i], &( SYS_CONTEXT->rval ) );
@@ -52,7 +52,7 @@ void Marshal_TPMU_HA(
 #endif
 #ifdef TPM_ALG_SHA1
 	case TPM_ALG_SHA1:
-		
+
 	for( i = 0; i < SHA1_DIGEST_SIZE; i++ )
 	{
 		Marshal_UINT8( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), ha->sha1[i], &( SYS_CONTEXT->rval ) );
@@ -61,7 +61,7 @@ void Marshal_TPMU_HA(
 #endif
 #ifdef TPM_ALG_SHA256
 	case TPM_ALG_SHA256:
-		
+
 	for( i = 0; i < SHA256_DIGEST_SIZE; i++ )
 	{
 		Marshal_UINT8( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), ha->sha256[i], &( SYS_CONTEXT->rval ) );
@@ -70,7 +70,7 @@ void Marshal_TPMU_HA(
 #endif
 #ifdef TPM_ALG_SHA384
 	case TPM_ALG_SHA384:
-		
+
 	for( i = 0; i < SHA384_DIGEST_SIZE; i++ )
 	{
 		Marshal_UINT8( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), ha->sha384[i], &( SYS_CONTEXT->rval ) );
@@ -79,7 +79,7 @@ void Marshal_TPMU_HA(
 #endif
 #ifdef TPM_ALG_SHA512
 	case TPM_ALG_SHA512:
-		
+
 	for( i = 0; i < SHA512_DIGEST_SIZE; i++ )
 	{
 		Marshal_UINT8( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), ha->sha512[i], &( SYS_CONTEXT->rval ) );
@@ -88,7 +88,7 @@ void Marshal_TPMU_HA(
 #endif
 #ifdef TPM_ALG_SM3_256
 	case TPM_ALG_SM3_256:
-		
+
 	for( i = 0; i < SM3_256_DIGEST_SIZE; i++ )
 	{
 		Marshal_UINT8( SYS_CONTEXT->tpmInBuffPtr, SYS_CONTEXT->maxCommandSize, &(SYS_CONTEXT->nextData), ha->sm3_256[i], &( SYS_CONTEXT->rval ) );

--- a/sysapi/sysapi_util/Unmarshal_TPM2B_CREATION_DATA.c
+++ b/sysapi/sysapi_util/Unmarshal_TPM2B_CREATION_DATA.c
@@ -1,27 +1,27 @@
 /***********************************************************************;
  * Copyright (c) 2015, Intel Corporation
  * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
+ *
+ * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
- * 1. Redistributions of source code must retain the above copyright notice, 
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
- * 
- * 2. Redistributions in binary form must reproduce the above copyright notice, 
- * this list of conditions and the following disclaimer in the documentation 
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
  ***********************************************************************/
 

--- a/sysapi/sysapi_util/Unmarshal_TPMS_NV_PIN_COUNTER_PARAMETERS.c
+++ b/sysapi/sysapi_util/Unmarshal_TPMS_NV_PIN_COUNTER_PARAMETERS.c
@@ -1,27 +1,27 @@
 /***********************************************************************;
  * Copyright (c) 2015, Intel Corporation
  * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
+ *
+ * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
- * 1. Redistributions of source code must retain the above copyright notice, 
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
- * 
- * 2. Redistributions in binary form must reproduce the above copyright notice, 
- * this list of conditions and the following disclaimer in the documentation 
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
  ***********************************************************************/
 

--- a/sysapi/sysapi_util/Unmarshal_TPMU_HA.c
+++ b/sysapi/sysapi_util/Unmarshal_TPMU_HA.c
@@ -46,7 +46,7 @@ void Unmarshal_TPMU_HA(
 	{
 #ifdef TPM_ALG_SHA
 	case TPM_ALG_SHA:
-		
+
 	for( i = 0; i < SHA_DIGEST_SIZE; i++ )
 	{
 		Unmarshal_UINT8( SYS_CONTEXT->tpmOutBuffPtr, SYS_CONTEXT->maxResponseSize, &(SYS_CONTEXT->nextData), &ha->sha[i], &( SYS_CONTEXT->rval ) );
@@ -55,7 +55,7 @@ void Unmarshal_TPMU_HA(
 #endif
 #ifdef TPM_ALG_SHA1
 	case TPM_ALG_SHA1:
-		
+
 	for( i = 0; i < SHA1_DIGEST_SIZE; i++ )
 	{
 		Unmarshal_UINT8( SYS_CONTEXT->tpmOutBuffPtr, SYS_CONTEXT->maxResponseSize, &(SYS_CONTEXT->nextData), &ha->sha1[i], &( SYS_CONTEXT->rval ) );
@@ -64,7 +64,7 @@ void Unmarshal_TPMU_HA(
 #endif
 #ifdef TPM_ALG_SHA256
 	case TPM_ALG_SHA256:
-		
+
 	for( i = 0; i < SHA256_DIGEST_SIZE; i++ )
 	{
 		Unmarshal_UINT8( SYS_CONTEXT->tpmOutBuffPtr, SYS_CONTEXT->maxResponseSize, &(SYS_CONTEXT->nextData), &ha->sha256[i], &( SYS_CONTEXT->rval ) );
@@ -73,7 +73,7 @@ void Unmarshal_TPMU_HA(
 #endif
 #ifdef TPM_ALG_SHA384
 	case TPM_ALG_SHA384:
-		
+
 	for( i = 0; i < SHA384_DIGEST_SIZE; i++ )
 	{
 		Unmarshal_UINT8( SYS_CONTEXT->tpmOutBuffPtr, SYS_CONTEXT->maxResponseSize, &(SYS_CONTEXT->nextData), &ha->sha384[i], &( SYS_CONTEXT->rval ) );
@@ -82,7 +82,7 @@ void Unmarshal_TPMU_HA(
 #endif
 #ifdef TPM_ALG_SHA512
 	case TPM_ALG_SHA512:
-		
+
 	for( i = 0; i < SHA512_DIGEST_SIZE; i++ )
 	{
 		Unmarshal_UINT8( SYS_CONTEXT->tpmOutBuffPtr, SYS_CONTEXT->maxResponseSize, &(SYS_CONTEXT->nextData), &ha->sha512[i], &( SYS_CONTEXT->rval ) );
@@ -91,7 +91,7 @@ void Unmarshal_TPMU_HA(
 #endif
 #ifdef TPM_ALG_SM3_256
 	case TPM_ALG_SM3_256:
-		
+
 	for( i = 0; i < SM3_256_DIGEST_SIZE; i++ )
 	{
 		Unmarshal_UINT8( SYS_CONTEXT->tpmOutBuffPtr, SYS_CONTEXT->maxResponseSize, &(SYS_CONTEXT->nextData), &ha->sm3_256[i], &( SYS_CONTEXT->rval ) );

--- a/sysapi/sysapi_util/copymem.c
+++ b/sysapi/sysapi_util/copymem.c
@@ -31,7 +31,7 @@ TSS2_RC CopyMem( UINT8 *dest, const UINT8 *src, const size_t len, const UINT8 *l
 {
     size_t i;
     TSS2_RC rval = TSS2_RC_SUCCESS;
-    
+
     if( ( dest + len ) <= limit )
     {
         for( i = 0; i < len; i++ )
@@ -48,7 +48,7 @@ TSS2_RC CopyMemReverse( UINT8 *dest, const UINT8 *src, const size_t len, const U
 {
     int i;
     TSS2_RC rval = TSS2_RC_SUCCESS;
-    
+
     if( dest < limit )
     {
         for( i = len - 1; i >= 0; i-- )

--- a/sysapi/sysapi_util/marshal_uint32.c
+++ b/sysapi/sysapi_util/marshal_uint32.c
@@ -48,4 +48,3 @@ void Marshal_UINT32( UINT8 *inBuffPtr, UINT32 maxCommandSize, UINT8 **nextData, 
         }
     }
 }
-    

--- a/sysapi/sysapi_util/marshal_uint64.c
+++ b/sysapi/sysapi_util/marshal_uint64.c
@@ -48,4 +48,3 @@ void Marshal_UINT64( UINT8 *inBuffPtr, UINT32 maxCommandSize, UINT8 **nextData, 
         }
     }
 }
-    

--- a/sysapi/sysapi_util/unmarshal_simple_tpm2b.c
+++ b/sysapi/sysapi_util/unmarshal_simple_tpm2b.c
@@ -33,10 +33,10 @@ void Unmarshal_Simple_TPM2B( UINT8 *outBuffPtr, UINT32 maxResponseSize, UINT8 **
 //deleted for now--spec issues with nested TPM2B's
 #if 0
     INT64 callerAllocatedSize;
-#endif    
+#endif
     int i;
     UINT16 length;
-    
+
     if( *rval == TSS2_RC_SUCCESS )
     {
         if( outBuffPtr == 0 || nextData == 0 || *nextData == 0 )

--- a/sysapi/sysapi_util/unmarshal_simple_tpm2b_no_size_check.c
+++ b/sysapi/sysapi_util/unmarshal_simple_tpm2b_no_size_check.c
@@ -1,26 +1,26 @@
 //**********************************************************************;
 // Copyright (c) 2015, Intel Corporation All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
+//
+// Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
-// 1. Redistributions of source code must retain the above copyright notice, 
+//
+// 1. Redistributions of source code must retain the above copyright notice,
 // this list of conditions and the following disclaimer.
-// 
-// 2. Redistributions in binary form must reproduce the above copyright notice, 
-// this list of conditions and the following disclaimer in the documentation 
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
 // and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 //**********************************************************************;
 
@@ -32,10 +32,10 @@ void Unmarshal_Simple_TPM2B_NoSizeCheck( UINT8 *outBuffPtr, UINT32 maxResponseSi
 //deleted for now--spec issues with nested TPM2B's
 #if 0
     INT64 callerAllocatedSize;
-#endif    
+#endif
     int i;
     UINT16 length;
-    
+
     if( *rval == TSS2_RC_SUCCESS )
     {
         if( outBuffPtr == 0 || nextData == 0 || *nextData == 0 )

--- a/tcti/commonchecks.c
+++ b/tcti/commonchecks.c
@@ -1,27 +1,27 @@
 //**********************************************************************;
 // Copyright (c) 2015, Intel Corporation
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
+//
+// Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
-// 1. Redistributions of source code must retain the above copyright notice, 
+//
+// 1. Redistributions of source code must retain the above copyright notice,
 // this list of conditions and the following disclaimer.
-// 
-// 2. Redistributions in binary form must reproduce the above copyright notice, 
-// this list of conditions and the following disclaimer in the documentation 
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
 // and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 //**********************************************************************;
 
@@ -43,13 +43,13 @@ TSS2_RC CommonSendChecks(
     )
 {
     TSS2_RC rval = TSS2_RC_SUCCESS;
-    
+
     if( tctiContext == NULL || command_buffer == NULL )
     {
         rval = TSS2_TCTI_RC_BAD_REFERENCE;
         goto returnFromCommonSendChecks;
-    }        
-    
+    }
+
     if( ( (TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->previousStage == TCTI_STAGE_SEND_COMMAND )
     {
         rval = TSS2_TCTI_RC_BAD_SEQUENCE;
@@ -62,14 +62,14 @@ TSS2_RC CommonSendChecks(
         rval = TSS2_TCTI_RC_BAD_CONTEXT;
         goto returnFromCommonSendChecks;
     }
-    
+
 returnFromCommonSendChecks:
 
     return rval;
 }
 
 
-TSS2_RC CommonReceiveChecks( 
+TSS2_RC CommonReceiveChecks(
     TSS2_TCTI_CONTEXT *tctiContext,     /* in */
     size_t          *response_size,     /* out */
     unsigned char   *response_buffer    /* in */
@@ -81,7 +81,7 @@ TSS2_RC CommonReceiveChecks(
     {
         rval = TSS2_TCTI_RC_BAD_REFERENCE;
         goto retCommonReceiveChecks;
-    }        
+    }
 
     if( ( (TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->previousStage == TCTI_STAGE_RECEIVE_RESPONSE )
     {
@@ -95,7 +95,7 @@ TSS2_RC CommonReceiveChecks(
         rval = TSS2_TCTI_RC_BAD_CONTEXT;
         goto retCommonReceiveChecks;
     }
-    
+
 retCommonReceiveChecks:
 
     return rval;

--- a/tcti/commonchecks.h
+++ b/tcti/commonchecks.h
@@ -1,27 +1,27 @@
 //**********************************************************************;
 // Copyright (c) 2015, Intel Corporation
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without 
+//
+// Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
-// 
-// 1. Redistributions of source code must retain the above copyright notice, 
+//
+// 1. Redistributions of source code must retain the above copyright notice,
 // this list of conditions and the following disclaimer.
-// 
-// 2. Redistributions in binary form must reproduce the above copyright notice, 
-// this list of conditions and the following disclaimer in the documentation 
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
 // and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 //**********************************************************************;
 
@@ -37,7 +37,7 @@ TSS2_RC CommonSendChecks(
     uint8_t           *command_buffer     /* in */
     );
 
-TSS2_RC CommonReceiveChecks( 
+TSS2_RC CommonReceiveChecks(
     TSS2_TCTI_CONTEXT *tctiContext,     /* in */
     size_t          *response_size,     /* out */
     unsigned char   *response_buffer    /* in */

--- a/tcti/tcti_device.c
+++ b/tcti/tcti_device.c
@@ -65,7 +65,7 @@ TSS2_RC LocalTpmSendTpmCommand(
     UINT32 cnt;
 #endif
     printf_type rmPrefix;
-    
+
     rval = CommonSendChecks( tctiContext, command_buffer );
 
     if( rval == TSS2_RC_SUCCESS )
@@ -95,7 +95,7 @@ TSS2_RC LocalTpmSendTpmCommand(
             rval = TSS2_TCTI_RC_IO_ERROR;
         }
         else if( (size_t)size != command_size )
-        {        
+        {
             rval = TSS2_TCTI_RC_IO_ERROR;
         }
 
@@ -108,7 +108,7 @@ TSS2_RC LocalTpmSendTpmCommand(
 
         }
     }
-    
+
     return rval;
 }
 
@@ -123,12 +123,12 @@ TSS2_RC LocalTpmReceiveTpmResponse(
     ssize_t  size;
     unsigned int i;
     printf_type rmPrefix;
-    
+
     rval = CommonReceiveChecks( tctiContext, response_size, response_buffer );
     if( rval != TSS2_RC_SUCCESS )
     {
         goto retLocalTpmReceive;
-    }        
+    }
 
     if( ( ( TSS2_TCTI_CONTEXT_INTEL *)tctiContext )->status.rmDebugPrefix == 1 )
         rmPrefix = RM_PREFIX;
@@ -153,7 +153,7 @@ TSS2_RC LocalTpmReceiveTpmResponse(
 
         ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->responseSize = size;
     }
-    
+
     if( response_buffer == NULL )
     {
         // In this case, just return the size
@@ -163,10 +163,10 @@ TSS2_RC LocalTpmReceiveTpmResponse(
 
     if( *response_size < ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->responseSize )
     {
-        rval = TSS2_TCTI_RC_INSUFFICIENT_BUFFER; 
+        rval = TSS2_TCTI_RC_INSUFFICIENT_BUFFER;
         *response_size = ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->responseSize;
         goto retLocalTpmReceive;
-    }        
+    }
 
     *response_size = ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->responseSize;
 
@@ -186,15 +186,15 @@ TSS2_RC LocalTpmReceiveTpmResponse(
 #endif
 
     ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->status.commandSent = 0;
-    
+
 retLocalTpmReceive:
 
-    if( rval == TSS2_RC_SUCCESS && 
+    if( rval == TSS2_RC_SUCCESS &&
 		response_buffer != NULL )
     {
         ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->previousStage = TCTI_STAGE_RECEIVE_RESPONSE;
     }
-    
+
     return rval;
 }
 
@@ -227,7 +227,7 @@ TSS2_RC LocalTpmSetLocality(
     TSS2_RC rval = TSS2_RC_SUCCESS;
 
     // TBD:  how do I do this?
-    
+
     return rval;
 }
 
@@ -268,7 +268,7 @@ TSS2_RC InitDeviceTcti (
         TCTI_LOG_DATA( tctiContext ) = config->logData;
 
         ( ( (TSS2_TCTI_CONTEXT_INTEL *)tctiContext )->devFile ) = open( config->device_path, O_RDWR );
-        if( ( (TSS2_TCTI_CONTEXT_INTEL *)tctiContext )->devFile < 0 ) 
+        if( ( (TSS2_TCTI_CONTEXT_INTEL *)tctiContext )->devFile < 0 )
         {
             return( TSS2_TCTI_RC_IO_ERROR );
         }

--- a/tcti/tcti_socket.cpp
+++ b/tcti/tcti_socket.cpp
@@ -92,7 +92,7 @@ TSS2_RC SendSessionEndSocketTcti(
     UINT32 tpmSendCommand = TPM_SESSION_END;  // Value for "send command" to MS simulator.
     SOCKET sock;
     TSS2_RC rval = TSS2_RC_SUCCESS;
-    
+
     if( tpmCmdServer )
     {
         sock = TCTI_CONTEXT_INTEL->tpmSock;
@@ -101,7 +101,7 @@ TSS2_RC SendSessionEndSocketTcti(
     {
         sock = TCTI_CONTEXT_INTEL->otherSock;
     }
-        
+
     tpmSendCommand = CHANGE_ENDIAN_DWORD(tpmSendCommand);
     rval = tctiSendBytes( tctiContext, sock, (char unsigned *)&tpmSendCommand, 4 );
 
@@ -118,8 +118,8 @@ TSS2_RC SocketSendTpmCommand(
     UINT32 cnt, cnt1;
     UINT8 locality;
     TSS2_RC rval = TSS2_RC_SUCCESS;
-    
-#ifdef DEBUG    
+
+#ifdef DEBUG
     UINT32 commandCode;
     printf_type rmPrefix;
 #endif
@@ -156,7 +156,7 @@ TSS2_RC SocketSendTpmCommand(
     rval = tctiSendBytes( tctiContext, TCTI_CONTEXT_INTEL->tpmSock, (unsigned char *)&tpmSendCommand, 4 );
     if( rval != TSS2_RC_SUCCESS )
         goto returnFromSocketSendTpmCommand;
-                
+
     // Send the locality
     locality = (UINT8)( (TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->status.locality;
     rval = tctiSendBytes( tctiContext, TCTI_CONTEXT_INTEL->tpmSock, (unsigned char *)&locality, 1 );
@@ -169,19 +169,19 @@ TSS2_RC SocketSendTpmCommand(
         TCTI_LOG( tctiContext, rmPrefix, "Locality = %d", ( (TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->status.locality );
     }
 #endif
-    
+
     // Send number of bytes.
     cnt1 = cnt;
     cnt = CHANGE_ENDIAN_DWORD(cnt);
     rval = tctiSendBytes( tctiContext, TCTI_CONTEXT_INTEL->tpmSock, (unsigned char *)&cnt, 4 );
     if( rval != TSS2_RC_SUCCESS )
         goto returnFromSocketSendTpmCommand;
-    
+
     // Send the TPM command buffer
     rval = tctiSendBytes( tctiContext, TCTI_CONTEXT_INTEL->tpmSock, (unsigned char *)command_buffer, cnt1 );
     if( rval != TSS2_RC_SUCCESS )
         goto returnFromSocketSendTpmCommand;
-    
+
 #ifdef DEBUG
     if( ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext )->status.debugMsgEnabled == 1 )
     {
@@ -229,7 +229,7 @@ TSS2_RC SocketCancel(
                 TCTI_LOG( tctiContext, NO_PREFIX, "%s sent cancel ON command:\n", interfaceName );
             }
         }
-#endif        
+#endif
     }
 
     return rval;
@@ -297,8 +297,8 @@ TSS2_RC SocketReceiveTpmResponse(
     if( rval != TSS2_RC_SUCCESS )
     {
         goto retSocketReceiveTpmResponse;
-    }        
-    
+    }
+
     if( ( ( TSS2_TCTI_CONTEXT_INTEL *)tctiContext )->status.rmDebugPrefix == 1 )
         rmPrefix = RM_PREFIX;
     else
@@ -339,7 +339,7 @@ TSS2_RC SocketReceiveTpmResponse(
     }
 
     if( ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->status.protocolResponseSizeReceived != 1 )
-    {        
+    {
         // Receive the size of the response.
         rval = tctiRecvBytes( tctiContext, TCTI_CONTEXT_INTEL->tpmSock, (unsigned char *)& (((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->responseSize ), 4 );
         if( rval != TSS2_RC_SUCCESS )
@@ -360,7 +360,7 @@ TSS2_RC SocketReceiveTpmResponse(
     if( *response_size < ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->responseSize )
     {
         *response_size = ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->responseSize;
-        rval = TSS2_TCTI_RC_INSUFFICIENT_BUFFER; 
+        rval = TSS2_TCTI_RC_INSUFFICIENT_BUFFER;
 
 
         // If possible, receive tag from TPM.
@@ -402,7 +402,7 @@ TSS2_RC SocketReceiveTpmResponse(
             TCTI_LOG( tctiContext, rmPrefix, "from socket #0x%x:\n", TCTI_CONTEXT_INTEL->tpmSock );
 #endif
         }
-        
+
         if( ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->status.tagReceived == 1 )
         {
             *(TPM_ST *)response_buffer = ( (TSS2_TCTI_CONTEXT_INTEL *)tctiContext )->tag;
@@ -439,7 +439,7 @@ TSS2_RC SocketReceiveTpmResponse(
     {
         *response_size = ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->responseSize;
     }
-    
+
     ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->status.commandSent = 0;
 
     // Turn cancel off.
@@ -459,12 +459,12 @@ TSS2_RC SocketReceiveTpmResponse(
     }
 
 retSocketReceiveTpmResponse:
-    if( rval == TSS2_RC_SUCCESS && 
+    if( rval == TSS2_RC_SUCCESS &&
 		response_buffer != NULL )
     {
         ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->previousStage = TCTI_STAGE_RECEIVE_RESPONSE;
     }
-    
+
     return rval;
 }
 
@@ -524,7 +524,7 @@ TSS2_RC InitSocketTcti (
         else
         {
             CloseSockets( otherSock, tpmSock);
-        }            
+        }
     }
 
     return rval;
@@ -533,7 +533,7 @@ TSS2_RC InitSocketTcti (
 TSS2_RC TeardownSocketTcti (TSS2_TCTI_CONTEXT *tctiContext)
 {
     ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->finalize( tctiContext );
-  
+
     return TSS2_RC_SUCCESS;
 }
 

--- a/test/common/sample/CopySizedBuffer.c
+++ b/test/common/sample/CopySizedBuffer.c
@@ -31,7 +31,7 @@ UINT16 CopySizedByteBuffer( TPM2B *dest, TPM2B *src )
 {
     int i;
     UINT16 rval = 0;
-    
+
     if( dest != 0 )
     {
         if( src == 0 )

--- a/test/common/sample/DecryptEncrypt.c
+++ b/test/common/sample/DecryptEncrypt.c
@@ -32,10 +32,10 @@
 TSS2_RC GetBlockSizeInBits( TPMI_ALG_SYM algorithm, UINT32 *blockSizeInBits )
 {
     TSS2_RC rval = TSS2_RC_SUCCESS;
-    
+
     if( algorithm == TPM_ALG_AES )
         *blockSizeInBits = 128;
-    else if( algorithm == TPM_ALG_SM3_256 ) 
+    else if( algorithm == TPM_ALG_SM3_256 )
         *blockSizeInBits = 128;
     else
         rval = TSS2_APP_RC_BAD_ALGORITHM;
@@ -53,7 +53,7 @@ TSS2_RC GenerateSessionEncryptDecryptKey( SESSION *session, TPM2B_MAX_BUFFER *cf
 
     CopySizedByteBuffer( &sessionValue.b, &session->sessionKey.b );
     CatSizedByteBuffer( &sessionValue.b, &authValue->b );
-    
+
     if( rval == TSS2_RC_SUCCESS )
     {
         INIT_SIMPLE_TPM2B_SIZE( key );
@@ -103,7 +103,7 @@ UINT32 LoadSessionEncryptDecryptKey( TPMT_SYM_DEF *symmetric, TPM2B_MAX_BUFFER *
     TPM2B_PUBLIC inPublic;
     UINT32 rval;
     TSS2_SYS_CONTEXT *sysContext;
-    
+
     keyAuth.size = 0;
 
     inPrivate.t.sensitiveArea.sensitiveType = TPM_ALG_SYMCIPHER;
@@ -134,7 +134,7 @@ UINT32 LoadSessionEncryptDecryptKey( TPMT_SYM_DEF *symmetric, TPM2B_MAX_BUFFER *
     rval = Tss2_Sys_LoadExternal( sysContext, 0, &inPrivate, &inPublic, TPM_RH_NULL, keyHandle, keyName, 0 );
 
     TeardownSysContext( &sysContext );
-    
+
     return rval;
 }
 
@@ -187,7 +187,7 @@ TSS2_RC EncryptCFB( SESSION *session, TPM2B_MAX_BUFFER *encryptedData, TPM2B_MAX
         }
     }
     TeardownSysContext( &sysContext );
-    
+
     return rval;
 }
 
@@ -241,7 +241,7 @@ TSS2_RC DecryptCFB( SESSION *session, TPM2B_MAX_BUFFER *clearData, TPM2B_MAX_BUF
         }
     }
     TeardownSysContext( &sysContext );
-    
+
     return rval;
 }
 
@@ -254,7 +254,7 @@ TSS2_RC EncryptDecryptXOR( SESSION *session, TPM2B_MAX_BUFFER *outputData, TPM2B
 
     CopySizedByteBuffer( &key.b, &session->sessionKey.b );
     CatSizedByteBuffer( &key.b, &authValue->b );
-    
+
     rval = KDFa( session->authHash, &key.b, "XOR", &session->nonceNewer.b, &session->nonceOlder.b, inputData->t.size * 8, &mask );
     if( rval == TSS2_RC_SUCCESS )
     {
@@ -272,7 +272,7 @@ TSS2_RC EncryptDecryptXOR( SESSION *session, TPM2B_MAX_BUFFER *outputData, TPM2B
 TSS2_RC EncryptCommandParam( SESSION *session, TPM2B_MAX_BUFFER *encryptedData, TPM2B_MAX_BUFFER *clearData, TPM2B_AUTH *authValue )
 {
     TSS2_RC rval = TSS2_RC_SUCCESS;
-    
+
     if( session->symmetric.algorithm == TPM_ALG_AES )
     {
         // CFB mode encryption.
@@ -290,7 +290,7 @@ TSS2_RC EncryptCommandParam( SESSION *session, TPM2B_MAX_BUFFER *encryptedData, 
 TSS2_RC DecryptResponseParam( SESSION *session, TPM2B_MAX_BUFFER *clearData, TPM2B_MAX_BUFFER *encryptedData, TPM2B_AUTH *authValue )
 {
     TSS2_RC rval = TSS2_RC_SUCCESS;
-    
+
     if( session->symmetric.algorithm == TPM_ALG_AES )
     {
         // CFB mode decryption.

--- a/test/common/sample/Entity.c
+++ b/test/common/sample/Entity.c
@@ -51,19 +51,19 @@ TPM_RC AddEntity( TPM_HANDLE entityHandle, TPM2B_AUTH *auth )
 {
     int i;
     TPM_RC rval = TPM_RC_FAILURE;
-    
+
     for( i = 0; i < MAX_NUM_ENTITIES; i++ )
     {
         if( entities[i].entityHandle == TPM_HT_NO_HANDLE )
         {
-            entities[i].entityHandle = entityHandle; 
+            entities[i].entityHandle = entityHandle;
             CopySizedByteBuffer( &( entities[i].entityAuth.b ), &( auth->b ) );
 
             if( ( entityHandle >> HR_SHIFT ) == TPM_HT_NV_INDEX )
             {
                 entities[i].nvNameChanged = 0;
             }
-            
+
             rval = TPM_RC_SUCCESS;
             break;
         }
@@ -75,12 +75,12 @@ TPM_RC DeleteEntity( TPM_HANDLE entityHandle )
 {
     int i;
     TPM_RC rval = TPM_RC_FAILURE;
-    
+
     for( i = 0; i < MAX_NUM_ENTITIES; i++ )
     {
         if( entities[i].entityHandle == entityHandle )
         {
-            entities[i].entityHandle = TPM_HT_NO_HANDLE; 
+            entities[i].entityHandle = TPM_HT_NO_HANDLE;
             rval = TPM_RC_SUCCESS;
             break;
         }
@@ -92,7 +92,7 @@ TPM_RC GetEntityAuth( TPM_HANDLE entityHandle, TPM2B_AUTH *auth )
 {
     int i;
     TPM_RC rval = TPM_RC_FAILURE;
-    
+
     for( i = 0; i < MAX_NUM_ENTITIES; i++ )
     {
         if( entities[i].entityHandle == entityHandle )
@@ -110,7 +110,7 @@ TPM_RC GetEntity( TPM_HANDLE entityHandle, ENTITY **entity )
 {
     int i;
     TPM_RC rval = TPM_RC_FAILURE;
-    
+
     for( i = 0; i < MAX_NUM_ENTITIES; i++ )
     {
         if( entities[i].entityHandle == entityHandle )

--- a/test/common/sample/LoadExternalHMACKey.c
+++ b/test/common/sample/LoadExternalHMACKey.c
@@ -37,7 +37,7 @@ UINT32 LoadExternalHMACKey( TPMI_ALG_HASH hashAlg, TPM2B *key, TPM_HANDLE *keyHa
     TPM2B_PUBLIC inPublic;
     UINT32 rval;
     TSS2_SYS_CONTEXT *sysContext;
-    
+
     keyAuth.size = 0;
 
     inPrivate.t.sensitiveArea.sensitiveType = TPM_ALG_KEYEDHASH;
@@ -67,6 +67,6 @@ UINT32 LoadExternalHMACKey( TPMI_ALG_HASH hashAlg, TPM2B *key, TPM_HANDLE *keyHa
     rval = Tss2_Sys_LoadExternal( sysContext, 0, &inPrivate, &inPublic, TPM_RH_NULL, keyHandle, keyName, 0 );
 
     TeardownSysContext( &sysContext );
-    
+
     return rval;
 }

--- a/test/common/sample/StartAuthSession.c
+++ b/test/common/sample/StartAuthSession.c
@@ -46,7 +46,7 @@ INT16 sessionEntriesUsed = 0;
 TPM_RC AddSession( SESSION_LIST_ENTRY **sessionEntry )
 {
     SESSION_LIST_ENTRY **lastEntry, *newEntry;
-    
+
 //    DebugPrintf( 0, "In AddSession\n" );
 
     // find end of list.
@@ -66,7 +66,7 @@ TPM_RC AddSession( SESSION_LIST_ENTRY **sessionEntry )
     {
         return TSS2_APP_RC_SESSION_SLOT_NOT_FOUND;
     }
-} 
+}
 
 
 void DeleteSession( SESSION *session )
@@ -75,7 +75,7 @@ void DeleteSession( SESSION *session )
     SESSION_LIST_ENTRY *newNextEntry;
 
 //    DebugPrintf( 0, "In DeleteSession\n" );
-    
+
     if( session == &sessionsList->session )
         sessionsList = 0;
     else
@@ -132,7 +132,7 @@ TPM_RC GetSessionAlgId( TPMI_SH_AUTH_SESSION sessionHandle, TPMI_ALG_HASH *sessi
     SESSION *session;
 
     DebugPrintf( 0, "In GetSessionAlgId\n" );
-    
+
     rval = GetSessionStruct( sessionHandle, &session );
 
     if( rval == TSS2_RC_SUCCESS )
@@ -164,7 +164,7 @@ TPM_RC StartAuthSession( SESSION *session, TSS2_TCTI_CONTEXT *tctiContext )
     TSS2_SYS_CONTEXT *tmpSysContext;
     UINT16 bytes;
     int i;
-    
+
     key.t.size = 0;
 
     tmpSysContext = InitSysContext( 1000, tctiContext, &abiVersion );
@@ -175,7 +175,7 @@ TPM_RC StartAuthSession( SESSION *session, TSS2_TCTI_CONTEXT *tctiContext )
     {
         session->nonceOlder.t.size = GetDigestSize( TPM_ALG_SHA1 );
         for( i = 0; i < session->nonceOlder.t.size; i++ )
-            session->nonceOlder.t.buffer[i] = 0; 
+            session->nonceOlder.t.buffer[i] = 0;
     }
 
     session->nonceNewer.t.size = session->nonceOlder.t.size;
@@ -220,7 +220,7 @@ TPM_RC StartAuthSession( SESSION *session, TSS2_TCTI_CONTEXT *tctiContext )
             }
             else
             {
-                rval = KDFa( session->authHash, &(key.b), label, &( session->nonceNewer.b ), 
+                rval = KDFa( session->authHash, &(key.b), label, &( session->nonceNewer.b ),
                         &( session->nonceOlder.b ), bytes * 8, (TPM2B_MAX_BUFFER *)&( session->sessionKey ) );
             }
 
@@ -251,7 +251,7 @@ TPM_RC StartAuthSession( SESSION *session, TSS2_TCTI_CONTEXT *tctiContext )
 // some uses.
 //
 TPM_RC StartAuthSessionWithParams( SESSION **session,
-    TPMI_DH_OBJECT tpmKey, TPM2B_MAX_BUFFER *salt, 
+    TPMI_DH_OBJECT tpmKey, TPM2B_MAX_BUFFER *salt,
     TPMI_DH_ENTITY bind, TPM2B_AUTH *bindAuth, TPM2B_NONCE *nonceCaller,
     TPM2B_ENCRYPTED_SECRET *encryptedSalt,
     TPM_SE sessionType, TPMT_SYM_DEF *symmetric, TPMI_ALG_HASH algId,
@@ -259,12 +259,12 @@ TPM_RC StartAuthSessionWithParams( SESSION **session,
 {
     TPM_RC rval;
     SESSION_LIST_ENTRY *sessionEntry;
-    
+
     rval = AddSession( &sessionEntry );
     if( rval == TSS2_RC_SUCCESS )
     {
         *session = &sessionEntry->session;
-        
+
         // Copy handles to session struct.
         (*session)->bind = bind;
         (*session)->tpmKey = tpmKey;
@@ -289,7 +289,7 @@ TPM_RC StartAuthSessionWithParams( SESSION **session,
         // Copy bind' authValue.
         if( bindAuth == 0 )
         {
-            (*session)->authValueBind.b.size = 0;   
+            (*session)->authValueBind.b.size = 0;
         }
         else
         {
@@ -325,9 +325,9 @@ TPM_RC StartAuthSessionWithParams( SESSION **session,
 TPM_RC EndAuthSession( SESSION *session )
 {
     TPM_RC rval = TPM_RC_SUCCESS;
-    
+
     DeleteSession( session );
 
     return rval;
-}   
+}
 

--- a/test/common/sample/TpmCalcPHash.c
+++ b/test/common/sample/TpmCalcPHash.c
@@ -122,7 +122,7 @@ TPM_RC TpmCalcPHash( TSS2_SYS_CONTEXT *sysContext, TPM_HANDLE handle1, TPM_HANDL
     if( rval != TPM_RC_SUCCESS )
         return rval;
 
-    hashInputPtr = &( hashInput.t.buffer[hashInput.b.size] );    
+    hashInputPtr = &( hashInput.t.buffer[hashInput.b.size] );
     *(UINT32 *)hashInputPtr = CHANGE_ENDIAN_DWORD( *(UINT32 *)cmdCodePtr );
     hashInput.t.size += 4;
 

--- a/test/common/sample/TpmHandleToName.c
+++ b/test/common/sample/TpmHandleToName.c
@@ -39,7 +39,7 @@ UINT32 TpmHandleToName( TPM_HANDLE handle, TPM2B_NAME *name )
     TPM2B_NV_PUBLIC nvPublic;
     TSS2_SYS_CONTEXT *sysContext;
     UINT8 *namePtr = &( name->t.name[0] );
-    
+
     // Initialize name to zero length in case of failure.
     INIT_SIMPLE_TPM2B_SIZE( *name );
     INIT_SIMPLE_TPM2B_SIZE( qualifiedName );
@@ -61,7 +61,7 @@ UINT32 TpmHandleToName( TPM_HANDLE handle, TPM2B_NAME *name )
                 nvPublic.t.size = 0;
                 rval = Tss2_Sys_NV_ReadPublic( sysContext, handle, 0, &nvPublic, name, 0 );
                 TeardownSysContext( &sysContext );
-                break;  
+                break;
 
             case TPM_HT_TRANSIENT:
             case TPM_HT_PERSISTENT:
@@ -73,7 +73,7 @@ UINT32 TpmHandleToName( TPM_HANDLE handle, TPM2B_NAME *name )
 				rval = Tss2_Sys_ReadPublic( sysContext, handle, 0, &public, name, &qualifiedName, 0 );
                 TeardownSysContext( &sysContext );
                 break;
-                    
+
             default:
                 rval = TPM_RC_SUCCESS;
                 name->b.size = sizeof( TPM_HANDLE );

--- a/test/common/sample/TpmHash.c
+++ b/test/common/sample/TpmHash.c
@@ -38,20 +38,20 @@ UINT32 TpmHash( TPMI_ALG_HASH hashAlg, UINT16 size, BYTE *data, TPM2B_DIGEST *re
     TPM2B_MAX_BUFFER dataSizedBuffer;
     UINT16 i;
     TSS2_SYS_CONTEXT *sysContext;
-    
+
     dataSizedBuffer.t.size = size;
     for( i = 0; i < size; i++ )
         dataSizedBuffer.t.buffer[i] = data[i];
-    
+
     sysContext = InitSysContext( 3000, resMgrTctiContext, &abiVersion );
     if( sysContext == 0 )
         return TSS2_APP_RC_INIT_SYS_CONTEXT_FAILED;
-    
+
     INIT_SIMPLE_TPM2B_SIZE( *result );
     rval = Tss2_Sys_Hash ( sysContext, 0, &dataSizedBuffer, hashAlg, TPM_RH_NULL, result, 0, 0);
 
     TeardownSysContext( &sysContext );
-    
+
     return rval;
 }
 
@@ -78,17 +78,17 @@ UINT32 TpmHashSequence( TPMI_ALG_HASH hashAlg, UINT8 numBuffers, TPM2B_DIGEST *b
 
     // Set result size to 0, in case any errors occur
     result->b.size = 0;
-    
+
     // Init input sessions struct
     cmdAuth.sessionHandle = TPM_RS_PW;
     cmdAuth.nonce.t.size = 0;
     *( (UINT8 *)((void *)&cmdAuth.sessionAttributes ) ) = 0;
     cmdAuth.hmac.t.size = 0;
-    
+
     sysContext = InitSysContext( 3000, resMgrTctiContext, &abiVersion );
     if( sysContext == 0 )
         return TSS2_APP_RC_INIT_SYS_CONTEXT_FAILED;
-    
+
     rval = Tss2_Sys_HashSequenceStart( sysContext, 0, &nullAuth, hashAlg, &sequenceHandle, 0 );
 
     if( rval != TPM_RC_SUCCESS )

--- a/test/common/sample/TpmHmac.c
+++ b/test/common/sample/TpmHmac.c
@@ -53,16 +53,16 @@ UINT32 TpmHmac( TPMI_ALG_HASH hashAlg, TPM2B *key, TPM2B **bufferList, TPM2B_DIG
     UINT32 rval;
     TPM_HANDLE keyHandle;
     TPM2B_NAME keyName;
-    
+
     TPM2B keyAuth;
     TSS2_SYS_CONTEXT *sysContext;
 
     sessionDataArray[0] = &sessionData;
     sessionDataOutArray[0] = &sessionDataOut;
-    
+
     // Set result size to 0, in case any errors occur
     result->b.size = 0;
-    
+
     keyAuth.size = 0;
     nullAuth.t.size = 0;
 
@@ -71,7 +71,7 @@ UINT32 TpmHmac( TPMI_ALG_HASH hashAlg, TPM2B *key, TPM2B **bufferList, TPM2B_DIG
     {
         return( rval );
     }
-    
+
     // Init input sessions struct
     sessionData.sessionHandle = TPM_RS_PW;
     nonce.t.size = 0;
@@ -85,13 +85,13 @@ UINT32 TpmHmac( TPMI_ALG_HASH hashAlg, TPM2B *key, TPM2B **bufferList, TPM2B_DIG
     // Init sessions out struct
     sessionsDataOut.rspAuthsCount = 1;
     sessionsDataOut.rspAuths = &sessionDataOutArray[0];
-    
+
     emptyBuffer.size = 0;
 
     sysContext = InitSysContext( 3000, resMgrTctiContext, &abiVersion );
     if( sysContext == 0 )
         return TSS2_APP_ERROR_LEVEL + TPM_RC_FAILURE;
-    
+
     rval = Tss2_Sys_HMAC_Start( sysContext, keyHandle, &sessionsData, &nullAuth, hashAlg, &sequenceHandle, 0 );
 
     if( rval != TPM_RC_SUCCESS )

--- a/test/common/sample/kdfa.c
+++ b/test/common/sample/kdfa.c
@@ -45,15 +45,15 @@ TPM_RC KDFa( TPMI_ALG_HASH hashAlg, TPM2B *key, char *label,
     TPM_RC rval;
     int i, j;
     UINT16 bytes = bits / 8;
-    
+
 #ifdef DEBUG
     DebugPrintf( 0, "KDFA, hashAlg = %4.4x\n", hashAlg );
     DebugPrintf( 0, "\n\nKDFA, key = \n" );
     PrintSizedBuffer( key );
 #endif
-    
+
     resultKey->t .size = 0;
-    
+
     tpm2b_i_2.t.size = 4;
 
     tpm2bBits.t.size = 4;
@@ -67,7 +67,7 @@ TPM_RC KDFa( TPMI_ALG_HASH hashAlg, TPM2B *key, char *label,
     {
         tpm2bLabel.t.buffer[i] = label[i];
     }
-    
+
 #ifdef DEBUG
     DebugPrintf( 0, "\n\nKDFA, tpm2bLabel = \n" );
     PrintSizedBuffer( (TPM2B *)&tpm2bLabel );
@@ -78,7 +78,7 @@ TPM_RC KDFa( TPMI_ALG_HASH hashAlg, TPM2B *key, char *label,
     DebugPrintf( 0, "\n\nKDFA, contextV = \n" );
     PrintSizedBuffer( contextV );
 #endif
-    
+
     resultKey->t.size = 0;
 
     i = 1;
@@ -120,6 +120,6 @@ TPM_RC KDFa( TPMI_ALG_HASH hashAlg, TPM2B *key, char *label,
     DebugPrintf( 0, "\n\nKDFA, resultKey = \n" );
     PrintSizedBuffer( &( resultKey->b ) );
 #endif
-    
+
     return TPM_RC_SUCCESS;
 }

--- a/test/common/sample/sample.h
+++ b/test/common/sample/sample.h
@@ -48,13 +48,13 @@ enum TSS2_APP_RC_CODE
     APP_RC_PASSED,
     APP_RC_GET_NAME_FAILED,
     APP_RC_CREATE_SESSION_KEY_FAILED,
-    APP_RC_SESSION_SLOT_NOT_FOUND,            
-    APP_RC_BAD_ALGORITHM,            
+    APP_RC_SESSION_SLOT_NOT_FOUND,
+    APP_RC_BAD_ALGORITHM,
     APP_RC_SYS_CONTEXT_CREATE_FAILED,
     APP_RC_GET_SESSION_STRUCT_FAILED,
-    APP_RC_GET_SESSION_ALG_ID_FAILED, 
-    APP_RC_INIT_SYS_CONTEXT_FAILED, 
-    APP_RC_TEARDOWN_SYS_CONTEXT_FAILED, 
+    APP_RC_GET_SESSION_ALG_ID_FAILED,
+    APP_RC_INIT_SYS_CONTEXT_FAILED,
+    APP_RC_TEARDOWN_SYS_CONTEXT_FAILED,
     APP_RC_BAD_LOCALITY
 };
 
@@ -109,7 +109,7 @@ typedef struct {
     // other session related functions.
     TPMI_SH_AUTH_SESSION sessionHandle;
     TPM2B_NONCE nonceTPM;
-    
+
     // Internal state for the session
     TPM2B_DIGEST sessionKey;
     TPM2B_DIGEST authValueBind;     // authValue of bind object
@@ -172,7 +172,7 @@ extern UINT32 ( *ComputeSessionHmacPtr )(
     TPM_HANDLE handle2,                  // Second handle == 0xff000000 indicates no handle
     TPMA_SESSION sessionAttributes,      // Current session attributes
     TPM2B_DIGEST *result,                // Where the result hash is saved.
-    TPM_RC sessionCmdRval    
+    TPM_RC sessionCmdRval
     );
 
 
@@ -247,7 +247,7 @@ TPM_RC TpmCalcPHash( TSS2_SYS_CONTEXT *sysContext, TPM_HANDLE handle1,
 extern UINT32 (*HmacFunctionPtr)( TPMI_ALG_HASH hashAlg, TPM2B *key,TPM2B **bufferList, TPM2B_DIGEST *result );
 
 //
-// Pointer to generic hash wrapper function.  
+// Pointer to generic hash wrapper function.
 //
 // Inputs:
 //

--- a/test/tpmclient/tpmclient.cpp
+++ b/test/tpmclient/tpmclient.cpp
@@ -98,7 +98,7 @@
                                               (pcrSelection).pcrSelect[2] = 0;
 
 #define SET_PCR_SELECT_SIZE( pcrSelection, size ) \
-                                                  (pcrSelection).sizeofSelect = size; 
+                                                  (pcrSelection).sizeofSelect = size;
 
 TPM_CC currentCommandCode;
 TPM_CC *currentCommandCodePtr = &currentCommandCode;
@@ -138,7 +138,7 @@ TCTI_SOCKET_CONF rmInterfaceConfig = {
     DebugPrintBufferCallback,
     NULL
 };
-    
+
 TSS2_TCTI_CONTEXT *resMgrTctiContext = 0;
 TSS2_ABI_VERSION abiVersion = { TSSWG_INTEROP, TSS_SAPI_FIRST_FAMILY, TSS_SAPI_FIRST_LEVEL, TSS_SAPI_FIRST_VERSION };
 
@@ -167,7 +167,7 @@ UINT32 ( *ComputeSessionHmacPtr )(
     TPM_HANDLE handle2,                  // Second handle == 0xff000000 indicates no handle
     TPMA_SESSION sessionAttributes,      // Current session attributes
     TPM2B_DIGEST *result,                // Where the result hash is saved.
-    TPM_RC sessionCmdRval    
+    TPM_RC sessionCmdRval
     ) = TpmComputeSessionHmac;
 
 TPM_RC ( *GetSessionAlgIdPtr )( TPMI_SH_AUTH_SESSION authHandle, TPMI_ALG_HASH *sessionAlgId ) = GetSessionAlgId;
@@ -228,7 +228,7 @@ void ErrorHandler( UINT32 rval )
 {
     UINT32 errorLevel = rval & TSS2_ERROR_LEVEL_MASK;
     char levelString[LEVEL_STRING_SIZE + 1];
-    
+
     switch( errorLevel )
     {
         case TSS2_TPM_ERROR_LEVEL:
@@ -259,7 +259,7 @@ void ErrorHandler( UINT32 rval )
             strncpy( levelString, "Unknown Level", LEVEL_STRING_SIZE );
             break;
 	}
-                
+
     sprintf_s( errorString, errorStringSize, "%s Error: 0x%x\n", levelString, rval );
 }
 
@@ -268,13 +268,13 @@ char resMgrInterfaceName[] = "Resource Manager";
 TSS2_RC InitTctiResMgrContext( TCTI_SOCKET_CONF *rmInterfaceConfig, TSS2_TCTI_CONTEXT **tctiContext, char *name )
 {
     size_t size;
-    
+
     TSS2_RC rval;
 
     rval = InitSocketTcti(NULL, &size, rmInterfaceConfig, 0 );
     if( rval != TSS2_RC_SUCCESS )
         return rval;
-    
+
     *tctiContext = (TSS2_TCTI_CONTEXT *)malloc(size);
 
     if( *tctiContext )
@@ -304,10 +304,10 @@ void Cleanup()
 
         TeardownTctiResMgrContext( resMgrTctiContext );
     }
-    
-#ifdef _WIN32        
+
+#ifdef _WIN32
     WSACleanup();
-#endif        
+#endif
     exit(1);
 }
 
@@ -320,7 +320,7 @@ void InitSysContextFailure()
 void Delay( UINT16 delay)
 {
     volatile UINT32 i, j;
-    
+
     for( j = 0; j < delay; j++ )
     {
         for( i = 0; i < 10000000; i++ )
@@ -371,7 +371,7 @@ void CheckFailed( UINT32 rval, UINT32 expectedTpmErrorCode )
 TSS2_RC TpmReset()
 {
     TSS2_RC rval = TSS2_RC_SUCCESS;
-    
+
     rval = (TSS2_RC)PlatformCommand( resMgrTctiContext, MS_SIM_POWER_OFF );
     if( rval == TSS2_RC_SUCCESS )
     {
@@ -384,13 +384,13 @@ void GetTpmVersion()
 {
     TSS2_RC rval = TSS2_RC_SUCCESS;
     TPMS_CAPABILITY_DATA capabilityData;
-    
+
     rval = Tss2_Sys_GetCapability( sysContext, 0,
             TPM_CAP_TPM_PROPERTIES, TPM_PT_REVISION,
             1, 0, &capabilityData, 0 );
     CheckPassed( rval );
 
-    if( capabilityData.data.tpmProperties.count == 1 && 
+    if( capabilityData.data.tpmProperties.count == 1 &&
             (capabilityData.data.tpmProperties.tpmProperty[0].property == TPM_PT_REVISION) )
     {
         tpmSpecVersion = capabilityData.data.tpmProperties.tpmProperty[0].value;
@@ -400,20 +400,20 @@ void GetTpmVersion()
     {
         DebugPrintf( NO_PREFIX, "Failed to get TPM spec version!!\n" );
         Cleanup();
-    }   
+    }
 }
 
 void GetTpmManufacturer()
 {
     TSS2_RC rval = TSS2_RC_SUCCESS;
     TPMS_CAPABILITY_DATA capabilityData;
-    
+
     rval = Tss2_Sys_GetCapability( sysContext, 0,
             TPM_CAP_TPM_PROPERTIES, TPM_PT_MANUFACTURER,
             1, 0, &capabilityData, 0 );
     CheckPassed( rval );
 
-    if( capabilityData.data.tpmProperties.count == 1 && 
+    if( capabilityData.data.tpmProperties.count == 1 &&
             (capabilityData.data.tpmProperties.tpmProperty[0].property == TPM_PT_MANUFACTURER ) )
     {
         tpmManufacturer = capabilityData.data.tpmProperties.tpmProperty[0].value;
@@ -422,7 +422,7 @@ void GetTpmManufacturer()
     {
         DebugPrintf( NO_PREFIX, "Failed to get TPM manufacturer!!\n" );
         Cleanup();
-    }   
+    }
 }
 
 void TestDictionaryAttackLockReset()
@@ -443,12 +443,12 @@ void TestDictionaryAttackLockReset()
     sessionsData.cmdAuths = &sessionDataArray[0];
 
     sessionsDataOut.rspAuthsCount = 1;
-    
+
     DebugPrintf( NO_PREFIX, "\nDICTIONARY ATTACK LOCK RESET TEST  :\n" );
 
     // Init authHandle
     sessionData.sessionHandle = TPM_RS_PW;
-    
+
     // Init nonce.
     sessionData.nonce.t.size = 0;
 
@@ -460,7 +460,7 @@ void TestDictionaryAttackLockReset()
 
     sessionsData.cmdAuthsCount = 1;
     sessionsData.cmdAuths[0] = &sessionData;
-    
+
     rval = Tss2_Sys_DictionaryAttackLockReset ( sysContext, TPM_RH_LOCKOUT, &sessionsData, &sessionsDataOut );
     CheckPassed( rval );
 }
@@ -473,11 +473,11 @@ TSS2_RC StartPolicySession( TPMI_SH_AUTH_SESSION *sessionHandle )
     TPMT_SYM_DEF symmetric;
     UINT16 digestSize;
     UINT32 rval;
-    
+
     digestSize = GetDigestSize( TPM_ALG_SHA1 );
     nonceCaller.t.size = digestSize;
     for( i = 0; i < nonceCaller.t.size; i++ )
-        nonceCaller.t.buffer[i] = 0; 
+        nonceCaller.t.buffer[i] = 0;
 
     salt.t.size = 0;
     symmetric.algorithm = TPM_ALG_NULL;
@@ -492,7 +492,7 @@ TSS2_RC StartPolicySession( TPMI_SH_AUTH_SESSION *sessionHandle )
 void TestTpmStartup()
 {
     UINT32 rval;
-    
+
     DebugPrintf( NO_PREFIX, "\nSTARTUP TESTS:\n" );
 
     //
@@ -506,7 +506,7 @@ void TestTpmStartup()
     // This one should pass.
     rval = Tss2_Sys_Startup( sysContext, TPM_SU_CLEAR );
     CheckPassed(rval);
-    
+
     // This one should fail.
     rval = Tss2_Sys_Startup( sysContext, TPM_SU_CLEAR );
     CheckFailed( rval, TPM_RC_INITIALIZE );
@@ -518,7 +518,7 @@ void TestTpmStartup()
     rval = PlatformCommand( resMgrTctiContext, MS_SIM_POWER_ON );
     CheckPassed( rval );
 
-    
+
     //
     // Now test the syncronous, non-one-call interface.
     //
@@ -528,7 +528,7 @@ void TestTpmStartup()
     // Execute the command syncronously.
     rval = Tss2_Sys_Execute( sysContext );
     CheckPassed( rval );
-    
+
     // Cycle power using simulator interface.
     rval = PlatformCommand( resMgrTctiContext, MS_SIM_POWER_OFF );
     CheckPassed( rval );
@@ -636,16 +636,16 @@ void TestTctiApis( TSS2_TCTI_CONTEXT *tstTctiContext, int againstRM )
     uint8_t goodResponseBuffer1[] = { 0x80, 0x01, 0x00, 0x00, 0x00, 0x18, 0x00, 0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00,
                                       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
     uint8_t *goodRspBuffer;
-    
+
     int responseBufferError = 0;
     unsigned int i;
     char *typeString;
     char typeRMString[] = "RM";
     char typeLocalString[] = "Local TPM";
-    
+
     TSS2_RC rval = TSS2_RC_SUCCESS;
-    
-    if( tpmManufacturer == MSFT_MANUFACTURER_ID || tpmManufacturer == IBM_MANUFACTURER_ID 
+
+    if( tpmManufacturer == MSFT_MANUFACTURER_ID || tpmManufacturer == IBM_MANUFACTURER_ID
 )
     {
         expectedResponseSize = 0x10;
@@ -665,7 +665,7 @@ void TestTctiApis( TSS2_TCTI_CONTEXT *tstTctiContext, int againstRM )
     {
         typeString = &typeLocalString[0];
     }
-    
+
     DebugPrintf( NO_PREFIX, "\nTCTI API TESTS (against %s TCTI interface):\n", typeString );
 
     //
@@ -684,7 +684,7 @@ void TestTctiApis( TSS2_TCTI_CONTEXT *tstTctiContext, int againstRM )
     rval = ( (TSS2_TCTI_CONTEXT_COMMON_CURRENT *)tstTctiContext )->transmit( 0, sizeof( tpmStartCommandBuffer ), &tpmStartCommandBuffer[0] );
     CheckFailed( rval, TSS2_TCTI_RC_BAD_REFERENCE ); // #3
     CleanupContextError( tstTctiContext, 1, savedMagic, savedVersion );
-    
+
     //
     // Test transmit for BAD CONTEXT:  version.
     //
@@ -692,7 +692,7 @@ void TestTctiApis( TSS2_TCTI_CONTEXT *tstTctiContext, int againstRM )
     rval = ( (TSS2_TCTI_CONTEXT_COMMON_CURRENT *)tstTctiContext )->transmit( 0, sizeof( tpmStartCommandBuffer ), &tpmStartCommandBuffer[0] );
     CheckFailed( rval, TSS2_TCTI_RC_BAD_REFERENCE ); // #4
     CleanupContextError( tstTctiContext, 0, savedMagic, savedVersion );
-    
+
     //
     // Test transmit for IO error.
     //
@@ -721,7 +721,7 @@ void TestTctiApis( TSS2_TCTI_CONTEXT *tstTctiContext, int againstRM )
     // any IO, so this test case will never work.  Left it and this comment here
     // in case anyone ever questions why we're not testing this case.
     //
-    
+
     //
     // Test setLocality for IO error.
     //
@@ -730,7 +730,7 @@ void TestTctiApis( TSS2_TCTI_CONTEXT *tstTctiContext, int againstRM )
     CleanupIOError( tstTctiContext, savedTpmSock, savedOtherSock, savedDevFile, 0 );
     CheckFailed( rval, TSS2_TCTI_RC_IO_ERROR ); // #8
 #endif
-    
+
     rval = ( (TSS2_TCTI_CONTEXT_COMMON_CURRENT *)tstTctiContext )->transmit( tstTctiContext, sizeof( tpmStartCommandBuffer ), &tpmStartCommandBuffer[0] );
     CheckPassed( rval ); // #9
 
@@ -750,7 +750,7 @@ void TestTctiApis( TSS2_TCTI_CONTEXT *tstTctiContext, int againstRM )
         rval = ( (TSS2_TCTI_CONTEXT_COMMON_CURRENT *)tstTctiContext )->setLocality( tstTctiContext, 0 );
         CheckFailed( rval, TSS2_TCTI_RC_BAD_SEQUENCE ); // #10
     }
-    
+
     //
     // Test transmit for SEQUENCE error.
     //
@@ -767,7 +767,7 @@ void TestTctiApis( TSS2_TCTI_CONTEXT *tstTctiContext, int againstRM )
         rval = ( (TSS2_TCTI_CONTEXT_COMMON_CURRENT *)tstTctiContext )->cancel( 0 );
         CheckFailed( rval, TSS2_TCTI_RC_BAD_REFERENCE ); // #12
     }
-    
+
     //
     // Test receive for NULL pointers.
     //
@@ -810,7 +810,7 @@ void TestTctiApis( TSS2_TCTI_CONTEXT *tstTctiContext, int againstRM )
         rval = ( (TSS2_TCTI_CONTEXT_COMMON_CURRENT *)tstTctiContext )->cancel( tstTctiContext );
         CheckFailed( rval, TSS2_TCTI_RC_BAD_SEQUENCE ); // #20
     }
-    
+
     //
     // Test receive for SEQUENCE error.
     //
@@ -892,30 +892,30 @@ void TestTctiApis( TSS2_TCTI_CONTEXT *tstTctiContext, int againstRM )
         DebugPrintBuffer( NO_PREFIX, (UINT8 *)&responseBuffer, responseSize );
         Cleanup();
     }
-    
+
 
     // Now test other corner cases for size:  1 bytes smaller than tag size and  1 bytes smaller smaller than tag size plus sizeof UINT32.
-    
-    
+
+
 #if 0
     //
     // No getPollHandles function so these are #ifdef'd out for now.
     //
-    
+
     //
     // Test getPollHandles for BAD REFERENCE errors.
     //
     rval = ( (TSS2_TCTI_CONTEXT_COMMON_CURRENT *)tstTctiContext )->getPollHandles( (TSS2_TCTI_CONTEXT *)0, (TSS2_TCTI_POLL_HANDLE *)1, (size_t *)1 );
     CheckFailed( rval, TSS2_TCTI_RC_BAD_REFERENCE ); // #23
-    
+
     rval = ( (TSS2_TCTI_CONTEXT_COMMON_CURRENT *)tstTctiContext )->getPollHandles( tstTctiContext, (TSS2_TCTI_POLL_HANDLE *)0, (size_t *)1 );
     CheckFailed( rval, TSS2_TCTI_RC_BAD_REFERENCE ); // #24
-    
+
     rval = ( (TSS2_TCTI_CONTEXT_COMMON_CURRENT *)tstTctiContext )->getPollHandles( tstTctiContext, (TSS2_TCTI_POLL_HANDLE *)1, (size_t *)0 );
     CheckFailed( rval, TSS2_TCTI_RC_BAD_REFERENCE ); // #25
 #endif
 }
-    
+
 
 void TestSapiApis()
 {
@@ -937,15 +937,15 @@ void TestSapiApis()
     int                 rpBufferError = 0;
     unsigned int        i;
     UINT32              savedRspSize;
-    
+
     DebugPrintf( NO_PREFIX, "\nSAPI API TESTS:\n" );
 
     //
     // First test the one-call interface.
     //
     rval = Tss2_Sys_GetTestResult( sysContext, 0, &outData, &testResult, 0 );
-    CheckPassed(rval); // #1 
-    
+    CheckPassed(rval); // #1
+
     // Check for BAD_SEQUENCE error.
     rval = Tss2_Sys_ExecuteAsync( sysContext );
     CheckFailed( rval, TSS2_SYS_RC_BAD_SEQUENCE ); // #2
@@ -992,7 +992,7 @@ void TestSapiApis()
     INIT_SIMPLE_TPM2B_SIZE( outData );
     rval = Tss2_Sys_GetTestResult_Complete( sysContext, &outData, &testResult );
     CheckFailed( rval, TSS2_SYS_RC_BAD_SEQUENCE ); // #11
-    
+
     // Check for BAD_REFERENCE error.
     rval = Tss2_Sys_ExecuteAsync( 0 );
     CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE ); // #12
@@ -1021,7 +1021,7 @@ void TestSapiApis()
     // and before ExecuteFinish
     rval = Tss2_Sys_GetTestResult_Complete( sysContext, &outData, &testResult );
     CheckFailed( rval, TSS2_SYS_RC_BAD_SEQUENCE ); // #18
-    
+
     // Get the command response. Wait a maximum of 20ms
     // for response.
     rval = Tss2_Sys_ExecuteFinish( sysContext, TSS2_TCTI_TIMEOUT_BLOCK );
@@ -1046,7 +1046,7 @@ void TestSapiApis()
     INIT_SIMPLE_TPM2B_SIZE( outData );
     rval = Tss2_Sys_GetTestResult_Complete( sysContext, &outData, &testResult );
     CheckPassed(rval); // #24
-    
+
     testSysContext = InitSysContext( 0,  resMgrTctiContext, &abiVersion );
     if( testSysContext == 0 )
     {
@@ -1061,7 +1061,7 @@ void TestSapiApis()
     CheckFailed( rval, TSS2_SYS_RC_BAD_SEQUENCE ); // #26
 
     TeardownSysContext( &testSysContext );
-    
+
     rval = Tss2_Sys_ReadPublic_Prepare( sysContext, handle2048rsa );
     CheckPassed(rval); // #27
 
@@ -1086,7 +1086,7 @@ void TestSapiApis()
 
     rval = Tss2_Sys_ExecuteFinish( sysContext, TSS2_TCTI_TIMEOUT_BLOCK );
     CheckFailed( rval, TSS2_SYS_RC_BAD_SEQUENCE ); // #33
-    
+
     rval = Tss2_Sys_ReadPublic_Prepare( sysContext, handle2048rsa );
     CheckPassed(rval); // #34
 
@@ -1098,12 +1098,12 @@ void TestSapiApis()
 	rval = Tss2_Sys_ReadPublic( sysContext, handle2048rsa, 0,
             &outPublic, 0, 0, 0 );
     CheckPassed( rval ); // #36
-            
+
     // Check case of ExecuteFinish receving TPM error code.
     // Subsequent _Complete call should fail with SEQUENCE error.
     rval = TpmReset();
     CheckPassed(rval); // #37
-    
+
     rval = Tss2_Sys_GetCapability_Prepare( sysContext,
             TPM_CAP_TPM_PROPERTIES, TPM_PT_ACTIVE_SESSIONS_MAX,
             1 );
@@ -1127,16 +1127,16 @@ void TestSapiApis()
 
     rval = Tss2_Sys_GetRpBuffer( 0, &rpBufferUsedSize, &rpBuffer );
     CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE ); // #43
-    
+
     rval = Tss2_Sys_GetRpBuffer( sysContext, 0, &rpBuffer );
     CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE ); // #44
-    
+
     rval = Tss2_Sys_GetRpBuffer( sysContext, &rpBufferUsedSize, 0 );
     CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE ); // #45
 
     rval = Tss2_Sys_GetRpBuffer( sysContext, &rpBufferUsedSize, &rpBuffer );
     CheckPassed( rval ); // #46
-    
+
     // Now test case for ExecuteFinish where TPM returns
     // an error.  ExecuteFinish should return same error
     // as TPM.
@@ -1161,14 +1161,14 @@ void TestSapiApis()
 
     rval = Tss2_Sys_GetRpBuffer( sysContext, &rpBufferUsedSize, &rpBuffer );
     CheckFailed( rval, TSS2_SYS_RC_BAD_SEQUENCE ); // #52
-    
+
     // Execute the command ayncronously.
     rval = Tss2_Sys_Execute( sysContext );
     CheckFailed( rval, TPM_RC_INITIALIZE ); // #53
 
     rval = Tss2_Sys_GetRpBuffer( sysContext, &rpBufferUsedSize, &rpBuffer );
     CheckFailed( rval, TSS2_SYS_RC_BAD_SEQUENCE ); // #54
-    
+
     // Test one-call for null sysContext pointer.
     rval = Tss2_Sys_Startup( 0, TPM_SU_CLEAR );
     CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE ); // #55
@@ -1181,7 +1181,7 @@ void TestSapiApis()
     // Test GetCommandCode for bad reference
     rval = Tss2_Sys_GetCommandCode( 0, &commandCode );
     CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE ); // #57
-    
+
     rval = Tss2_Sys_GetCommandCode( sysContext, 0 );
     CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE ); // #58
 
@@ -1203,7 +1203,7 @@ void TestSapiApis()
     //
     // Test GetRpBuffer for case of response params.
     //
-    rval = Tss2_Sys_GetCapability( sysContext, 0, 
+    rval = Tss2_Sys_GetCapability( sysContext, 0,
             TPM_CAP_TPM_PROPERTIES, TPM_PT_ACTIVE_SESSIONS_MAX,
             1, &moreData, &capabilityData, 0 );
     CheckPassed(rval); // #61
@@ -1235,7 +1235,7 @@ void TestSapiApis()
         DebugPrintBuffer( NO_PREFIX, (UINT8 *)&(goodRpBuffer[0]), rpBufferUsedSize );
         Cleanup();
     }
-    
+
     TeardownSysContext( &testSysContext );
 
     rval = Tss2_Sys_GetTestResult_Prepare( sysContext );
@@ -1265,7 +1265,7 @@ void TestSapiApis()
 
 
 void TestTpmSelftest()
-{   
+{
     UINT32 rval;
 
     DebugPrintf( NO_PREFIX, "\nSELFTEST TESTS:\n" );
@@ -1284,12 +1284,12 @@ void TestTpmSelftest()
 void TestTpmGetCapability()
 {
     UINT32 rval;
-    
+
     char manuID[5] = "    ";
     char *manuIDPtr = &manuID[0];
     TPMI_YES_NO moreData;
     TPMS_CAPABILITY_DATA capabilityData;
-    
+
     DebugPrintf( NO_PREFIX, "\nGET_CAPABILITY TESTS:\n" );
 
     rval = Tss2_Sys_GetCapability( sysContext, 0, TPM_CAP_TPM_PROPERTIES, TPM_PT_MANUFACTURER, 1, &moreData, &capabilityData, 0 );
@@ -1300,14 +1300,14 @@ void TestTpmGetCapability()
             capabilityData.data.tpmProperties.count,
             capabilityData.data.tpmProperties.tpmProperty[0].property,
             manuID );
-            
+
     rval = Tss2_Sys_GetCapability( sysContext, 0, TPM_CAP_TPM_PROPERTIES, TPM_PT_MAX_COMMAND_SIZE, 1, &moreData, &capabilityData, 0 );
     CheckPassed( rval );
     DebugPrintf( NO_PREFIX, "\t\tcount: %d, property: %x, max cmd size: %d\n",
             capabilityData.data.tpmProperties.count,
             capabilityData.data.tpmProperties.tpmProperty[0].property,
             capabilityData.data.tpmProperties.tpmProperty[0].value );
-            
+
 
     rval = Tss2_Sys_GetCapability( sysContext, 0, TPM_CAP_TPM_PROPERTIES, TPM_PT_MAX_COMMAND_SIZE, 40, &moreData, &capabilityData, 0 );
     CheckPassed( rval );
@@ -1315,7 +1315,7 @@ void TestTpmGetCapability()
             capabilityData.data.tpmProperties.count,
             capabilityData.data.tpmProperties.tpmProperty[0].property,
             capabilityData.data.tpmProperties.tpmProperty[0].value );
-            
+
 
     rval = Tss2_Sys_GetCapability( sysContext, 0, TPM_CAP_TPM_PROPERTIES, TPM_PT_MAX_RESPONSE_SIZE, 1, &moreData, &capabilityData, 0 );
     CheckPassed( rval );
@@ -1323,7 +1323,7 @@ void TestTpmGetCapability()
             capabilityData.data.tpmProperties.count,
             capabilityData.data.tpmProperties.tpmProperty[0].property,
             capabilityData.data.tpmProperties.tpmProperty[0].value );
-            
+
     rval = Tss2_Sys_GetCapability( sysContext, 0, 0xff, TPM_PT_MANUFACTURER, 1, &moreData, &capabilityData, 0 );
 
     if( tpmSpecVersion == 115 || tpmSpecVersion == 119 )
@@ -1357,12 +1357,12 @@ void TestTpmClear()
 
     sessionsDataOut.rspAuthsCount = 1;
     sessionsDataOut.rspAuths[0] = &sessionDataOut;
-    
+
     DebugPrintf( NO_PREFIX, "\nCLEAR and CLEAR CONTROL TESTS:\n" );
 
     // Init sessionHandle
     sessionData.sessionHandle = TPM_RS_PW;
-    
+
     // Init nonce.
     nonce.t.size = 0;
     sessionData.nonce = nonce;
@@ -1376,7 +1376,7 @@ void TestTpmClear()
 
     sessionsDataIn.cmdAuthsCount = 1;
     sessionsDataIn.cmdAuths[0] = &sessionData;
-    
+
     rval = Tss2_Sys_Clear ( sysContext, TPM_RH_PLATFORM, &sessionsDataIn, 0 );
     CheckPassed( rval );
 
@@ -1402,7 +1402,7 @@ void TestTpmClear()
 
 }
 
-#ifdef DEBUG_GAP_HANDLING   
+#ifdef DEBUG_GAP_HANDLING
 
 #define SESSIONS_ABOVE_MAX_ACTIVE 1
 #define DEBUG_MAX_ACTIVE_SESSIONS   32
@@ -1419,7 +1419,7 @@ SESSION *sessions[300];
 
 SESSION *sessions[5];
 
-#endif    
+#endif
 
 void TestStartAuthSession()
 {
@@ -1429,11 +1429,11 @@ void TestStartAuthSession()
     SESSION *authSession;
     TPM2B_NONCE nonceCaller;
     UINT16 i;
-#ifdef DEBUG_GAP_HANDLING    
-    UINT16 debugGapMax = DEBUG_GAP_MAX, debugMaxActiveSessions = DEBUG_MAX_ACTIVE_SESSIONS;    
+#ifdef DEBUG_GAP_HANDLING
+    UINT16 debugGapMax = DEBUG_GAP_MAX, debugMaxActiveSessions = DEBUG_MAX_ACTIVE_SESSIONS;
     TPMS_CONTEXT    evictedSessionContext;
     TPM_HANDLE   evictedHandle;
-#endif    
+#endif
     TPMA_LOCALITY locality;
     TPM_HANDLE badSessionHandle = 0x03010000;
 
@@ -1444,16 +1444,16 @@ void TestStartAuthSession()
     TPMS_AUTH_COMMAND *sessionDataArray[1];
 
     TPM2B_AUTH      hmac;
-    
+
     sessionDataArray[0] = &sessionData;
 
     sessionsDataIn.cmdAuths = &sessionDataArray[0];
 
     sessionsDataIn.cmdAuthsCount = 1;
-    
+
     // Init sessionHandle
     sessionData.sessionHandle = badSessionHandle;
-    
+
     // Init nonce.
     nonce.t.size = 0;
     sessionData.nonce = nonce;
@@ -1466,9 +1466,9 @@ void TestStartAuthSession()
     *( (UINT8 *)((void *)&sessionData.sessionAttributes ) ) = 0;
 
     encryptedSalt.t.size = 0;
-    
+
     DebugPrintf( NO_PREFIX, "\nSTART_AUTH_SESSION TESTS:\n" );
-    
+
     symmetric.algorithm = TPM_ALG_NULL;
     symmetric.keyBits.sym = 0;
     symmetric.mode.sym = 0;
@@ -1476,11 +1476,11 @@ void TestStartAuthSession()
     nonceCaller.t.size = 0;
 
     encryptedSalt.t.size = 0;
-    
+
      // Init session
     rval = StartAuthSessionWithParams( &authSession, TPM_RH_NULL, 0, TPM_RH_PLATFORM, 0, &nonceCaller, &encryptedSalt, TPM_SE_POLICY, &symmetric, TPM_ALG_SHA256, resMgrTctiContext );
     CheckPassed( rval );
-    
+
     rval = Tss2_Sys_FlushContext( sysContext, authSession->sessionHandle );
     CheckPassed( rval );
     EndAuthSession( authSession );
@@ -1490,12 +1490,12 @@ void TestStartAuthSession()
     CheckFailed( rval, TPM_RC_VALUE + TPM_RC_P + TPM_RC_3 );
 
     // Try starting a bunch to see if resource manager handles this correctly.
-    
-#ifdef DEBUG_GAP_HANDLING   
+
+#ifdef DEBUG_GAP_HANDLING
     for( i = 0; i < debugMaxActiveSessions*3; i++ )
-#else        
+#else
     for( i = 0; i < ( sizeof(sessions) / sizeof (SESSION *) ); i++ )
-#endif        
+#endif
     {
 //        DebugPrintf( NO_PREFIX, "i = 0x%4.4x\n", i );
 
@@ -1504,24 +1504,24 @@ void TestStartAuthSession()
         CheckPassed( rval );
         DebugPrintf( NO_PREFIX, "Number of sessions created: %d\n\n", i );
 
-#ifdef DEBUG_GAP_HANDLING   
+#ifdef DEBUG_GAP_HANDLING
         if( i == 0 )
         {
            // Save evicted session's context so we can use it for a test.
            rval = Tss2_Sys_ContextSave( sysContext, sessions[i]->sessionHandle, &evictedSessionContext );
            CheckPassed( rval );
         }
-#endif        
+#endif
     }
 
-#ifdef DEBUG_GAP_HANDLING   
+#ifdef DEBUG_GAP_HANDLING
     DebugPrintf( NO_PREFIX, "loading evicted session's context\n" );
     // Now try loading an evicted session's context.
     // NOTE: simulator versions 01.19 and earlier this test will fail due to a
     // simulator bug (unless patches have been applied).
     rval = Tss2_Sys_ContextLoad( sysContext, &evictedSessionContext, &evictedHandle );
     CheckFailed( rval, TPM_RC_HANDLE + TPM_RC_P + ( 1 << 8  ));
-#endif    
+#endif
 
     // Now try two ways of using a bad session handle.  Both should fail.
 
@@ -1534,11 +1534,11 @@ void TestStartAuthSession()
     // Second way is to use as handle in session area.
     rval = Tss2_Sys_PolicyLocality( sysContext, sessions[0]->sessionHandle, &sessionsDataIn, locality, 0 );
     CheckFailed( rval, TSS2_RESMGRTPM_ERROR_LEVEL + TPM_RC_VALUE + TPM_RC_S + ( 1 << 8 ) );
-        
+
     // clean up the sessions that I don't want here.
-#ifdef DEBUG_GAP_HANDLING   
+#ifdef DEBUG_GAP_HANDLING
     for( i = 0; i < ( debugMaxActiveSessions*3); i++ )
-#else        
+#else
     for( i = 0; i < ( sizeof(sessions) / sizeof (SESSION *)); i++ )
 #endif
     {
@@ -1552,15 +1552,15 @@ void TestStartAuthSession()
     rval = StartAuthSessionWithParams( &sessions[0], TPM_RH_NULL, 0, TPM_RH_PLATFORM, 0, &nonceCaller, &encryptedSalt, TPM_SE_POLICY, &symmetric, TPM_ALG_SHA256, resMgrTctiContext );
     CheckPassed( rval );
 
-#ifdef DEBUG_GAP_HANDLING   
+#ifdef DEBUG_GAP_HANDLING
 //    for( i = 1; i < debugGapMax/2; i++ )
     for( i = 1; i < 300; i++ )
-#else        
+#else
     for( i = 1; i < ( sizeof(sessions) / sizeof (SESSION *) ); i++ )
-#endif        
+#endif
     {
 //        DebugPrintf( NO_PREFIX, "i(3) = 0x%4.4x\n", i );
-        
+
         rval = StartAuthSessionWithParams( &sessions[i], TPM_RH_NULL, 0, TPM_RH_PLATFORM, 0, &nonceCaller, &encryptedSalt, TPM_SE_POLICY, &symmetric, TPM_ALG_SHA256, resMgrTctiContext );
         CheckPassed( rval );
 
@@ -1571,17 +1571,17 @@ void TestStartAuthSession()
         CheckPassed( rval );
     }
 
-#ifdef DEBUG_GAP_HANDLING   
+#ifdef DEBUG_GAP_HANDLING
     // Now do some gap tests.
     rval = StartAuthSessionWithParams( &sessions[8], TPM_RH_NULL, 0, TPM_RH_PLATFORM, 0, &nonceCaller, &encryptedSalt, TPM_SE_POLICY, &symmetric, TPM_ALG_SHA256, resMgrTctiContext );
     CheckPassed( rval );
 #endif
-    
-#ifdef DEBUG_GAP_HANDLING   
+
+#ifdef DEBUG_GAP_HANDLING
     for( i = 9; i < debugGapMax; i++ )
-#else        
+#else
     for( i = 0; i < ( sizeof(sessions) / sizeof (SESSION *) ); i++ )
-#endif        
+#endif
     {
 //        DebugPrintf( NO_PREFIX, "i(4) = 0x%4.4x\n", i );
         rval = StartAuthSessionWithParams( &sessions[i], TPM_RH_NULL, 0, TPM_RH_PLATFORM, 0, &nonceCaller, &encryptedSalt, TPM_SE_POLICY, &symmetric, TPM_ALG_SHA256, resMgrTctiContext );
@@ -1592,10 +1592,10 @@ void TestStartAuthSession()
 
         rval = EndAuthSession( sessions[i] );
         CheckPassed( rval );
-        
+
     }
-    
-#ifdef DEBUG_GAP_HANDLING   
+
+#ifdef DEBUG_GAP_HANDLING
     for( i = 0; i < 5; i++ )
     {
 //        DebugPrintf( NO_PREFIX, "i(5) = 0x%4.4x\n", i );
@@ -1624,10 +1624,10 @@ void TestStartAuthSession()
 
     rval = EndAuthSession( sessions[8] );
     CheckPassed( rval );
-#endif    
-    
+#endif
+
 }
-    
+
 void TestChangeEps()
 {
     UINT32 rval;
@@ -1647,14 +1647,14 @@ void TestChangeEps()
     sessionsData.cmdAuths = &sessionDataArray[0];
 
     sessionsDataOut.rspAuthsCount = 1;
-    
+
     DebugPrintf( NO_PREFIX, "\nCHANGE_EPS TESTS:\n" );
 
 	sessionsData.cmdAuthsCount = 1;
-    
+
     // Init authHandle
     sessionsData.cmdAuths[0]->sessionHandle = TPM_RS_PW;
-    
+
     // Init nonce.
     sessionsData.cmdAuths[0]->nonce.t.size = 0;
 
@@ -1663,7 +1663,7 @@ void TestChangeEps()
 
     // Init session attributes
     *( (UINT8 *)((void *)&sessionsData.cmdAuths[0]->sessionAttributes ) ) = 0;
-    
+
     rval = Tss2_Sys_ChangeEPS( sysContext, TPM_RH_PLATFORM, &sessionsData, &sessionsDataOut );
     CheckPassed( rval );
 
@@ -1671,7 +1671,7 @@ void TestChangeEps()
 
     rval = Tss2_Sys_ChangeEPS( sysContext, TPM_RH_PLATFORM, &sessionsData, 0 );
     CheckFailed( rval, TPM_RC_1 + TPM_RC_S + TPM_RC_BAD_AUTH );
-}   
+}
 
 void TestChangePps()
 {
@@ -1693,14 +1693,14 @@ void TestChangePps()
     sessionsData.cmdAuths = &sessionDataArray[0];
 
     sessionsDataOut.rspAuthsCount = 1;
-    
+
     DebugPrintf( NO_PREFIX, "\nCHANGE_PPS TESTS:\n" );
 
     sessionsData.cmdAuthsCount = 1;
-    
+
     // Init authHandle
     sessionsData.cmdAuths[0]->sessionHandle = TPM_RS_PW;
-    
+
     // Init nonce.
     sessionsData.cmdAuths[0]->nonce.t.size = 0;
 
@@ -1709,7 +1709,7 @@ void TestChangePps()
 
     // Init session attributes
     *( (UINT8 *)((void *)&sessionsData.cmdAuths[0]->sessionAttributes ) ) = 0;
-    
+
     rval = Tss2_Sys_ChangePPS( sysContext, TPM_RH_PLATFORM, &sessionsData, &sessionsDataOut );
     CheckPassed( rval );
 
@@ -1717,7 +1717,7 @@ void TestChangePps()
 
     rval = Tss2_Sys_ChangePPS( sysContext, TPM_RH_PLATFORM, &sessionsData, &sessionsDataOut );
     CheckFailed( rval, TPM_RC_1 + TPM_RC_S + TPM_RC_BAD_AUTH );
-}   
+}
 
 void TestHierarchyChangeAuth()
 {
@@ -1726,7 +1726,7 @@ void TestHierarchyChangeAuth()
     TPMS_AUTH_COMMAND sessionData;
     TSS2_SYS_CMD_AUTHS sessionsData;
     int i;
-    
+
     TPMS_AUTH_COMMAND *sessionDataArray[1];
 
     sessionDataArray[0] = &sessionData;
@@ -1734,7 +1734,7 @@ void TestHierarchyChangeAuth()
     sessionsData.cmdAuths = &sessionDataArray[0];
 
     DebugPrintf( NO_PREFIX, "\nHIERARCHY_CHANGE_AUTH TESTS:\n" );
-    
+
     // Init authHandle
     sessionData.sessionHandle = TPM_RS_PW;
 
@@ -1749,7 +1749,7 @@ void TestHierarchyChangeAuth()
 
     sessionsData.cmdAuthsCount = 1;
     sessionsData.cmdAuths[0] = &sessionData;
-    
+
     newAuth.t.size = 0;
     rval = Tss2_Sys_HierarchyChangeAuth( sysContext, TPM_RH_PLATFORM, &sessionsData, &newAuth, 0 );
     CheckPassed( rval );
@@ -1758,7 +1758,7 @@ void TestHierarchyChangeAuth()
     newAuth.t.size = 20;
     for( i = 0; i < newAuth.t.size; i++ )
         newAuth.t.buffer[i] = i;
-    
+
     rval = Tss2_Sys_HierarchyChangeAuth( sysContext, TPM_RH_PLATFORM, &sessionsData, &newAuth, 0 );
     CheckPassed( rval );
 
@@ -1768,7 +1768,7 @@ void TestHierarchyChangeAuth()
 
     // Init new auth
     newAuth.t.size = 0;
-    
+
     rval = Tss2_Sys_HierarchyChangeAuth( sysContext, TPM_RH_PLATFORM, &sessionsData, &newAuth, 0 );
     CheckPassed( rval );
 
@@ -1816,14 +1816,14 @@ void TestPcrExtend()
     TPML_DIGEST pcrValues;
     TPML_DIGEST_VALUES digests;
     TPML_PCR_SELECTION pcrSelectionOut;
-            
+
     TPMS_AUTH_COMMAND *sessionDataArray[1];
 
     sessionDataArray[0] = &sessionData;
     sessionsData.cmdAuths = &sessionDataArray[0];
-    
+
     DebugPrintf( NO_PREFIX, "\nPCR_EXTEND, PCR_EVENT, PCR_ALLOCATE, and PCR_READ TESTS:\n" );
-    
+
     // Init authHandle
     sessionData.sessionHandle = TPM_RS_PW;
 
@@ -1857,7 +1857,7 @@ void TestPcrExtend()
 
     // Now set the PCR you want to read
     SET_PCR_SELECT_BIT( pcrSelection.pcrSelections[0], PCR_17 );
-        
+
     rval = Tss2_Sys_PCR_Read( sysContext, 0, &pcrSelection, &pcrUpdateCounterBeforeExtend, &pcrSelectionOut, &pcrValues, 0 );
     CheckPassed( rval );
 
@@ -1867,7 +1867,7 @@ void TestPcrExtend()
 
     sessionsData.cmdAuthsCount = 1;
     sessionsData.cmdAuths[0] = &sessionData;
-    
+
     rval = Tss2_Sys_PCR_Extend( sysContext, PCR_17, &sessionsData, &digests, 0  );
     CheckPassed( rval );
 
@@ -1887,7 +1887,7 @@ void TestPcrExtend()
         DebugPrintf( NO_PREFIX, "ERROR!! PCR didn't change value\n" );
         Cleanup();
     }
-    
+
     pcrSelection.pcrSelections[0].sizeofSelect = 4;
 
     rval = Tss2_Sys_PCR_Read( sysContext, 0, &pcrSelection, &pcrUpdateCounterAfterExtend, 0, 0, 0 );
@@ -1898,7 +1898,7 @@ void TestPcrExtend()
     eventData.t.buffer[1] = 0xff;
     eventData.t.buffer[2] = 0x55;
     eventData.t.buffer[3] = 0xaa;
-    
+
     rval = Tss2_Sys_PCR_Event( sysContext, PCR_18, &sessionsData, &eventData, &digests, 0  );
     CheckPassed( rval );
 }
@@ -1907,7 +1907,7 @@ void TestGetRandom()
 {
     UINT32 rval;
     TPM2B_DIGEST        randomBytes1, randomBytes2;
-    
+
     DebugPrintf( NO_PREFIX, "\nGET_RANDOM TESTS:\n" );
 
     INIT_SIMPLE_TPM2B_SIZE( randomBytes1 );
@@ -1938,9 +1938,9 @@ void TestShutdown()
     sessionsDataOut.rspAuths = &sessionDataOutArray[0];
 
     sessionsDataOut.rspAuthsCount = 1;
-    
+
     DebugPrintf( NO_PREFIX, "\nSHUTDOWN TESTS:\n" );
-    
+
     rval = Tss2_Sys_Shutdown( sysContext, 0, TPM_SU_STATE, &sessionsDataOut );
     CheckPassed( rval );
 
@@ -1966,7 +1966,7 @@ void TestNV()
     int i;
     TPM2B_MAX_NV_BUFFER nvWriteData;
     TPM2B_MAX_NV_BUFFER nvData;
-    
+
     TPM2B_NV_PUBLIC nvPublic;
     TPM2B_NAME nvName;
 
@@ -2004,7 +2004,7 @@ void TestNV()
     publicInfo.t.nvPublic.attributes.TPMA_NV_ORDERLY = 1;
     publicInfo.t.nvPublic.authPolicy.t.size = 0;
     publicInfo.t.nvPublic.dataSize = 32;
-    
+
     sessionData.sessionHandle = TPM_RS_PW;
 
     // Init nonce.
@@ -2020,7 +2020,7 @@ void TestNV()
     sessionsData.cmdAuths[0] = &sessionData;
 
     INIT_SIMPLE_TPM2B_SIZE( nvData );
-    rval = Tss2_Sys_NV_Read( sysContext, TPM_RH_PLATFORM, TPM20_INDEX_TEST1, &sessionsData, 32, 0, &nvData, &sessionsDataOut ); 
+    rval = Tss2_Sys_NV_Read( sysContext, TPM_RH_PLATFORM, TPM20_INDEX_TEST1, &sessionsData, 32, 0, &nvData, &sessionsDataOut );
     CheckFailed( rval, TPM_RC_2 + TPM_RC_HANDLE );
 
     rval = Tss2_Sys_NV_DefineSpace( sysContext, TPM_RH_PLATFORM, &sessionsData, &nvAuth, &publicInfo, &sessionsDataOut );
@@ -2032,13 +2032,13 @@ void TestNV()
     CheckPassed( rval );
 
     INIT_SIMPLE_TPM2B_SIZE( nvData );
-    rval = Tss2_Sys_NV_Read( sysContext, TPM_RH_PLATFORM, TPM20_INDEX_TEST1, &sessionsData, 32, 0, &nvData, &sessionsDataOut ); 
+    rval = Tss2_Sys_NV_Read( sysContext, TPM_RH_PLATFORM, TPM20_INDEX_TEST1, &sessionsData, 32, 0, &nvData, &sessionsDataOut );
     CheckFailed( rval, TPM_RC_NV_UNINITIALIZED );
 
     // Should fail since index is already defined.
     rval = Tss2_Sys_NV_DefineSpace( sysContext, TPM_RH_PLATFORM, &sessionsData, &nvAuth, &publicInfo, &sessionsDataOut );
     CheckFailed( rval, TPM_RC_NV_DEFINED );
-    
+
     nvWriteData.t.size = 4;
     for( i = 0; i < nvWriteData.t.size; i++ )
         nvWriteData.t.buffer[i] = 0xff - i;
@@ -2059,27 +2059,27 @@ void TestNV()
     //      subsequent times.
     //      Removing NVWrite works around this problem.
     //
-    rval = Tss2_Sys_NV_Write( sysContext, TPM_RH_PLATFORM, TPM20_INDEX_TEST1, &sessionsData, &nvWriteData, 0, &sessionsDataOut ); 
+    rval = Tss2_Sys_NV_Write( sysContext, TPM_RH_PLATFORM, TPM20_INDEX_TEST1, &sessionsData, &nvWriteData, 0, &sessionsDataOut );
     CheckPassed( rval );
 
     INIT_SIMPLE_TPM2B_SIZE( nvData );
-    rval = Tss2_Sys_NV_Read( sysContext, TPM_RH_PLATFORM, TPM20_INDEX_TEST1, &sessionsData, 32, 0, &nvData, &sessionsDataOut ); 
+    rval = Tss2_Sys_NV_Read( sysContext, TPM_RH_PLATFORM, TPM20_INDEX_TEST1, &sessionsData, 32, 0, &nvData, &sessionsDataOut );
     CheckPassed( rval );
 
-    rval = Tss2_Sys_NV_WriteLock( sysContext, TPM_RH_PLATFORM, TPM20_INDEX_TEST1, &sessionsData, &sessionsDataOut ); 
+    rval = Tss2_Sys_NV_WriteLock( sysContext, TPM_RH_PLATFORM, TPM20_INDEX_TEST1, &sessionsData, &sessionsDataOut );
     CheckPassed( rval );
 
     rval = Tss2_Sys_NV_Write( sysContext, TPM_RH_PLATFORM, TPM20_INDEX_TEST1, &sessionsData, &nvWriteData, 0, &sessionsDataOut );
     CheckFailed( rval, TPM_RC_NV_LOCKED );
 #endif
-    
+
     // Now undefine the index.
     rval = Tss2_Sys_NV_UndefineSpace( sysContext, TPM_RH_PLATFORM, TPM20_INDEX_TEST1, &sessionsData, 0 );
     CheckPassed( rval );
 
     rval = Tss2_Sys_NV_DefineSpace( sysContext, TPM_RH_PLATFORM, &sessionsData, &nvAuth, &publicInfo, 0 );
     CheckPassed( rval );
-    
+
     // Now undefine the index so that next run will work correctly.
     rval = Tss2_Sys_NV_UndefineSpace( sysContext, TPM_RH_PLATFORM, TPM20_INDEX_TEST1, &sessionsData, 0 );
     CheckPassed( rval );
@@ -2100,7 +2100,7 @@ void TestNV()
     CheckPassed( rval );
 
     INIT_SIMPLE_TPM2B_SIZE( nvData );
-    rval = Tss2_Sys_NV_Read( sysContext, TPM_RH_PLATFORM, TPM20_INDEX_TEST2, &sessionsData, 32, 0, &nvData, 0 ); 
+    rval = Tss2_Sys_NV_Read( sysContext, TPM_RH_PLATFORM, TPM20_INDEX_TEST2, &sessionsData, 32, 0, &nvData, 0 );
     CheckFailed( rval, TPM_RC_NV_AUTHORIZATION );
 
     // Now undefine the index.
@@ -2116,12 +2116,12 @@ void TestNV()
 
 #if 0
     DebugPrintf( NO_PREFIX, "\nStart of NVUndefineSpaceSpecial test\n" );
-    
+
     // Init nonceNewer
     digestSize = GetDigestSize( TPM_ALG_SHA1 );
     nonceNewer.t.size = digestSize;
     for( i = 0; i < nonceNewer.t.size; i++ )
-        nonceNewer.t.buffer[i] = 0; 
+        nonceNewer.t.buffer[i] = 0;
 
     // Init salt
     salt.t.size = 0;
@@ -2145,7 +2145,7 @@ void TestNV()
     CheckPassed( rval );
 
     rval = Tss2_Sys_FlushContext( sysContext, nvSessionHandle );
-    
+
     nvAuth1 = (TPM2B_AUTH *)&( ( ( TPM20_PolicyGetDigest_Out *)(TpmOutBuff) )->otherData );
     publicInfo.t.nvPublic.authPolicy.t.size = nvAuth1->t.size;
     memcpy( &( publicInfo.t.nvPublic.authPolicy.t.buffer[0] ),c
@@ -2174,12 +2174,12 @@ void TestNV()
 
     rval = Tss2_Sys_PolicyCommandCode ( sysContext, nvSessionHandle, 0, TPM_CC_NV_UndefineSpaceSpecial, 0 );
     CheckPassed( rval );
-    
+
     nvSession->hmac = publicInfo.t.nvPublic.authPolicy;
 
     nvSessions.cmdAuthsCount = 2;
     nvSessions.session[0] = nvSession;
-    
+
     rval = Tss2_Sys_NVUndefineSpaceSpecial( sysContext, TPM20_INDEX_TEST2, TPM_RH_PLATFORM, &nvSessions, &sessionsData );
     CheckPassed( rval );
 #endif
@@ -2234,7 +2234,7 @@ void TestHierarchyControl()
     publicInfo.t.nvPublic.attributes.TPMA_NV_ORDERLY = 1;
     publicInfo.t.nvPublic.authPolicy.t.size = 0;
     publicInfo.t.nvPublic.dataSize = 32;
-    
+
     sessionData.sessionHandle = TPM_RS_PW;
 
     // Init nonce.
@@ -2248,7 +2248,7 @@ void TestHierarchyControl()
 
     sessionsData.cmdAuthsCount = 1;
     sessionsData.cmdAuths[0] = &sessionData;
-    
+
     rval = Tss2_Sys_NV_DefineSpace( sysContext, TPM_RH_PLATFORM, &sessionsData, &nvAuth, &publicInfo, 0 );
     CheckPassed( rval );
 
@@ -2263,28 +2263,28 @@ void TestHierarchyControl()
     rval = Tss2_Sys_NV_ReadPublic( sysContext, TPM20_INDEX_TEST1, 0, &nvPublic, &nvName, 0 );
     CheckPassed( rval );
 
-    rval = Tss2_Sys_NV_Read( sysContext, TPM_RH_PLATFORM, TPM20_INDEX_TEST1, &sessionsData, 32, 0, &nvData, &sessionsDataOut ); 
+    rval = Tss2_Sys_NV_Read( sysContext, TPM_RH_PLATFORM, TPM20_INDEX_TEST1, &sessionsData, 32, 0, &nvData, &sessionsDataOut );
     CheckFailed( rval, TPM_RC_NV_UNINITIALIZED );
 
     rval = Tss2_Sys_HierarchyControl( sysContext, TPM_RH_PLATFORM, &sessionsData, TPM_RH_PLATFORM, NO, &sessionsDataOut );
     CheckPassed( rval );
-    
-    rval = Tss2_Sys_NV_Read( sysContext, TPM_RH_PLATFORM, TPM20_INDEX_TEST1, &sessionsData, 32, 0, &nvData, &sessionsDataOut ); 
+
+    rval = Tss2_Sys_NV_Read( sysContext, TPM_RH_PLATFORM, TPM20_INDEX_TEST1, &sessionsData, 32, 0, &nvData, &sessionsDataOut );
     CheckFailed( rval, TPM_RC_1 + TPM_RC_HIERARCHY );
 
     rval = Tss2_Sys_HierarchyControl( sysContext, TPM_RH_PLATFORM, &sessionsData, TPM_RH_PLATFORM, YES, &sessionsDataOut );
     CheckFailed( rval, TPM_RC_1 + TPM_RC_HIERARCHY );
-    
+
     // Need to do TPM reset and Startup to re-enable platform hierarchy.
     rval = TpmReset();
     CheckPassed(rval);
 
     rval = Tss2_Sys_Startup ( sysContext, TPM_SU_CLEAR );
     CheckPassed( rval );
-    
+
     rval = Tss2_Sys_HierarchyControl( sysContext, TPM_RH_PLATFORM, &sessionsData, TPM_RH_PLATFORM, YES, &sessionsDataOut );
     CheckPassed( rval );
-    
+
     // Now undefine the index so that next run will work correctly.
     rval = Tss2_Sys_NV_UndefineSpace( sysContext, TPM_RH_PLATFORM, TPM20_INDEX_TEST1, &sessionsData, 0 );
     CheckPassed( rval );
@@ -2320,14 +2320,14 @@ void TestCreate(){
     sessionsData.cmdAuths = &sessionDataArray[0];
 
     sessionsDataOut.rspAuthsCount = 1;
-        
+
     DebugPrintf( NO_PREFIX, "\nCREATE, CREATE PRIMARY, and LOAD TESTS:\n" );
 
     inSensitive.t.sensitive.userAuth = loadedSha1KeyAuth;
     inSensitive.t.sensitive.userAuth = loadedSha1KeyAuth;
     inSensitive.t.sensitive.data.t.size = 0;
     inSensitive.t.size = loadedSha1KeyAuth.b.size + 2;
-    
+
     inPublic.t.publicArea.type = TPM_ALG_RSA;
     inPublic.t.publicArea.nameAlg = TPM_ALG_SHA1;
 
@@ -2341,7 +2341,7 @@ void TestCreate(){
     inPublic.t.publicArea.objectAttributes.sensitiveDataOrigin = 1;
 
     inPublic.t.publicArea.authPolicy.t.size = 0;
-    
+
     inPublic.t.publicArea.parameters.rsaDetail.symmetric.algorithm = TPM_ALG_AES;
     inPublic.t.publicArea.parameters.rsaDetail.symmetric.keyBits.aes = 128;
     inPublic.t.publicArea.parameters.rsaDetail.symmetric.mode.aes = TPM_ALG_ECB;
@@ -2353,7 +2353,7 @@ void TestCreate(){
 
     outsideInfo.t.size = 0;
     creationPCR.count = 0;
-    
+
     sessionData.sessionHandle = TPM_RS_PW;
 
     // Init nonce.
@@ -2382,7 +2382,7 @@ void TestCreate(){
 
     rval = Tss2_Sys_FlushContext( sysContext, handle2048rsa );
     CheckPassed( rval );
-    
+
     outPublic.t.size = 0;
     INIT_SIMPLE_TPM2B_SIZE( creationData );
     INIT_SIMPLE_TPM2B_SIZE( creationHash );
@@ -2394,7 +2394,7 @@ void TestCreate(){
 
     rval = Tss2_Sys_FlushContext( sysContext, handle2048rsa );
     CheckPassed( rval );
-    
+
     outPublic.t.size = 0;
     creationData.t.size = 0;
     INIT_SIMPLE_TPM2B_SIZE( creationHash );
@@ -2443,7 +2443,7 @@ void TestCreate(){
 
     rval = CompareTPM2B( &name.b, &name1.b );
     CheckPassed( rval );
-    
+
     DebugPrintf( NO_PREFIX, "\nLoaded key handle:  %8.8x\n", loadedSha1KeyHandle );
 }
 
@@ -2479,7 +2479,7 @@ void TestEvict()
     sessionsData.cmdAuthsCount = 1;
 
     sessionsDataOut.rspAuthsCount = 1;
-    
+
     outsideInfo.t.size = 0;
     creationPCR.count = 0;
 
@@ -2527,7 +2527,7 @@ void TestEvict()
     inSensitive.t.sensitive.userAuth = loadedSha1KeyAuth;
     inSensitive.t.sensitive.data.t.size = 0;
     inSensitive.t.size = loadedSha1KeyAuth.b.size + 2;
-    
+
     outsideInfo.t.size = 0;
     outPublic.t.size = 0;
     creationData.t.size = 0;
@@ -2545,13 +2545,13 @@ void TestEvict()
     {
         (( TSS2_TCTI_CONTEXT_INTEL *)otherResMgrTctiContext )->status.debugMsgEnabled = debugLevel;
     }
-    
+
     otherSysContext = InitSysContext( 0, otherResMgrTctiContext, &abiVersion );
     if( otherSysContext == 0 )
     {
         InitSysContextFailure();
     }
-    
+
     rval = Tss2_Sys_Create( otherSysContext, 0x81800000, &sessionsData, &inSensitive, &inPublic,
             &outsideInfo, &creationPCR,
             &outPrivate, &outPublic, &creationData,
@@ -2560,9 +2560,9 @@ void TestEvict()
 
     rval = TeardownTctiResMgrContext( otherResMgrTctiContext );
     CheckPassed( rval );
-    
+
     TeardownSysContext( &otherSysContext );
-    
+
     outsideInfo.t.size = 0;
     outPublic.t.size = 0;
     creationData.t.size = 0;
@@ -2603,7 +2603,7 @@ TPM_RC DefineNvIndex( TPMI_RH_PROVISION authHandle, TPMI_SH_AUTH_SESSION session
     *( (UINT8 *)((void *)&sessionData.sessionAttributes ) ) = 0;
 
     attributes.TPMA_NV_ORDERLY = 1;
-    
+
     // Init public info structure.
     publicInfo.t.nvPublic.attributes = attributes;
     CopySizedByteBuffer( &publicInfo.t.nvPublic.authPolicy.b, &authPolicy->b );
@@ -2639,7 +2639,7 @@ TPM_RC BuildPolicy( TSS2_SYS_CONTEXT *sysContext, SESSION **policySession,
     TPM2B_NONCE nonceCaller;
 
     nonceCaller.t.size = 0;
-    
+
     // Start policy session.
     symmetric.algorithm = TPM_ALG_NULL;
     rval = StartAuthSessionWithParams( policySession, TPM_RH_NULL, 0, TPM_RH_NULL, 0, &nonceCaller, &encryptedSalt, trialSession ? TPM_SE_TRIAL : TPM_SE_POLICY , &symmetric, TPM_ALG_SHA256, resMgrTctiContext );
@@ -2666,7 +2666,7 @@ TPM_RC BuildPolicy( TSS2_SYS_CONTEXT *sysContext, SESSION **policySession,
         rval = EndAuthSession( *policySession );
         CheckPassed( rval );
     }
-    
+
     return rval;
 }
 
@@ -2704,7 +2704,7 @@ TPM_RC CreateNVIndex( TSS2_SYS_CONTEXT *sysContext, SESSION **policySession, TPM
     rval = Tss2_Sys_PolicyGetDigest( sysContext,
             (*policySession)->sessionHandle, 0, policyDigest, 0 );
     CheckPassed( rval );
- 
+
     nvAuth.t.size = 0;
 
     // Now set the attributes.
@@ -2755,26 +2755,26 @@ TPM_RC TestLocality( TSS2_SYS_CONTEXT *sysContext, SESSION *policySession )
 
     rval = SetLocality( sysContext, 2 );
     CheckPassed( rval );
-    
+
     // Do NV write using open session's policy.
     rval = Tss2_Sys_NV_Write( sysContext, TPM20_INDEX_PASSWORD_TEST,
             TPM20_INDEX_PASSWORD_TEST,
-            &sessionsData, &nvWriteData, 0, &sessionsDataOut ); 
+            &sessionsData, &nvWriteData, 0, &sessionsDataOut );
     CheckFailed( rval, TPM_RC_LOCALITY );
 
     rval = SetLocality( sysContext, 3 );
     CheckPassed( rval );
-     
+
     // Do NV write using open session's policy.
     rval = Tss2_Sys_NV_Write( sysContext, TPM20_INDEX_PASSWORD_TEST,
             TPM20_INDEX_PASSWORD_TEST,
-            &sessionsData, &nvWriteData, 0, &sessionsDataOut ); 
+            &sessionsData, &nvWriteData, 0, &sessionsDataOut );
     CheckPassed( rval );
 
     // Do another NV write using open session's policy.
     rval = Tss2_Sys_NV_Write( sysContext, TPM20_INDEX_PASSWORD_TEST,
             TPM20_INDEX_PASSWORD_TEST,
-            &sessionsData, &nvWriteData, 0, &sessionsDataOut ); 
+            &sessionsData, &nvWriteData, 0, &sessionsDataOut );
     CheckFailed( rval, TPM_RC_POLICY_FAIL + TPM_RC_S + TPM_RC_1 );
 
     // Delete NV index
@@ -2824,11 +2824,11 @@ TPM_RC BuildPasswordPcrPolicy( TSS2_SYS_CONTEXT *sysContext, SESSION *policySess
 {
     TPM_RC rval = TPM_RC_SUCCESS;
     TPM2B_DIGEST pcrDigest;
-    TPML_PCR_SELECTION pcrs;                         
+    TPML_PCR_SELECTION pcrs;
     TPML_DIGEST pcrValues;
     UINT32 pcrUpdateCounter;
     TPML_PCR_SELECTION pcrSelectionOut;
-    
+
     pcrDigest.t.size = 0;
     rval = Tss2_Sys_PolicyPassword( sysContext, policySession->sessionHandle, 0, 0 );
     CheckPassed( rval );
@@ -2846,14 +2846,14 @@ TPM_RC BuildPasswordPcrPolicy( TSS2_SYS_CONTEXT *sysContext, SESSION *policySess
     // Compute pcrDigest
     //
     // Read PCRs
-    rval = Tss2_Sys_PCR_Read( sysContext, 0, &pcrs, &pcrUpdateCounter, &pcrSelectionOut, &pcrValues, 0 );               
+    rval = Tss2_Sys_PCR_Read( sysContext, 0, &pcrs, &pcrUpdateCounter, &pcrSelectionOut, &pcrValues, 0 );
     CheckPassed( rval );
 
     // Hash them together
     INIT_SIMPLE_TPM2B_SIZE( pcrDigest );
     rval = TpmHashSequence( policySession->authHash, pcrValues.count, &pcrValues.digests[0], &pcrDigest );
     CheckPassed( rval );
-    
+
     rval = Tss2_Sys_PolicyPCR( sysContext, policySession->sessionHandle, 0, &pcrDigest, &pcrs, 0 );
     CheckPassed( rval );
 
@@ -2879,7 +2879,7 @@ TPM_RC CreateDataBlob( TSS2_SYS_CONTEXT *sysContext, SESSION **policySession, TP
     TPM2B_NAME srkName, blobName;
 	TPM2B_DIGEST data;
     TPM2B_PRIVATE outPrivate;
-    
+
     cmdAuth.sessionHandle = TPM_RS_PW;
     cmdAuth.nonce.t.size = 0;
     *( (UINT8 *)((void *)&cmdAuth.sessionAttributes ) ) = 0;
@@ -2898,13 +2898,13 @@ TPM_RC CreateDataBlob( TSS2_SYS_CONTEXT *sysContext, SESSION **policySession, TP
     inPublic.t.publicArea.objectAttributes.fixedParent = 1;
     inPublic.t.publicArea.objectAttributes.sensitiveDataOrigin = 1;
     inPublic.t.publicArea.authPolicy.t.size = 0;
-    inPublic.t.publicArea.parameters.rsaDetail.symmetric.algorithm = TPM_ALG_AES; 
-    inPublic.t.publicArea.parameters.rsaDetail.symmetric.keyBits.aes = 128; 
-    inPublic.t.publicArea.parameters.rsaDetail.symmetric.mode.aes = TPM_ALG_CBC; 
-    inPublic.t.publicArea.parameters.rsaDetail.scheme.scheme = TPM_ALG_NULL; 
-    inPublic.t.publicArea.parameters.rsaDetail.keyBits = 2048; 
-    inPublic.t.publicArea.parameters.rsaDetail.exponent = 0; 
-    inPublic.t.publicArea.unique.rsa.t.size = 0; 
+    inPublic.t.publicArea.parameters.rsaDetail.symmetric.algorithm = TPM_ALG_AES;
+    inPublic.t.publicArea.parameters.rsaDetail.symmetric.keyBits.aes = 128;
+    inPublic.t.publicArea.parameters.rsaDetail.symmetric.mode.aes = TPM_ALG_CBC;
+    inPublic.t.publicArea.parameters.rsaDetail.scheme.scheme = TPM_ALG_NULL;
+    inPublic.t.publicArea.parameters.rsaDetail.keyBits = 2048;
+    inPublic.t.publicArea.parameters.rsaDetail.exponent = 0;
+    inPublic.t.publicArea.unique.rsa.t.size = 0;
 
     outPublic.t.size = 0;
     creationData.t.size = 0;
@@ -2932,9 +2932,9 @@ TPM_RC CreateDataBlob( TSS2_SYS_CONTEXT *sysContext, SESSION **policySession, TP
     inPublic.t.publicArea.objectAttributes.decrypt = 0;
     inPublic.t.publicArea.objectAttributes.sensitiveDataOrigin = 0;
     CopySizedByteBuffer( &( inPublic.t.publicArea.authPolicy.b), &( policyDigest->b ) );
-    inPublic.t.publicArea.parameters.keyedHashDetail.scheme.scheme = TPM_ALG_NULL; 
+    inPublic.t.publicArea.parameters.keyedHashDetail.scheme.scheme = TPM_ALG_NULL;
     inPublic.t.publicArea.unique.keyedHash.t.size = 0;
-    
+
     outPublic.t.size = 0;
     creationData.t.size = 0;
     INIT_SIMPLE_TPM2B_SIZE( outPrivate );
@@ -2949,7 +2949,7 @@ TPM_RC CreateDataBlob( TSS2_SYS_CONTEXT *sysContext, SESSION **policySession, TP
     INIT_SIMPLE_TPM2B_SIZE( blobName );
     rval = Tss2_Sys_Load( sysContext, srkHandle, &cmdAuthArray, &outPrivate, &outPublic, &blobHandle, &blobName, 0 );
     CheckPassed( rval );
-    
+
     return rval;
 }
 
@@ -2966,7 +2966,7 @@ TPM_RC AuthValueUnseal( TSS2_SYS_CONTEXT *sysContext, SESSION *policySession )
     *( (UINT8 *)((void *)&cmdAuth.sessionAttributes ) ) = 0;
     cmdAuth.sessionAttributes.continueSession = 1;
     cmdAuth.hmac.t.size = 0;
-    
+
     // Now try to unseal the blob without setting the HMAC.
     // This test should fail.
     INIT_SIMPLE_TPM2B_SIZE( outData );
@@ -2990,7 +2990,7 @@ TPM_RC AuthValueUnseal( TSS2_SYS_CONTEXT *sysContext, SESSION *policySession )
 
     // Roll nonces for command.
     RollNonces( policySession, &cmdAuth.nonce );
-    
+
     // Now generate the HMAC.
     rval = ComputeCommandHmacs( sysContext,
             blobHandle,
@@ -3003,7 +3003,7 @@ TPM_RC AuthValueUnseal( TSS2_SYS_CONTEXT *sysContext, SESSION *policySession )
 
     rval = DeleteEntity( blobHandle );
     CheckPassed( rval );
-    
+
     // Add test to make sure we unsealed correctly.
 
     // Now we'll want to flush the data blob and remove it
@@ -3027,7 +3027,7 @@ TPM_RC PasswordUnseal( TSS2_SYS_CONTEXT *sysContext, SESSION *policySession )
     *( (UINT8 *)((void *)&cmdAuth.sessionAttributes ) ) = 0;
     cmdAuth.sessionAttributes.continueSession = 1;
     cmdAuth.hmac.t.size = 0;
-    
+
     // Now try to unseal the blob without setting the password.
     // This test should fail.
     INIT_SIMPLE_TPM2B_SIZE( outData );
@@ -3036,7 +3036,7 @@ TPM_RC PasswordUnseal( TSS2_SYS_CONTEXT *sysContext, SESSION *policySession )
 
     // Clear DA lockout.
     TestDictionaryAttackLockReset();
-    
+
     // Now try to unseal the blob after setting the password.
     // This test should pass.
     INIT_SIMPLE_TPM2B_SIZE( outData );
@@ -3065,7 +3065,7 @@ POLICY_TEST_SETUP policyTestSetups[] =
     { "PASSWORD", BuildPasswordPolicy, CreateDataBlob, PasswordUnseal },
     { "PASSWORD/PCR", BuildPasswordPcrPolicy, CreateDataBlob, PasswordUnseal },
     { "AUTHVALUE", BuildAuthValuePolicy, CreateDataBlob, AuthValueUnseal },
-    // TBD...        
+    // TBD...
 };
 
 void TestPolicy()
@@ -3104,7 +3104,7 @@ void TestPolicy()
             DebugPrintf( NO_PREFIX, "Policy digest used to create object:  \n" );
             DebugPrintBuffer( NO_PREFIX, &(policyDigest.t.buffer[0]), policyDigest.t.size );
 #endif
-            
+
             rval = ( *policyTestSetups[i].createObjectFn )( sysContext, &policySession, &policyDigest);
             CheckPassed( rval );
         }
@@ -3248,7 +3248,7 @@ void TestHash()
     sessionsData.cmdAuths = &sessionDataArray[0];
 
     sessionsDataOut.rspAuthsCount = 1;
-    
+
     DebugPrintf( NO_PREFIX, "\nHASH TESTS:\n" );
 
     auth.t.size = 2;
@@ -3256,10 +3256,10 @@ void TestHash()
     auth.t.buffer[1] = 0xff;
     rval = Tss2_Sys_HashSequenceStart ( sysContext, 0, &auth, TPM_ALG_SHA1, &sequenceHandle[0], 0 );
     CheckPassed( rval );
-    
+
     // Init authHandle
     sessionData.sessionHandle = TPM_RS_PW;
-    
+
     // Init nonce.
     sessionData.nonce.t.size = 0;
 
@@ -3271,7 +3271,7 @@ void TestHash()
 
     sessionsData.cmdAuthsCount = 1;
     sessionsData.cmdAuths[0] = &sessionData;
-    
+
     dataToHash.t.size = MAX_DIGEST_BUFFER;
     memcpy( &dataToHash.t.buffer[0], &memoryToHash[0], dataToHash.t.size );
 
@@ -3296,11 +3296,11 @@ void TestHash()
                 TPM_RH_PLATFORM, &result, &validation, &sessionsDataOut );
         CheckPassed( rval );
     }
-    
+
     //  Now try to finish the interrupted sequence.
     rval = Tss2_Sys_SequenceUpdate ( sysContext, sequenceHandle[0], &sessionsData, &dataToHash, &sessionsDataOut );
     CheckPassed( rval );
-    
+
     dataToHash.t.size = sizeof( memoryToHash ) - MAX_DIGEST_BUFFER;
     memcpy( &dataToHash.t.buffer[0], &memoryToHash[MAX_DIGEST_BUFFER], dataToHash.t.size );
     INIT_SIMPLE_TPM2B_SIZE( result );
@@ -3314,7 +3314,7 @@ void TestHash()
         DebugPrintf( NO_PREFIX, "ERROR!! resulting hash is incorrect.\n" );
         Cleanup();
     }
-    
+
     // Now try starting a bunch of sequences to see what happens.
     // This stresses the resource manager.
     for( i = 0; i < MAX_TEST_SEQUENCES; i++ )
@@ -3359,12 +3359,12 @@ void TestQuote()
     sessionsData.cmdAuths = &sessionDataArray[0];
 
     sessionsDataOut.rspAuthsCount = 1;
-    
+
     DebugPrintf( NO_PREFIX, "\nQUOTE CONTROL TESTS:\n" );
 
     // Init authHandle
     sessionData.sessionHandle = TPM_RS_PW;
-    
+
     // Init nonce.
     sessionData.nonce.t.size = 0;
 
@@ -3375,12 +3375,12 @@ void TestQuote()
 
     // Init session attributes
     *( (UINT8 *)((void *)&sessionData.sessionAttributes ) ) = 0;
-        
+
     qualifyingData.t.size = sizeof( qualDataString );
-    memcpy( &( qualifyingData.t.buffer[0] ), qualDataString, sizeof( qualDataString ) );        
+    memcpy( &( qualifyingData.t.buffer[0] ), qualDataString, sizeof( qualDataString ) );
 
     inScheme.scheme = TPM_ALG_NULL;
-    
+
     pcrSelection.count = 1;
     pcrSelection.pcrSelections[0].hash = TPM_ALG_SHA1;
     pcrSelection.pcrSelections[0].sizeofSelect = 3;
@@ -3390,20 +3390,20 @@ void TestQuote()
     pcrSelection.pcrSelections[0].pcrSelect[1] = 0;
     pcrSelection.pcrSelections[0].pcrSelect[2] = 0;
 
-    // Now set the PCR you want 
+    // Now set the PCR you want
     pcrSelection.pcrSelections[0].pcrSelect[( PCR_17/8 )] = ( 1 << ( PCR_18 % 8) );
 
     sessionsData.cmdAuthsCount = 1;
     sessionsData.cmdAuths[0] = &sessionData;
-    
+
     // Test with wrong type of key.
     INIT_SIMPLE_TPM2B_SIZE( quoted );
     rval = Tss2_Sys_Quote ( sysContext, loadedSha1KeyHandle, &sessionsData, &qualifyingData, &inScheme,
             &pcrSelection,  &quoted, &signature, &sessionsDataOut );
     CheckPassed( rval );
-    
+
     // Create signing key
-    
+
 
     // Now test quote operation
 //    Tpm20Quote ( ??TPMI_DH_OBJECT signHandle, TPM2B_DATA *qualifyingData,
@@ -3434,7 +3434,7 @@ void ProvisionOtherIndices()
     otherIndicesSessionsData.cmdAuths = &sessionDataArray[0];
 
     otherIndicesSessionsDataOut.rspAuthsCount = 1;
-    
+
     DebugPrintf( NO_PREFIX, "\nPROVISION OTHER NV INDICES:\n" );
 
     //
@@ -3495,7 +3495,7 @@ void ProvisionOtherIndices()
 
     otherIndicesSessionsData.cmdAuthsCount = 1;
     otherIndicesSessionsData.cmdAuths[0] = &otherIndicesSessionData;
-    
+
     rval = Tss2_Sys_NV_DefineSpace( sysContext, TPM_RH_PLATFORM, &otherIndicesSessionsData,
             &nvAuth, &publicInfo, &otherIndicesSessionsDataOut );
     CheckPassed( rval );
@@ -3515,10 +3515,10 @@ TSS2_RC InitNvAuxPolicySession( TPMI_SH_AUTH_SESSION *nvAuxPolicySessionHandle )
 {
     TPMA_LOCALITY locality;
     TPM_RC rval;
-    
+
     rval = StartPolicySession( nvAuxPolicySessionHandle );
     CheckPassed( rval );
-    
+
     // 2.  PolicyLocality(3)
     *(UINT8 *)((void *)&locality) = 0;
     locality.TPM_LOC_THREE = 1;
@@ -3550,7 +3550,7 @@ void ProvisionNvAux()
     nvAuxSessionsData.cmdAuths = &sessionDataArray[0];
 
     nvAuxSessionsDataOut.rspAuthsCount = 1;
-    
+
     DebugPrintf( NO_PREFIX, "\nPROVISION NV AUX:\n" );
 
     //
@@ -3590,7 +3590,7 @@ void ProvisionNvAux()
 
     nvAuxSessionsData.cmdAuthsCount = 1;
     nvAuxSessionsData.cmdAuths[0] = &nvAuxSessionData;
-    
+
     publicInfo.t.size = sizeof( TPMI_RH_NV_INDEX ) +
             sizeof( TPMI_ALG_HASH ) + sizeof( TPMA_NV ) + sizeof( UINT16) +
             sizeof( UINT16 );
@@ -3647,15 +3647,15 @@ void TpmAuxWrite( int locality)
 
     nullSessionsData.cmdAuthsCount = 1;
     nullSessionsData.cmdAuths[0] = &nullSessionData;
-    
-    rval = Tss2_Sys_NV_Write( sysContext, INDEX_AUX, INDEX_AUX, &nullSessionsData, &nvWriteData, 0, &nullSessionsDataOut ); 
+
+    rval = Tss2_Sys_NV_Write( sysContext, INDEX_AUX, INDEX_AUX, &nullSessionsData, &nvWriteData, 0, &nullSessionsDataOut );
 
     {
         TSS2_RC setLocalityRval;
         setLocalityRval = SetLocality( sysContext, 3 );
         CheckPassed( setLocalityRval );
     }
-    
+
     if( locality == 3 || locality == 4 )
     {
         CheckPassed( rval );
@@ -3680,7 +3680,7 @@ void TpmAuxReadWriteTest()
     TPM2B_MAX_NV_BUFFER nvData;
 
     DebugPrintf( NO_PREFIX, "TPM AUX READ/WRITE TEST\n" );
-    
+
     nullSessionData.sessionAttributes.continueSession = 0;
 
     // Try writing it from all localities.  Only locality 3 should work.
@@ -3700,14 +3700,14 @@ void TpmAuxReadWriteTest()
         CheckPassed( rval );
 
         INIT_SIMPLE_TPM2B_SIZE( nvData );
-        rval = Tss2_Sys_NV_Read( sysContext, INDEX_AUX, INDEX_AUX, &nullSessionsData, 4, 0, &nvData, &nullSessionsDataOut ); 
+        rval = Tss2_Sys_NV_Read( sysContext, INDEX_AUX, INDEX_AUX, &nullSessionsData, 4, 0, &nvData, &nullSessionsDataOut );
         CheckPassed( rval );
 
         rval = SetLocality( sysContext, 3 );
         CheckPassed( rval );
     }
 }
-    
+
 void TpmOtherIndicesReadWriteTest()
 {
     UINT32 rval;
@@ -3726,35 +3726,35 @@ void TpmOtherIndicesReadWriteTest()
     nullSessionsData.cmdAuthsCount = 1;
     nullSessionsData.cmdAuths[0] = &nullSessionData;
 
-    rval = Tss2_Sys_NV_Write( sysContext, INDEX_LCP_SUP, INDEX_LCP_SUP, &nullSessionsData, &nvWriteData, 0, &nullSessionsDataOut ); 
+    rval = Tss2_Sys_NV_Write( sysContext, INDEX_LCP_SUP, INDEX_LCP_SUP, &nullSessionsData, &nvWriteData, 0, &nullSessionsDataOut );
     CheckPassed( rval );
 
-    rval = Tss2_Sys_NV_Write( sysContext, INDEX_LCP_OWN, INDEX_LCP_OWN, &nullSessionsData, &nvWriteData, 0, &nullSessionsDataOut ); 
-    CheckPassed( rval );
-
-    INIT_SIMPLE_TPM2B_SIZE( nvData );
-    rval = Tss2_Sys_NV_Read( sysContext, INDEX_LCP_SUP, INDEX_LCP_SUP, &nullSessionsData, 4, 0, &nvData, &nullSessionsDataOut ); 
+    rval = Tss2_Sys_NV_Write( sysContext, INDEX_LCP_OWN, INDEX_LCP_OWN, &nullSessionsData, &nvWriteData, 0, &nullSessionsDataOut );
     CheckPassed( rval );
 
     INIT_SIMPLE_TPM2B_SIZE( nvData );
-    rval = Tss2_Sys_NV_Read( sysContext, INDEX_LCP_OWN, INDEX_LCP_OWN, &nullSessionsData, 4, 0, &nvData, &nullSessionsDataOut ); 
+    rval = Tss2_Sys_NV_Read( sysContext, INDEX_LCP_SUP, INDEX_LCP_SUP, &nullSessionsData, 4, 0, &nvData, &nullSessionsDataOut );
+    CheckPassed( rval );
+
+    INIT_SIMPLE_TPM2B_SIZE( nvData );
+    rval = Tss2_Sys_NV_Read( sysContext, INDEX_LCP_OWN, INDEX_LCP_OWN, &nullSessionsData, 4, 0, &nvData, &nullSessionsDataOut );
     CheckPassed( rval );
 }
-    
+
 void NvIndexProto()
 {
     UINT32 rval;
 
     DebugPrintf( NO_PREFIX, "\nNV INDEX PROTOTYPE TESTS:\n" );
 
-    
+
     // AUX index: Write is controlled by TPM2_PolicyLocality; Read is controlled by authValue and is unrestricted since authValue is set to emptyBuffer
     // PS index: Write and read are unrestricted until TPM2_WriteLock. After that content is write protected
     // PO index: Write is restricted by ownerAuth; Read is controlled by authValue and is unrestricted since authValue is set to emptyBuffer
 
     // Now we need to configure NV indices
     ProvisionNvAux();
-    
+
     ProvisionOtherIndices();
 
     TpmAuxReadWriteTest();
@@ -3810,12 +3810,12 @@ void TestPcrAllocate()
 
     // Init session attributes
     *( (UINT8 *)((void *)&sessionData.sessionAttributes ) ) = 0;
-    
+
     pcrSelection.count = 0;
 
     sessionsData.cmdAuthsCount = 1;
     sessionsData.cmdAuths[0] = &sessionData;
-    
+
     rval = Tss2_Sys_PCR_Allocate( sysContext, TPM_RH_PLATFORM, &sessionsData, &pcrSelection,
             &allocationSuccess, &maxPcr, &sizeNeeded, &sizeAvailable, &sessionsDataOut);
     CheckPassed( rval );
@@ -3832,7 +3832,7 @@ void TestPcrAllocate()
     SET_PCR_SELECT_BIT( pcrSelection.pcrSelections[1], PCR_5 );
     SET_PCR_SELECT_BIT( pcrSelection.pcrSelections[1], PCR_8 );
     pcrSelection.pcrSelections[2].hash = TPM_ALG_SHA256;
-    CLEAR_PCR_SELECT_BITS( pcrSelection.pcrSelections[2] ); 
+    CLEAR_PCR_SELECT_BITS( pcrSelection.pcrSelections[2] );
     SET_PCR_SELECT_SIZE( pcrSelection.pcrSelections[2], 3 );
     SET_PCR_SELECT_BIT( pcrSelection.pcrSelections[2], PCR_6 );
 
@@ -3864,7 +3864,7 @@ void TestUnseal()
     sessionsData.cmdAuths = &sessionDataArray[0];
 
     sessionsDataOut.rspAuthsCount = 1;
-        
+
     TPM2B_PRIVATE outPrivate;
     TPM2B_PUBLIC outPublic;
     TPM2B_CREATION_DATA creationData;
@@ -3872,11 +3872,11 @@ void TestUnseal()
     TPMT_TK_CREATION creationTicket;
     TPM2B_NAME name;
     TPM2B_SENSITIVE_DATA outData;
-    
+
 
     const char authStr[] = "test";
     const char sensitiveData[] = "this is sensitive";
-    
+
     DebugPrintf( NO_PREFIX, "\nUNSEAL TEST  :\n" );
 
     sessionData.sessionHandle = TPM_RS_PW;
@@ -3895,12 +3895,12 @@ void TestUnseal()
     memcpy( &( inSensitive.t.sensitive.userAuth.t.buffer[0] ), authStr, sizeof( authStr ) - 1 );
     inSensitive.t.sensitive.data.t.size = sizeof( sensitiveData ) - 1;
     memcpy( &( inSensitive.t.sensitive.data.t.buffer[0] ), sensitiveData, sizeof( sensitiveData ) - 1 );
-    
+
     inPublic.t.publicArea.authPolicy.t.size = 0;
 
     inPublic.t.publicArea.unique.keyedHash.t.size = 0;
 
-    outsideInfo.t.size = 0;    
+    outsideInfo.t.size = 0;
     creationPCR.count = 0;
 
     inPublic.t.publicArea.type = TPM_ALG_KEYEDHASH;
@@ -3913,7 +3913,7 @@ void TestUnseal()
 
     inPublic.t.publicArea.unique.keyedHash.t.size = 0;
 
-    outsideInfo.t.size = 0;    
+    outsideInfo.t.size = 0;
 
     sessionsData.cmdAuthsCount = 1;
     sessionsData.cmdAuths[0]  = &sessionData;
@@ -3933,7 +3933,7 @@ void TestUnseal()
             TPM_RH_PLATFORM, &loadedObjectHandle, &name, 0 );
     CheckPassed( rval );
 
-    rval = Tss2_Sys_FlushContext( sysContext, loadedObjectHandle ); 
+    rval = Tss2_Sys_FlushContext( sysContext, loadedObjectHandle );
     CheckPassed( rval );
 
     INIT_SIMPLE_TPM2B_SIZE( name );
@@ -3947,7 +3947,7 @@ void TestUnseal()
     INIT_SIMPLE_TPM2B_SIZE( outData );
     rval = Tss2_Sys_Unseal( sysContext, loadedObjectHandle, &sessionsData, &outData, &sessionsDataOut );
 
-    rval = Tss2_Sys_FlushContext( sysContext, loadedObjectHandle ); 
+    rval = Tss2_Sys_FlushContext( sysContext, loadedObjectHandle );
     CheckPassed( rval );
 
     CheckPassed( rval );
@@ -4010,7 +4010,7 @@ void CreatePasswordTestNV( TPMI_RH_NV_INDEX nvIndex, char * password )
     publicInfo.t.nvPublic.attributes.TPMA_NV_ORDERLY = 1;
     publicInfo.t.nvPublic.authPolicy.t.size = 0;
     publicInfo.t.nvPublic.dataSize = 32;
-    
+
     rval = Tss2_Sys_NV_DefineSpace( sysContext, TPM_RH_PLATFORM,
             &sessionsData, &nvAuth, &publicInfo, &sessionsDataOut );
     CheckPassed( rval );
@@ -4055,7 +4055,7 @@ void PasswordTest()
     //
     // Initialize the command authorization area.
     //
-    
+
     // Init sessionHandle, nonce, session
     // attributes, and hmac (password).
     sessionData.sessionHandle = TPM_RS_PW;
@@ -4093,7 +4093,7 @@ void PasswordTest()
             TPM20_INDEX_PASSWORD_TEST,
             TPM20_INDEX_PASSWORD_TEST,
             &sessionsData, &nvWriteData, 0,
-            &sessionsDataOut ); 
+            &sessionsDataOut );
     // Check that the function failed as expected,
     // since password was incorrect.  If wrong
     // response code received, exit.
@@ -4137,7 +4137,7 @@ void SimplePolicyTest()
     TSS2_SYS_RSP_AUTHS nvRspAuths = { 1, &nvRspAuthArray[0] };
     TPM_ALG_ID sessionAlg = TPM_ALG_SHA256;
     TPM2B_NONCE nonceCaller;
-    
+
     nonceCaller.t.size = 0;
 
     DebugPrintf( NO_PREFIX, "\nSIMPLE POLICY TEST:\n" );
@@ -4181,7 +4181,7 @@ void SimplePolicyTest()
     // And remove the trial policy session from sessions table.
     rval = EndAuthSession( trialPolicySession );
     CheckPassed( rval );
-    
+
     // Now set the NV index's attributes:
     // policyRead, authWrite, and platormCreate.
     *(UINT32 *)( (void *)&nvAttributes ) = 0;
@@ -4212,7 +4212,7 @@ void SimplePolicyTest()
     // encryption algorithm, and SHA256 is the session's
     // hash algorithm.
     //
-    
+
     // Zero sized encrypted salt, since the session
     // is unsalted.
     encryptedSalt.t.size = 0;
@@ -4256,7 +4256,7 @@ void SimplePolicyTest()
 
     // First call prepare in order to create cpBuffer.
     rval = Tss2_Sys_NV_Write_Prepare( sysContext, TPM20_INDEX_PASSWORD_TEST,
-            TPM20_INDEX_PASSWORD_TEST, &nvWriteData, 0 ); 
+            TPM20_INDEX_PASSWORD_TEST, &nvWriteData, 0 );
     CheckPassed( rval );
 
     // Configure command authorization area, except for HMAC.
@@ -4269,7 +4269,7 @@ void SimplePolicyTest()
 
     // Roll nonces for command
     RollNonces( nvSession, &nvCmdAuths.cmdAuths[0]->nonce );
-    
+
     // Complete command authorization area, by computing
     // HMAC and setting it in nvCmdAuths.
     rval = ComputeCommandHmacs( sysContext,
@@ -4289,7 +4289,7 @@ void SimplePolicyTest()
 
     // Roll nonces for response
     RollNonces( nvSession, &nvRspAuths.rspAuths[0]->nonce );
-    
+
     if( sessionCmdRval == TPM_RC_SUCCESS )
     {
         // If the command was successful, check the
@@ -4306,15 +4306,15 @@ void SimplePolicyTest()
 
     // First call prepare in order to create cpBuffer.
     rval = Tss2_Sys_NV_Read_Prepare( sysContext, TPM20_INDEX_PASSWORD_TEST,
-            TPM20_INDEX_PASSWORD_TEST, sizeof( dataToWrite ), 0 ); 
+            TPM20_INDEX_PASSWORD_TEST, sizeof( dataToWrite ), 0 );
     CheckPassed( rval );
 
     // Roll nonces for command
     RollNonces( nvSession, &nvCmdAuths.cmdAuths[0]->nonce );
-    
+
     // End the session after next command.
     nvCmdAuths.cmdAuths[0]->sessionAttributes.continueSession = 0;
-    
+
     // Complete command authorization area, by computing
     // HMAC and setting it in nvCmdAuths.
     rval = ComputeCommandHmacs( sysContext,
@@ -4336,7 +4336,7 @@ void SimplePolicyTest()
 
     // Roll nonces for response
     RollNonces( nvSession, &nvRspAuths.rspAuths[0]->nonce );
-    
+
     if( sessionCmdRval == TPM_RC_SUCCESS )
     {
         // If the command was successful, check the
@@ -4355,7 +4355,7 @@ void SimplePolicyTest()
         DebugPrintf( NO_PREFIX, "ERROR!! read data not equal to written data\n" );
         Cleanup();
     }
-    
+
     //
     // Now cleanup:  undefine the NV index and delete
     // the NV index's entity table entry.
@@ -4421,7 +4421,7 @@ void SimpleHmacTest()
     // to zero sized policy since we won't be
     // using policy to authorize.
     authPolicy.t.size = 0;
-    
+
     // Now set the NV index's attributes:
     // policyRead, authWrite, and platormCreate.
     *(UINT32 *)( (void *)&nvAttributes ) = 0;
@@ -4452,7 +4452,7 @@ void SimpleHmacTest()
     // encryption algorithm, and SHA256 is the session's
     // hash algorithm.
     //
-    
+
     // Zero sized encrypted salt, since the session
     // is unsalted.
     encryptedSalt.t.size = 0;
@@ -4487,7 +4487,7 @@ void SimpleHmacTest()
 
     // First call prepare in order to create cpBuffer.
     rval = Tss2_Sys_NV_Write_Prepare( sysContext, TPM20_INDEX_PASSWORD_TEST,
-            TPM20_INDEX_PASSWORD_TEST, &nvWriteData, 0 ); 
+            TPM20_INDEX_PASSWORD_TEST, &nvWriteData, 0 );
     CheckPassed( rval );
 
     // Configure command authorization area, except for HMAC.
@@ -4500,7 +4500,7 @@ void SimpleHmacTest()
 
     // Roll nonces for command
     RollNonces( nvSession, &nvCmdAuths.cmdAuths[0]->nonce );
-    
+
     // Complete command authorization area, by computing
     // HMAC and setting it in nvCmdAuths.
     rval = ComputeCommandHmacs( sysContext,
@@ -4520,7 +4520,7 @@ void SimpleHmacTest()
 
     // Roll nonces for response
     RollNonces( nvSession, &nvRspAuths.rspAuths[0]->nonce );
-    
+
     if( sessionCmdRval == TPM_RC_SUCCESS )
     {
         // If the command was successful, check the
@@ -4534,15 +4534,15 @@ void SimpleHmacTest()
 
     // First call prepare in order to create cpBuffer.
     rval = Tss2_Sys_NV_Read_Prepare( sysContext, TPM20_INDEX_PASSWORD_TEST,
-            TPM20_INDEX_PASSWORD_TEST, sizeof( dataToWrite ), 0 ); 
+            TPM20_INDEX_PASSWORD_TEST, sizeof( dataToWrite ), 0 );
     CheckPassed( rval );
 
     // Roll nonces for command
     RollNonces( nvSession, &nvCmdAuths.cmdAuths[0]->nonce );
-    
+
     // End the session after next command.
     nvCmdAuths.cmdAuths[0]->sessionAttributes.continueSession = 0;
-    
+
     // Complete command authorization area, by computing
     // HMAC and setting it in nvCmdAuths.
     rval = ComputeCommandHmacs( sysContext,
@@ -4564,7 +4564,7 @@ void SimpleHmacTest()
 
     // Roll nonces for response
     RollNonces( nvSession, &nvRspAuths.rspAuths[0]->nonce );
-    
+
     if( sessionCmdRval == TPM_RC_SUCCESS )
     {
         // If the command was successful, check the
@@ -4583,7 +4583,7 @@ void SimpleHmacTest()
         DebugPrintf( NO_PREFIX, "ERROR!! read data not equal to written data\n" );
         Cleanup();
     }
-    
+
     //
     // Now cleanup:  undefine the NV index and delete
     // the NV index's entity table entry.
@@ -4649,7 +4649,7 @@ void SimpleHmacOrPolicyTest( bool hmacTest )
 
     if( hmacTest )
         testString = testStringHmac;
-    else        
+    else
         testString = testStringPolicy;
 
     DebugPrintf( NO_PREFIX, "\nSIMPLE %s SESSION TEST:\n", testString );
@@ -4813,7 +4813,7 @@ void SimpleHmacOrPolicyTest( bool hmacTest )
     // First call prepare in order to create cpBuffer.
     rval = Tss2_Sys_NV_Write_Prepare( simpleTestContext,
             TPM20_INDEX_PASSWORD_TEST,
-            TPM20_INDEX_PASSWORD_TEST, &nvWriteData, 0 ); 
+            TPM20_INDEX_PASSWORD_TEST, &nvWriteData, 0 );
     CheckPassed( rval );
 
     // Configure command authorization area, except for HMAC.
@@ -4870,7 +4870,7 @@ void SimpleHmacOrPolicyTest( bool hmacTest )
     rval = Tss2_Sys_NV_Read_Prepare( simpleTestContext,
             TPM20_INDEX_PASSWORD_TEST,
             TPM20_INDEX_PASSWORD_TEST,
-            sizeof( dataToWrite ), 0 ); 
+            sizeof( dataToWrite ), 0 );
     CheckPassed( rval );
 
     // Roll nonces for command
@@ -5011,10 +5011,10 @@ void HmacSessionTest()
 
     char buffer1contents[] = "test";
     char buffer2contents[] = "string";
-    
+
     TPM2B_MAX_BUFFER buffer1;
     TPM2B_MAX_BUFFER buffer2;
-    
+
 //    TPM2B_IV ivIn, ivOut;
     TPM2B_MAX_NV_BUFFER nvData;
     TPM2B_ENCRYPTED_SECRET encryptedSalt;
@@ -5022,7 +5022,7 @@ void HmacSessionTest()
     encryptedSalt.t.size = 0;
 //    ivIn.t.size = 0;
 //    ivOut.t.size = 0;
-    
+
     buffer1.t.size = strlen( buffer1contents );
     memcpy (buffer1.t.buffer, buffer1contents, buffer1.t.size );
     buffer2.t.size = strlen( buffer2contents );
@@ -5065,7 +5065,7 @@ void HmacSessionTest()
                     sessionsData.cmdAuths[0]->sessionHandle = TPM_RS_PW;
                     sessionsData.cmdAuths[0]->nonce.t.size = 0;
                     *( (UINT8 *)(&sessionData.sessionAttributes ) ) = 0;
-                    
+
                     inScheme.scheme = TPM_ALG_OAEP;
                     inScheme.details.oaep.hashAlg = TPM_ALG_SHA1;
                     memcpy( &( label.b.buffer ), "SECRET", 1 + strlen( "SECRET" ) );
@@ -5139,7 +5139,7 @@ void HmacSessionTest()
                         symmetric.keyBits.exclusiveOr = TPM_ALG_SHA256;
                     }
                 }
-                    
+
                 rval = StartAuthSessionWithParams( &nvSession, hmacTestSetups[j].tpmKey,
                         hmacTestSetups[j].salt, hmacTestSetups[j].bound, &nvAuth, &nonceOlder, &encryptedSalt,
                         TPM_SE_HMAC, &symmetric, TPM_ALG_SHA1, resMgrTctiContext );
@@ -5177,7 +5177,7 @@ void HmacSessionTest()
                     sessionsData.cmdAuths[0]->sessionAttributes.decrypt = 0;
                 }
                 sessionsData.cmdAuths[0]->sessionAttributes.encrypt = 0;
-                
+
                 CheckPassed( rval );
 
                 sessionsData.cmdAuths[0]->sessionHandle = nvSession->sessionHandle;
@@ -5186,10 +5186,10 @@ void HmacSessionTest()
 
                 // Roll nonces for command
                 RollNonces( nvSession, &sessionsData.cmdAuths[0]->nonce );
-                
+
                 // Now try writing with bad HMAC.
                 rval = Tss2_Sys_NV_Write_Prepare( wrSysContext, TPM20_INDEX_PASSWORD_TEST,
-                        TPM20_INDEX_PASSWORD_TEST, &nvWriteData, 0 ); 
+                        TPM20_INDEX_PASSWORD_TEST, &nvWriteData, 0 );
                 CheckPassed( rval );
 
                 rval = ComputeCommandHmacs( wrSysContext,
@@ -5203,11 +5203,11 @@ void HmacSessionTest()
 
                 sessionCmdRval = Tss2_Sys_NV_Write( wrSysContext, TPM20_INDEX_PASSWORD_TEST,
                         TPM20_INDEX_PASSWORD_TEST,
-                        &sessionsData, &nvWriteData, 0, &sessionsDataOut ); 
+                        &sessionsData, &nvWriteData, 0, &sessionsDataOut );
                 CheckFailed( sessionCmdRval, TPM_RC_S + TPM_RC_1 + TPM_RC_AUTH_FAIL );
 
                 // Since command failed, no need to roll nonces.
-                
+
                 TestDictionaryAttackLockReset();
 
                 // Now try writing with good HMAC.
@@ -5215,12 +5215,12 @@ void HmacSessionTest()
                 // Do stage 1 of NVRead, followed by stage 1 and 2 of NVWrite, followed by
                 // stage 2 of NVRead.  This tests that the staged processing is thread-safe.
                 sessionsData.cmdAuths[0]->sessionAttributes.continueSession = 0;
-                rval = Tss2_Sys_NV_Read_Prepare( rdSysContext, TPM20_INDEX_PASSWORD_TEST, TPM20_INDEX_PASSWORD_TEST, sizeof( dataToWrite ), 0 ); 
+                rval = Tss2_Sys_NV_Read_Prepare( rdSysContext, TPM20_INDEX_PASSWORD_TEST, TPM20_INDEX_PASSWORD_TEST, sizeof( dataToWrite ), 0 );
                 CheckPassed( rval );
 
                 sessionsData.cmdAuths[0]->sessionAttributes.continueSession = 1;
                 rval = Tss2_Sys_NV_Write_Prepare( wrSysContext, TPM20_INDEX_PASSWORD_TEST, TPM20_INDEX_PASSWORD_TEST,
-                        &nvWriteData, 0 ); 
+                        &nvWriteData, 0 );
                 CheckPassed( rval );
 
                 rval = ComputeCommandHmacs( wrSysContext, TPM20_INDEX_PASSWORD_TEST,
@@ -5228,7 +5228,7 @@ void HmacSessionTest()
                 CheckPassed( rval );
 
                 sessionCmdRval = Tss2_Sys_NV_Write( wrSysContext,
-                        TPM20_INDEX_PASSWORD_TEST, TPM20_INDEX_PASSWORD_TEST, &sessionsData, &nvWriteData, 0, &sessionsDataOut ); 
+                        TPM20_INDEX_PASSWORD_TEST, TPM20_INDEX_PASSWORD_TEST, &sessionsData, &nvWriteData, 0, &sessionsDataOut );
                 CheckPassed( sessionCmdRval );
                 if( sessionCmdRval == TPM_RC_SUCCESS )
                 {
@@ -5242,7 +5242,7 @@ void HmacSessionTest()
 
                 // Roll nonces for command
                 RollNonces( nvSession, &sessionsData.cmdAuths[0]->nonce );
-                
+
                 sessionsData.cmdAuths[0]->sessionAttributes.continueSession = 0;
                 rval = ComputeCommandHmacs( rdSysContext, TPM20_INDEX_PASSWORD_TEST,
                        TPM20_INDEX_PASSWORD_TEST, &sessionsData, sessionCmdRval );
@@ -5260,7 +5260,7 @@ void HmacSessionTest()
 
                 INIT_SIMPLE_TPM2B_SIZE( nvData );
                 sessionCmdRval = Tss2_Sys_NV_Read( rdSysContext, TPM20_INDEX_PASSWORD_TEST,
-                        TPM20_INDEX_PASSWORD_TEST, &sessionsData, sizeof( dataToWrite ), 0, &nvData, &sessionsDataOut ); 
+                        TPM20_INDEX_PASSWORD_TEST, &sessionsData, sizeof( dataToWrite ), 0, &nvData, &sessionsDataOut );
                 CheckPassed( sessionCmdRval );
                 if( sessionCmdRval == TPM_RC_SUCCESS )
                 {
@@ -5326,7 +5326,7 @@ void HmacSessionTest()
                     // TBD:  Need to encrypt data before sending.
 
                     rval = Tss2_Sys_NV_Write_Prepare( wrSysContext, TPM20_INDEX_PASSWORD_TEST,
-                            TPM20_INDEX_PASSWORD_TEST, &nvWriteData, 0 ); 
+                            TPM20_INDEX_PASSWORD_TEST, &nvWriteData, 0 );
                     CheckPassed( rval );
 
                     // Roll nonces for command
@@ -5336,7 +5336,7 @@ void HmacSessionTest()
                             TPM20_INDEX_PASSWORD_TEST, &sessionsData, TPM_RC_FAILURE );
                     CheckPassed( rval );
 
-                    sessionCmdRval = Tss2_Sys_NV_Write( wrSysContext, TPM20_INDEX_PASSWORD_TEST, TPM20_INDEX_PASSWORD_TEST, &sessionsData, &nvWriteData, 0, &sessionsDataOut ); 
+                    sessionCmdRval = Tss2_Sys_NV_Write( wrSysContext, TPM20_INDEX_PASSWORD_TEST, TPM20_INDEX_PASSWORD_TEST, &sessionsData, &nvWriteData, 0, &sessionsDataOut );
                     sessionsData.cmdAuths[0]->sessionAttributes.decrypt = 0;
                     CheckPassed( sessionCmdRval );
                     if( sessionCmdRval == TPM_RC_SUCCESS )
@@ -5368,7 +5368,7 @@ void HmacSessionTest()
 
                     INIT_SIMPLE_TPM2B_SIZE( nvData );
                     sessionCmdRval = Tss2_Sys_NV_Read( rdSysContext, TPM20_INDEX_PASSWORD_TEST,
-                            TPM20_INDEX_PASSWORD_TEST, &sessionsData, sizeof( dataToWrite ), 0, &nvData, &sessionsDataOut ); 
+                            TPM20_INDEX_PASSWORD_TEST, &sessionsData, sizeof( dataToWrite ), 0, &nvData, &sessionsDataOut );
                     sessionsData.cmdAuths[0]->sessionAttributes.encrypt = 0;
                     sessionsData.cmdAuths[0]->sessionAttributes.audit = 0;
                     if( sessionCmdRval == TPM_RC_SUCCESS )
@@ -5388,7 +5388,7 @@ void HmacSessionTest()
                 }
 
                 // Removed comparison for now until we figure out how to properly
-                // encrypt data before writing to NV index. 
+                // encrypt data before writing to NV index.
                 //        rval = CompareTPM2B( &(nvWriteData.b), &(nvData.b) );
                 //        CheckPassed( rval );
 
@@ -5434,7 +5434,7 @@ void TestEncryptDecryptSession()
     TPM2B_NONCE         nonceCaller;
 
     nonceCaller.t.size = 0;
-    
+
     // Authorization structure for undefine command.
     TPMS_AUTH_COMMAND nvUndefineAuth;
 
@@ -5508,7 +5508,7 @@ void TestEncryptDecryptSession()
 
         // Setup session parameters.
         if( i == 0 )
-        {                
+        {
             // AES encryption/decryption and CFB mode.
             symmetric.algorithm = TPM_ALG_AES;
             symmetric.keyBits.aes = 128;
@@ -5518,7 +5518,7 @@ void TestEncryptDecryptSession()
         {
             // XOR encryption/decryption.
             symmetric.algorithm = TPM_ALG_XOR;
-            symmetric.keyBits.exclusiveOr = TPM_ALG_SHA256; 
+            symmetric.keyBits.exclusiveOr = TPM_ALG_SHA256;
         }
 
         // Start policy session for decrypt/encrypt session.
@@ -5623,16 +5623,16 @@ void TestEncryptDecryptSession()
                 &decryptEncryptSessionCmdAuth.nonce );
 
         // Now read the data without encrypt set.
-        nvRdWrCmdAuths.cmdAuthsCount = 1;            
-        nvRdWrRspAuths.rspAuthsCount = 1;            
+        nvRdWrCmdAuths.cmdAuthsCount = 1;
+        nvRdWrRspAuths.rspAuthsCount = 1;
         INIT_SIMPLE_TPM2B_SIZE( readData );
         rval = Tss2_Sys_NV_Read( sysContext, TPM20_INDEX_TEST1,
                 TPM20_INDEX_TEST1, &nvRdWrCmdAuths,
                 sizeof( writeDataString ), 0, &readData,
                 &nvRdWrRspAuths );
         CheckPassed( rval );
-        nvRdWrCmdAuths.cmdAuthsCount = 2;            
-        nvRdWrRspAuths.rspAuthsCount = 2;            
+        nvRdWrCmdAuths.cmdAuthsCount = 2;
+        nvRdWrRspAuths.rspAuthsCount = 2;
 
         // Roll the nonces for response
         RollNonces( encryptDecryptSession,
@@ -5653,7 +5653,7 @@ void TestEncryptDecryptSession()
         // Read TPM index with encrypt session; use
         // syncronous APIs to do this.
         //
-        
+
         rval = Tss2_Sys_NV_Read_Prepare( sysContext, TPM20_INDEX_TEST1,
                 TPM20_INDEX_TEST1, sizeof( writeDataString ), 0 );
         CheckPassed( rval );
@@ -5723,7 +5723,7 @@ void TestEncryptDecryptSession()
         }
 
         rval = Tss2_Sys_FlushContext( sysContext,
-                encryptDecryptSession->sessionHandle ); 
+                encryptDecryptSession->sessionHandle );
         CheckPassed( rval );
 
         rval = EndAuthSession( encryptDecryptSession );
@@ -5738,7 +5738,7 @@ void TestEncryptDecryptSession()
 
     // Undefine NV index.
     rval = Tss2_Sys_NV_UndefineSpace( sysContext,
-            TPM_RH_PLATFORM, TPM20_INDEX_TEST1, &nvUndefineAuths, 0 );       
+            TPM_RH_PLATFORM, TPM20_INDEX_TEST1, &nvUndefineAuths, 0 );
     CheckPassed( rval );
 }
 
@@ -5792,7 +5792,7 @@ void TestRsaEncryptDecrypt()
     inPublic.t.publicArea.parameters.rsaDetail.exponent = 0;
     inPublic.t.publicArea.unique.rsa.t.size = 0;
 
-    outsideInfo.t.size = 0;    
+    outsideInfo.t.size = 0;
     outPublic.t.size = 0;
     creationData.t.size = 0;
     INIT_SIMPLE_TPM2B_SIZE( outPrivate );
@@ -5819,7 +5819,7 @@ void TestRsaEncryptDecrypt()
     // Decrypt message with private key.
 
     // Print decrypted message.
-    
+
 }
 
 
@@ -5834,7 +5834,7 @@ void GetSetDecryptParamTests()
     TSS2_RC rval;
     int i;
     TSS2_SYS_CONTEXT *decryptParamTestSysContext;
-    
+
     DebugPrintf( NO_PREFIX, "\nGET/SET DECRYPT PARAM TESTS:\n" );
 
     // Create two sysContext structures.
@@ -5854,30 +5854,30 @@ void GetSetDecryptParamTests()
 
     // NOTE:  Two tests for BAD_SEQUENCE for GetDecryptParam and SetDecryptParam after ExecuteAsync
     // are in the GetSetEncryptParamTests function, just because it's easier to do this way.
-    
+
     // Do Prepare.
     rval = Tss2_Sys_NV_Write_Prepare( decryptParamTestSysContext, TPM20_INDEX_PASSWORD_TEST,
-            TPM20_INDEX_PASSWORD_TEST, &nvWriteData1, 0x55aa ); 
+            TPM20_INDEX_PASSWORD_TEST, &nvWriteData1, 0x55aa );
     CheckPassed( rval );
 
     // Test for bad reference:  Tss2_Sys_GetDecryptParam
     rval = Tss2_Sys_GetDecryptParam( 0, &decryptParamSize, &decryptParamBuffer );
     CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE );
-    
+
     rval = Tss2_Sys_GetDecryptParam( decryptParamTestSysContext, 0, &decryptParamBuffer );
     CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE );
-    
+
     rval = Tss2_Sys_GetDecryptParam( decryptParamTestSysContext, &decryptParamSize, 0 );
     CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE );
 
-    
+
     // Test for bad reference:  Tss2_Sys_SetDecryptParam
     rval = Tss2_Sys_SetDecryptParam( decryptParamTestSysContext, 4, 0 );
     CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE );
 
     rval = Tss2_Sys_SetDecryptParam( 0, 4, 0 );
     CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE );
-    
+
 
     // Test for bad size.
     rval = Tss2_Sys_SetDecryptParam( decryptParamTestSysContext, 5, &( nvWriteData.t.buffer[0] ) );
@@ -5907,11 +5907,11 @@ void GetSetDecryptParamTests()
 
 #ifdef DEBUG
     DebugPrintf( NO_PREFIX, "cpBuffer = ");
-#endif    
+#endif
     DEBUG_PRINT_BUFFER( NO_PREFIX, (UINT8 *)cpBuffer1, cpBufferUsedSize1 );
-    
+
     // Test for no decrypt param.
-    rval = Tss2_Sys_NV_Read_Prepare( decryptParamTestSysContext, TPM20_INDEX_PASSWORD_TEST, TPM20_INDEX_PASSWORD_TEST, sizeof( nvWriteData ) - 2, 0 ); 
+    rval = Tss2_Sys_NV_Read_Prepare( decryptParamTestSysContext, TPM20_INDEX_PASSWORD_TEST, TPM20_INDEX_PASSWORD_TEST, sizeof( nvWriteData ) - 2, 0 );
     CheckPassed( rval );
 
     rval = Tss2_Sys_GetDecryptParam( decryptParamTestSysContext, &decryptParamSize, &decryptParamBuffer );
@@ -5922,7 +5922,7 @@ void GetSetDecryptParamTests()
 
     // Null decrypt param.
     rval = Tss2_Sys_NV_Write_Prepare( decryptParamTestSysContext, TPM20_INDEX_PASSWORD_TEST,
-            TPM20_INDEX_PASSWORD_TEST, 0, 0x55aa ); 
+            TPM20_INDEX_PASSWORD_TEST, 0, 0x55aa );
     CheckPassed( rval );
 
     rval = Tss2_Sys_GetDecryptParam( decryptParamTestSysContext, &decryptParamSize, &decryptParamBuffer );
@@ -5938,7 +5938,7 @@ void GetSetDecryptParamTests()
     // Test for insufficient size.
     rval = Tss2_Sys_GetCpBuffer( decryptParamTestSysContext, &cpBufferUsedSize2, &cpBuffer2 );
     CheckPassed( rval );
-    nvWriteData.t.size = MAX_NV_BUFFER_SIZE - 
+    nvWriteData.t.size = MAX_NV_BUFFER_SIZE -
             CHANGE_ENDIAN_DWORD( ( (TPM20_Header_In *)( ( (_TSS2_SYS_CONTEXT_BLOB *)decryptParamTestSysContext )->tpmInBuffPtr ) )->commandSize ) +
             1;
     rval = Tss2_Sys_SetDecryptParam( decryptParamTestSysContext, nvWriteData.t.size, &( nvWriteData.t.buffer[0] ) );
@@ -5951,7 +5951,7 @@ void GetSetDecryptParamTests()
 
 
     rval = Tss2_Sys_NV_Write_Prepare( decryptParamTestSysContext, TPM20_INDEX_PASSWORD_TEST,
-            TPM20_INDEX_PASSWORD_TEST, 0, 0x55aa ); 
+            TPM20_INDEX_PASSWORD_TEST, 0, 0x55aa );
     CheckPassed( rval );
 
     rval = Tss2_Sys_GetDecryptParam( decryptParamTestSysContext, &decryptParamSize, &decryptParamBuffer );
@@ -5965,7 +5965,7 @@ void GetSetDecryptParamTests()
 
 #ifdef DEBUG
     DebugPrintf( NO_PREFIX, "cpBuffer = ");
-#endif    
+#endif
     DEBUG_PRINT_BUFFER( NO_PREFIX, (UINT8 *)cpBuffer2, cpBufferUsedSize2 );
 
     if( cpBufferUsedSize1 != cpBufferUsedSize2 )
@@ -5985,7 +5985,7 @@ void GetSetDecryptParamTests()
     // Test case of zero sized decrypt param, another case of bad size.
     nvWriteData1.t.size = 0;
     rval = Tss2_Sys_NV_Write_Prepare( decryptParamTestSysContext, TPM20_INDEX_PASSWORD_TEST,
-            TPM20_INDEX_PASSWORD_TEST, &nvWriteData1, 0x55aa ); 
+            TPM20_INDEX_PASSWORD_TEST, &nvWriteData1, 0x55aa );
     CheckPassed( rval );
 
     rval = Tss2_Sys_SetDecryptParam( decryptParamTestSysContext, 1, &( nvWriteData.t.buffer[0] ) );
@@ -6006,13 +6006,13 @@ void SysInitializeTests()
 
     rval = Tss2_Sys_Initialize( (TSS2_SYS_CONTEXT *)0, 10, (TSS2_TCTI_CONTEXT *)1, (TSS2_ABI_VERSION *)1 );
     CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE );
-    
+
     rval = Tss2_Sys_Initialize( (TSS2_SYS_CONTEXT *)1, 10, (TSS2_TCTI_CONTEXT *)0, (TSS2_ABI_VERSION *)1 );
     CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE );
-    
+
     rval = Tss2_Sys_Initialize( (TSS2_SYS_CONTEXT *)1, 10, (TSS2_TCTI_CONTEXT *)1, (TSS2_ABI_VERSION *)0 );
     CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE );
-    
+
     rval = Tss2_Sys_Initialize( (TSS2_SYS_CONTEXT *)1, 10, (TSS2_TCTI_CONTEXT *)1, (TSS2_ABI_VERSION *)1 );
     CheckFailed( rval, TSS2_SYS_RC_INSUFFICIENT_CONTEXT );
 
@@ -6044,7 +6044,7 @@ void GetContextSizeTests()
 {
     TSS2_RC rval = TSS2_RC_SUCCESS;
     TSS2_SYS_CONTEXT *testSysContext;
-    
+
     DebugPrintf( NO_PREFIX, "\nSYS GETCONTEXTSIZE TESTS:\n" );
 
     testSysContext = InitSysContext( 9, resMgrTctiContext, &abiVersion );
@@ -6069,7 +6069,7 @@ void GetTctiContextTests()
     TSS2_RC rval = TSS2_RC_SUCCESS;
     TSS2_SYS_CONTEXT *testSysContext;
     TSS2_TCTI_CONTEXT *tctiContext;
-            
+
     DebugPrintf( NO_PREFIX, "\nSYS GETTCTICONTEXT TESTS:\n" );
 
     testSysContext = InitSysContext( 9, resMgrTctiContext, &abiVersion );
@@ -6080,7 +6080,7 @@ void GetTctiContextTests()
 
     rval = Tss2_Sys_GetTctiContext( testSysContext, 0 );
     CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE );
-    
+
     rval = Tss2_Sys_GetTctiContext( 0, &tctiContext );
     CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE );
 
@@ -6091,7 +6091,7 @@ void PrepareTests()
 {
     TSS2_RC rval = TSS2_RC_SUCCESS;
     TSS2_SYS_CONTEXT *testSysContext;
-    
+
     DebugPrintf( NO_PREFIX, "\nSYS PREPARE TESTS:\n" );
 
     testSysContext = InitSysContext( 0, resMgrTctiContext, &abiVersion );
@@ -6133,7 +6133,7 @@ void PrepareTests()
     // Test for other NULL params
     rval = Tss2_Sys_Create_Prepare( testSysContext, 0xffffffff, 0, 0, 0, 0 );
     CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE );
-    
+
     TeardownSysContext( &testSysContext );
 }
 
@@ -6151,14 +6151,14 @@ void  RmZeroSizedResponseTest()
     // Added this test because this took me a while to understand, and I
     // never want to have to debug this again.
     //
-    
+
     DebugPrintf( NO_PREFIX, "\nRM ZERO SIZED RESPONSE TEST:\n" );
 
     rval = PlatformCommand( resMgrTctiContext, MS_SIM_POWER_OFF );
 
     nonceCaller.t.size = 1;
     nonceCaller.t.buffer[0] = 0xa5;
-    
+
     // AES encryption/decryption and CFB mode.
     symmetric.algorithm = TPM_ALG_AES;
     symmetric.keyBits.aes = 128;
@@ -6179,7 +6179,7 @@ void CmdRspAuthsTests()
     TPMT_SYM_DEF symmetric;
 	TSS2_RC rval = TSS2_RC_SUCCESS;
     int i;
-    TPM2B_ENCRYPTED_SECRET	encryptedSalt; 
+    TPM2B_ENCRYPTED_SECRET	encryptedSalt;
 	UINT32 savedMaxCommandSize, savedResponseSize;
 
     TSS2_SYS_CONTEXT *otherSysContext;
@@ -6193,7 +6193,7 @@ void CmdRspAuthsTests()
     TPMS_AUTH_RESPONSE *rspAuthArray[3] =
             { &encryptRspAuth, &decryptRspAuth, &auditRspAuth };
     TSS2_SYS_RSP_AUTHS rspAuths = { 3, &rspAuthArray[0] };
-    
+
     DebugPrintf( NO_PREFIX, "\nSETCMDAUTHS TESTS:\n" );
 
     nonceCaller.t.size = SHA256_DIGEST_SIZE;
@@ -6202,7 +6202,7 @@ void CmdRspAuthsTests()
     {
         nonceCaller.t.buffer[i] = 0xa5;
     }
-    
+
     // AES encryption/decryption and CFB mode.
     symmetric.algorithm = TPM_ALG_AES;
     symmetric.keyBits.aes = 128;
@@ -6282,19 +6282,19 @@ void CmdRspAuthsTests()
     rval = Tss2_Sys_SetCmdAuths( sysContext, &cmdAuths );
     CheckFailed( rval, TSS2_SYS_RC_BAD_VALUE ); // #11
     cmdAuthArray[2] = &auditCmdAuth;
-    
+
     // Test for insufficient context.
     cmdAuths.cmdAuthsCount= 0;
     savedMaxCommandSize = ( (_TSS2_SYS_CONTEXT_BLOB *)sysContext )->maxCommandSize;
     ( (_TSS2_SYS_CONTEXT_BLOB *)sysContext )->maxCommandSize = sizeof( TPM20_Header_In ) + 3 * sizeof( TPM_HANDLE ) - 1;
     rval = Tss2_Sys_SetCmdAuths( sysContext, &cmdAuths );
     CheckPassed( rval ); // #12
-    
+
     cmdAuths.cmdAuthsCount= 0;
     ( (_TSS2_SYS_CONTEXT_BLOB *)sysContext )->maxCommandSize = sizeof( TPM20_Header_In ) + 3 * sizeof( TPM_HANDLE );
     rval = Tss2_Sys_SetCmdAuths( sysContext, &cmdAuths );
     CheckPassed( rval );// #13
-    
+
     cmdAuths.cmdAuthsCount= 3;
     ( (_TSS2_SYS_CONTEXT_BLOB *)sysContext )->maxCommandSize = sizeof( TPM20_Header_In ) + 3 * sizeof( TPM_HANDLE );
     rval = Tss2_Sys_SetCmdAuths( sysContext, &cmdAuths );
@@ -6309,7 +6309,7 @@ void CmdRspAuthsTests()
     ( (_TSS2_SYS_CONTEXT_BLOB *)sysContext )->maxCommandSize = GetCommandSize( sysContext ) - 1;
     rval = Tss2_Sys_SetCmdAuths( sysContext, &cmdAuths );
     CheckFailed( rval, TSS2_SYS_RC_INSUFFICIENT_CONTEXT ); // #16
-    
+
     // Reset size of sysContext.
     ( (_TSS2_SYS_CONTEXT_BLOB *)sysContext )->maxCommandSize = savedMaxCommandSize;
 
@@ -6365,7 +6365,7 @@ void CmdRspAuthsTests()
     cmdAuths.cmdAuthsCount = 2;
     rval = Tss2_Sys_SetCmdAuths( sysContext, &cmdAuths );
     CheckPassed( rval ); // #9
-	
+
 	rval = Tss2_Sys_Execute( sysContext );
     CheckPassed( rval ); // #10
 
@@ -6400,7 +6400,7 @@ void CmdRspAuthsTests()
     ( (TPM20_Header_Out *)( ( (_TSS2_SYS_CONTEXT_BLOB *)sysContext )->tpmOutBuffPtr ) )->responseSize = CHANGE_ENDIAN_DWORD( savedResponseSize - 7 );
     rval = Tss2_Sys_GetRspAuths( sysContext, &rspAuths );
     CheckFailed( rval, TSS2_SYS_RC_MALFORMED_RESPONSE ); // #16
-        
+
     // Ths one should pass.
     ( (TPM20_Header_Out *)( ( (_TSS2_SYS_CONTEXT_BLOB *)sysContext )->tpmOutBuffPtr ) )->responseSize = CHANGE_ENDIAN_DWORD( savedResponseSize );
     rval = Tss2_Sys_GetRspAuths( sysContext, &rspAuths );
@@ -6444,18 +6444,18 @@ void GetSetEncryptParamTests()
 
     TPM2B_MAX_NV_BUFFER nvReadData;
     const uint8_t 		*cpBuffer;
-    
+
     DebugPrintf( NO_PREFIX, "\nGET/SET ENCRYPT PARAM TESTS:\n" );
 
     // Do Prepare.
     rval = Tss2_Sys_NV_Write_Prepare( sysContext, TPM20_INDEX_PASSWORD_TEST,
-            TPM20_INDEX_PASSWORD_TEST, &nvWriteData, 0 ); 
+            TPM20_INDEX_PASSWORD_TEST, &nvWriteData, 0 );
     CheckPassed( rval ); // #1
 
     // Test for bad sequence
     rval = Tss2_Sys_GetEncryptParam( sysContext, &encryptParamSize, &encryptParamBuffer );
     CheckFailed( rval, TSS2_SYS_RC_BAD_SEQUENCE ); // #2
-    
+
     rval = Tss2_Sys_SetEncryptParam( sysContext, 4, &( nvWriteData.t.buffer[0] ) );
     CheckFailed( rval, TSS2_SYS_RC_BAD_SEQUENCE ); // #3
 
@@ -6477,7 +6477,7 @@ void GetSetEncryptParamTests()
 
     // Write the index.
     rval = Tss2_Sys_NV_Write_Prepare( sysContext, TPM20_INDEX_PASSWORD_TEST,
-            TPM20_INDEX_PASSWORD_TEST, &nvWriteData, 0 ); 
+            TPM20_INDEX_PASSWORD_TEST, &nvWriteData, 0 );
     CheckPassed( rval ); // #5
 
     // NOTE: add GetCpBuffer tests here, just because its easier.
@@ -6509,27 +6509,27 @@ void GetSetEncryptParamTests()
     // because it's easier to do this way.
     rval = Tss2_Sys_GetCpBuffer( sysContext, (size_t *)4, &cpBuffer );
 	CheckFailed( rval, TSS2_SYS_RC_BAD_SEQUENCE ); // #13
-    
+
     // Now finish the write command so that TPM isn't stuck trying
     // to send a response.
-    rval = Tss2_Sys_ExecuteFinish( sysContext, -1 ); 
+    rval = Tss2_Sys_ExecuteFinish( sysContext, -1 );
     CheckPassed( rval ); // #14
 
     // Test GetEncryptParam for no encrypt param case.
     rval = Tss2_Sys_GetEncryptParam( sysContext, &encryptParamSize, &encryptParamBuffer );
     CheckFailed( rval, TSS2_SYS_RC_NO_ENCRYPT_PARAM ); // #15
-    
+
     // Test SetEncryptParam for no encrypt param case.
     rval = Tss2_Sys_SetEncryptParam( sysContext, encryptParamSize, encryptParamBuffer1 );
     CheckFailed( rval, TSS2_SYS_RC_NO_ENCRYPT_PARAM ); // #16
-    
+
     // Now read it and do tests on get/set encrypt functions
-    rval = Tss2_Sys_NV_Read_Prepare( sysContext, TPM20_INDEX_PASSWORD_TEST, TPM20_INDEX_PASSWORD_TEST, 4, 0 ); 
+    rval = Tss2_Sys_NV_Read_Prepare( sysContext, TPM20_INDEX_PASSWORD_TEST, TPM20_INDEX_PASSWORD_TEST, 4, 0 );
     CheckPassed( rval ); // #17
 
     INIT_SIMPLE_TPM2B_SIZE( nvReadData );
     rval = Tss2_Sys_NV_Read( sysContext, TPM20_INDEX_PASSWORD_TEST,
-            TPM20_INDEX_PASSWORD_TEST, &sessionsData, 4, 0, &nvReadData, &sessionsDataOut ); 
+            TPM20_INDEX_PASSWORD_TEST, &sessionsData, 4, 0, &nvReadData, &sessionsDataOut );
     CheckPassed( rval ); // #18
 
     rval = Tss2_Sys_GetEncryptParam( sysContext, &encryptParamSize, &encryptParamBuffer );
@@ -6561,7 +6561,7 @@ void GetSetEncryptParamTests()
             Cleanup();
         }
     }
-    
+
     rval = Tss2_Sys_NV_UndefineSpace( sysContext, TPM_RH_PLATFORM, TPM20_INDEX_PASSWORD_TEST, &sessionsData, 0 );
     CheckPassed( rval ); // #24
 
@@ -6569,13 +6569,13 @@ void GetSetEncryptParamTests()
     // Test for bad reference
     rval = Tss2_Sys_GetEncryptParam( 0, &encryptParamSize, &encryptParamBuffer );
     CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE ); // #25
-    
+
     rval = Tss2_Sys_GetEncryptParam( sysContext, 0, &encryptParamBuffer );
     CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE ); // #26
-    
+
     rval = Tss2_Sys_GetEncryptParam( sysContext, &encryptParamSize, 0 );
     CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE ); // #27
-    
+
     rval = Tss2_Sys_SetEncryptParam( sysContext, 4, 0 );
     CheckFailed( rval, TSS2_SYS_RC_BAD_REFERENCE ); // #28
 
@@ -6609,13 +6609,13 @@ void TestRM()
 
     TPMS_CONTEXT context;
     TSS2_TCTI_CONTEXT *tctiContext;
-    
-    TPMI_DH_CONTEXT loadedHandle, newHandle, newNewHandle, newHandleDummy;               
+
+    TPMI_DH_CONTEXT loadedHandle, newHandle, newNewHandle, newHandleDummy;
     TPMS_CONTEXT    newContext;
     char otherResMgrInterfaceName[] = "Test RM Resource Manager";
 
     DebugPrintf( NO_PREFIX, "\nRM TESTS:\n" );
-    
+
     sessionDataArray[0] = &sessionData;
     sessionDataOutArray[0] = &sessionDataOut;
 
@@ -6627,7 +6627,7 @@ void TestRM()
     inSensitive.t.sensitive.userAuth = loadedSha1KeyAuth;
     inSensitive.t.sensitive.data.t.size = 0;
     inSensitive.t.size = loadedSha1KeyAuth.b.size + 2;
-    
+
     inPublic.t.publicArea.type = TPM_ALG_RSA;
     inPublic.t.publicArea.nameAlg = TPM_ALG_SHA1;
 
@@ -6641,7 +6641,7 @@ void TestRM()
     inPublic.t.publicArea.objectAttributes.sensitiveDataOrigin = 1;
 
     inPublic.t.publicArea.authPolicy.t.size = 0;
-    
+
     inPublic.t.publicArea.parameters.rsaDetail.symmetric.algorithm = TPM_ALG_AES;
     inPublic.t.publicArea.parameters.rsaDetail.symmetric.keyBits.aes = 128;
     inPublic.t.publicArea.parameters.rsaDetail.symmetric.mode.aes = TPM_ALG_ECB;
@@ -6653,7 +6653,7 @@ void TestRM()
 
     outsideInfo.t.size = 0;
     creationPCR.count = 0;
-    
+
     sessionData.sessionHandle = TPM_RS_PW;
 
     // Init nonce.
@@ -6667,7 +6667,7 @@ void TestRM()
 
     sessionsData.cmdAuthsCount = 1;
     sessionsData.cmdAuths[0] = &sessionData;
-    
+
     rval = InitTctiResMgrContext( &rmInterfaceConfig, &otherResMgrTctiContext, &otherResMgrInterfaceName[0] );
     if( rval != TSS2_RC_SUCCESS )
     {
@@ -6679,7 +6679,7 @@ void TestRM()
     {
         (( TSS2_TCTI_CONTEXT_INTEL *)otherResMgrTctiContext )->status.debugMsgEnabled = debugLevel;
     }
-    
+
     otherSysContext = InitSysContext( 0, otherResMgrTctiContext, &abiVersion );
     if( otherSysContext == 0 )
     {
@@ -6687,7 +6687,7 @@ void TestRM()
     }
 
     // TEST WITH AN INVALID COMMAND CODE.
-    
+
     rval = Tss2_Sys_Startup_Prepare( sysContext, TPM_SU_CLEAR );
     CheckPassed(rval);
 
@@ -6702,7 +6702,7 @@ void TestRM()
     CheckFailed( rval, TPM_RC_COMMAND_CODE );
 
     // TEST OWNERSHIP
-    
+
     // Try to access a key created by the first TCTI context.
     sessionData.hmac.t.size = 2;
     sessionData.hmac.t.buffer[0] = 0x00;
@@ -6721,7 +6721,7 @@ void TestRM()
     inPublic.t.publicArea.objectAttributes.sensitiveDataOrigin = 1;
 
     inPublic.t.publicArea.authPolicy.t.size = 0;
-    
+
     inPublic.t.publicArea.parameters.rsaDetail.symmetric.algorithm = TPM_ALG_AES;
     inPublic.t.publicArea.parameters.rsaDetail.symmetric.keyBits.aes = 128;
     inPublic.t.publicArea.parameters.rsaDetail.symmetric.mode.aes = TPM_ALG_ECB;
@@ -6789,7 +6789,7 @@ void TestRM()
     // Try cancel with null tctiContext ptr.
     rval = (((TSS2_TCTI_CONTEXT_COMMON_V1 *)otherResMgrTctiContext)->cancel)( 0 );
     CheckFailed( rval, TSS2_TCTI_RC_BAD_REFERENCE );
-    
+
     // Try cancel when no commands are pending.
     rval = (((TSS2_TCTI_CONTEXT_COMMON_V1 *)otherResMgrTctiContext)->cancel)( otherResMgrTctiContext );
     CheckFailed( rval, TSS2_TCTI_RC_BAD_SEQUENCE );
@@ -6821,7 +6821,7 @@ void TestRM()
 
     rval = (((TSS2_TCTI_CONTEXT_COMMON_V1 *)tctiContext)->cancel)( tctiContext );
     CheckPassed( rval );
-    
+
     rval = Tss2_Sys_ExecuteFinish( sysContext, TSS2_TCTI_TIMEOUT_BLOCK );
     CheckFailed( rval, TPM_RC_CANCELED );
 
@@ -6835,7 +6835,7 @@ void TestRM()
 
     rval = Tss2_Sys_ExecuteAsync( sysContext );
     CheckPassed( rval );
-    
+
     rval = Tss2_Sys_ExecuteFinish( sysContext, 0 );
     CheckFailed( rval, TSS2_TCTI_RC_TRY_AGAIN );
 
@@ -6858,7 +6858,7 @@ void TestRM()
 
     rval = (((TSS2_TCTI_CONTEXT_COMMON_V1 *)otherResMgrTctiContext)->cancel)( otherResMgrTctiContext );
     CheckFailed( rval, TSS2_TCTI_RC_BAD_SEQUENCE );
-    
+
     rval = Tss2_Sys_ExecuteFinish( sysContext, TSS2_TCTI_TIMEOUT_BLOCK );
     CheckPassed( rval );
 
@@ -6889,7 +6889,7 @@ void TestRM()
     INIT_SIMPLE_TPM2B_SIZE( name );
     INIT_SIMPLE_TPM2B_SIZE( creationHash );
     rval = Tss2_Sys_CreatePrimary( sysContext, TPM_RH_ENDORSEMENT, &sessionsData, &inSensitive, &inPublic,
-            &outsideInfo, &creationPCR, &newHandleDummy, &outPublic, &creationData, &creationHash, 
+            &outsideInfo, &creationPCR, &newHandleDummy, &outPublic, &creationData, &creationHash,
 			&creationTicket, &name, &sessionsDataOut );
     CheckPassed( rval );
 
@@ -6912,7 +6912,7 @@ void TestRM()
     // Now flush dummy object.
     rval = Tss2_Sys_FlushContext( sysContext, newHandleDummy );
     CheckPassed( rval );
-   
+
     rval = TeardownTctiResMgrContext( otherResMgrTctiContext );
     CheckPassed( rval );
 
@@ -6936,7 +6936,7 @@ void EcEphemeralTest()
     rval = Tss2_Sys_EC_Ephemeral( sysContext, 0, TPM_ECC_BN_P256, &Q, &counter, 0 );
     CheckPassed( rval );
 }
-    
+
 
 void AbiVersionTests()
 {
@@ -6959,17 +6959,17 @@ void AbiVersionTests()
         tstAbiVersion.tssCreator = 0xF0000000;
         rval = Tss2_Sys_Initialize( sysContext, contextSize, resMgrTctiContext, &tstAbiVersion );
         CheckFailed( rval, TSS2_SYS_RC_ABI_MISMATCH );
-        
+
         tstAbiVersion.tssCreator = TSSWG_INTEROP;
         tstAbiVersion.tssFamily = 0xF0000000;
         rval = Tss2_Sys_Initialize( sysContext, contextSize, resMgrTctiContext, &tstAbiVersion );
-        CheckFailed( rval, TSS2_SYS_RC_ABI_MISMATCH );        
+        CheckFailed( rval, TSS2_SYS_RC_ABI_MISMATCH );
 
         tstAbiVersion.tssFamily = TSS_SAPI_FIRST_FAMILY;
         tstAbiVersion.tssLevel = 0xF0000000;
         rval = Tss2_Sys_Initialize( sysContext, contextSize, resMgrTctiContext, &tstAbiVersion );
-        CheckFailed( rval, TSS2_SYS_RC_ABI_MISMATCH );        
-        
+        CheckFailed( rval, TSS2_SYS_RC_ABI_MISMATCH );
+
         tstAbiVersion.tssLevel = TSS_SAPI_FIRST_LEVEL;
         tstAbiVersion.tssVersion = 0xF0000000;
         rval = Tss2_Sys_Initialize( sysContext, contextSize, resMgrTctiContext, &tstAbiVersion );
@@ -7030,14 +7030,14 @@ void TestCreate1()
     sessionsData.cmdAuths = &sessionDataArray[0];
 
     sessionsDataOut.rspAuthsCount = 1;
-        
+
     printf( "\nCREATE PRIMARY, encrypt and decrypt TESTS:\n" );
 
     inSensitive.t.sensitive.userAuth = loadedSha1KeyAuth;
     inSensitive.t.sensitive.userAuth = loadedSha1KeyAuth;
     inSensitive.t.sensitive.data.t.size = 0;
     inSensitive.t.size = loadedSha1KeyAuth.b.size + 2;
-    
+
     inPublic.t.publicArea.type = TPM_ALG_RSA;
     inPublic.t.publicArea.nameAlg = TPM_ALG_SHA1;
 
@@ -7051,7 +7051,7 @@ void TestCreate1()
     inPublic.t.publicArea.objectAttributes.sensitiveDataOrigin = 1;
 
     inPublic.t.publicArea.authPolicy.t.size = 0;
-    
+
     inPublic.t.publicArea.parameters.rsaDetail.symmetric.algorithm = TPM_ALG_AES;
     inPublic.t.publicArea.parameters.rsaDetail.symmetric.keyBits.aes = 128;
     inPublic.t.publicArea.parameters.rsaDetail.symmetric.mode.aes = TPM_ALG_ECB;
@@ -7063,7 +7063,7 @@ void TestCreate1()
 
     outsideInfo.t.size = 0;
     creationPCR.count = 0;
-    
+
     sessionData.sessionHandle = TPM_RS_PW;
 
     // Init nonce.
@@ -7103,7 +7103,7 @@ void TestCreate1()
             handle2048rsa );
     printf( "Name of created primary key: " );
     PrintSizedBuffer( (TPM2B *)&name );
-  
+
     char buffer1contents[] = "test";
     //char buffer2contents[] = "string";
 
@@ -7111,13 +7111,13 @@ void TestCreate1()
     TPMT_RSA_DECRYPT inScheme;
     TPM2B_PUBLIC_KEY_RSA message;
     TPM2B_PUBLIC_KEY_RSA outData;
-    
+
     message.t.size = strlen(buffer1contents);
     memcpy(message.t.buffer, buffer1contents, message.t.size);
 
     inScheme.scheme = TPM_ALG_NULL;
-    
-    //printf("keyHandle: %x\n", keyHandle); 
+
+    //printf("keyHandle: %x\n", keyHandle);
     INIT_SIMPLE_TPM2B_SIZE( outData );
     rval = Tss2_Sys_RSA_Encrypt(sysContext, keyHandle, &sessionsData, &message, &inScheme, &outsideInfo, &outData, &sessionsDataOut);
     if( tpmSpecVersion >= 124 )
@@ -7128,7 +7128,7 @@ void TestCreate1()
     INIT_SIMPLE_TPM2B_SIZE( outData );
     rval = Tss2_Sys_RSA_Encrypt(sysContext, keyHandle, 0, &message, &inScheme, &outsideInfo, &outData, &sessionsDataOut);
     CheckPassed( rval );
-    
+
     for (int i=0; i<message.t.size; i++)
     	printf("\nlabel size:%d, label buffer:%x, outData size:%d, outData buffer:%x, msg size:%d, msg buffer:%x", outsideInfo.t.size, outsideInfo.t.buffer[i], outData.t.size, outData.t.buffer[i], message.t.size, message.t.buffer[i]);
     CheckPassed(rval);
@@ -7147,12 +7147,12 @@ void TestLocalTCTI()
     };
     TSS2_RC rval = TSS2_RC_SUCCESS;
     const char *deviceTctiName = "Local Device TCTI";
-    
+
     TSS2_TCTI_CONTEXT *downstreamTctiContext;
 
     DebugPrintf( NO_PREFIX,  "\nLOCAL TCTI TESTS:\n" );
     DebugPrintf( NO_PREFIX,  "WARNING!!  This test requires that a local TPM is present and that the resource manager has NOT been started.\n\n" );
-       
+
     // Test TCTI interface against local TPM TCTI interface, if available.
     //
     // Init downstream interface to tpm (in this case the local TPM).
@@ -7169,14 +7169,14 @@ void TestLocalTCTI()
         {
             ((TSS2_TCTI_CONTEXT_INTEL *)downstreamTctiContext )->status.debugMsgEnabled = debugLevel;
         }
-        
+
         TestTctiApis( downstreamTctiContext, 0 );
 
         TeardownDeviceTcti( downstreamTctiContext );
 
         exit( 0 );
     }
-    
+
 }
 #endif
 
@@ -7190,7 +7190,7 @@ void TpmTest()
     nullSessionsDataOut.rspAuths[0]->hmac = nullSessionHmac;
     nullSessionNonceOut.t.size = 0;
     nullSessionNonce.t.size = 0;
-            
+
     loadedSha1KeyAuth.t.size = 2;
     loadedSha1KeyAuth.t.buffer[0] = 0x00;
     loadedSha1KeyAuth.t.buffer[1] = 0xff;
@@ -7199,7 +7199,7 @@ void TpmTest()
     CheckPassed( rval );
 
     InitEntities();
-    
+
     InitNullSession( &nullSessionData);
 
     AbiVersionTests();
@@ -7211,14 +7211,14 @@ void TpmTest()
     GetContextSizeTests();
 
     GetTctiContextTests();
-    
+
     GetSetDecryptParamTests();
 
 #ifdef _WIN32
     // This test can only be run agains the simulator
-    RmZeroSizedResponseTest();    
+    RmZeroSizedResponseTest();
 #endif
-    
+
     rval = PlatformCommand( resMgrTctiContext, MS_SIM_POWER_ON );
     CheckPassed( rval );
 
@@ -7237,7 +7237,7 @@ void TpmTest()
     TestTctiApis( resMgrTctiContext, 1 );
 
     CmdRspAuthsTests();
-	    
+
     PrepareTests();
 
     // Clear DA lockout.
@@ -7246,7 +7246,7 @@ void TpmTest()
     TestTpmSelftest();
 
     TestDictionaryAttackLockReset();
-    
+
     TestCreate();
 
     TestCreate1();
@@ -7256,7 +7256,7 @@ void TpmTest()
     TestHierarchyControl();
 
     NvIndexProto();
-        
+
     GetSetEncryptParamTests();
 
     TestEncryptDecryptSession();
@@ -7264,11 +7264,11 @@ void TpmTest()
     SimpleHmacOrPolicyTest( true );
 
     SimpleHmacOrPolicyTest( false );
-   
+
     for( i = 1; i <= (UINT32)passCount; i++ )
     {
         DebugPrintf( NO_PREFIX, "\n****** PASS #: %d ******\n\n", i );
-        
+
         TestTpmGetCapability();
 
         TestPcrExtend();
@@ -7295,7 +7295,7 @@ void TpmTest()
         TestCreate();
 
         TestEvict();
-        
+
         NvIndexProto();
 
         PasswordTest();
@@ -7311,7 +7311,7 @@ void TpmTest()
         TestUnseal();
 
         TestRM();
-        
+
         EcEphemeralTest();
 #if 0
         TestRsaEncryptDecrypt();
@@ -7323,7 +7323,7 @@ void TpmTest()
     CheckPassed( rval );
     rval = Tss2_Sys_FlushContext( sysContext, loadedSha1KeyHandle );
     CheckPassed( rval );
-       
+
     PlatformCommand( resMgrTctiContext, MS_SIM_POWER_OFF );
 }
 
@@ -7335,7 +7335,7 @@ void PrintHelp()
     printf( "TPM client test app, Version %s\nUsage:  tpmclient [-rmhost hostname|ip_addr] [-rmport port] [-passes passNum] [-demoDelay delay] [-dbg dbgLevel] [-startAuthSessionTest] "
 #if __linux || __unix
             "[-localTctiTest]"
-#endif            
+#endif
             "\n\n"
             "where:\n"
             "\n"
@@ -7349,10 +7349,10 @@ void PrintHelp()
             "-startAuthSessionTest enables some special tests of the resource manager for starting sessions\n"
 #if __linux || __unix
             "-localTctiTest enables a TCTI interface test against a local TPM.  WARNING:  This test requires no resource manager and a local TPM\n"
-#endif            
+#endif
 #ifdef SHARED_OUT_FILE
             "-out selects the output file (default is stdout)\n"
-#endif            
+#endif
             , version, DEFAULT_HOSTNAME, DEFAULT_RESMGR_TPM_PORT );
 }
 
@@ -7360,13 +7360,13 @@ int main(int argc, char* argv[])
 {
     int count;
     TSS2_RC rval;
-    
+
     setvbuf (stdout, NULL, _IONBF, BUFSIZ);
 #ifdef SHARED_OUT_FILE
     if( argc > 12 )
-#else        
+#else
     if( argc > 10 )
-#endif        
+#endif
     {
         PrintHelp();
         return 1;
@@ -7412,7 +7412,7 @@ int main(int argc, char* argv[])
                     PrintHelp();
                     return 1;
                 }
-            }            
+            }
             else if( 0 == strcmp( argv[count], "-dbg" ) )
             {
                 count++;
@@ -7441,17 +7441,17 @@ int main(int argc, char* argv[])
         TestLocalTCTI();
     }
 #endif
-    
+
     rval = InitTctiResMgrContext( &rmInterfaceConfig, &resMgrTctiContext, &resMgrInterfaceName[0] );
     if( rval != TSS2_RC_SUCCESS )
     {
         DebugPrintf( NO_PREFIX, "Resource Mgr, %s, failed initialization: 0x%x.  Exiting...\n", resMgrInterfaceName, rval );
-#ifdef _WIN32        
+#ifdef _WIN32
         WSACleanup();
 #endif
         if( resMgrTctiContext != 0 )
             free( resMgrTctiContext );
-        
+
         return( 1 );
     }
     else
@@ -7459,7 +7459,7 @@ int main(int argc, char* argv[])
         (( TSS2_TCTI_CONTEXT_INTEL *)resMgrTctiContext )->status.debugMsgEnabled = debugLevel;
         resMgrInitialized = 1;
     }
-    
+
     sysContext = InitSysContext( 0, resMgrTctiContext, &abiVersion );
     if( sysContext == 0 )
     {
@@ -7471,7 +7471,7 @@ int main(int argc, char* argv[])
 
         rval = TeardownTctiResMgrContext( resMgrTctiContext );
         CheckPassed( rval );
-        
+
         TeardownSysContext( &sysContext );
     }
 

--- a/test/tpmtest/tpmtest.cpp
+++ b/test/tpmtest/tpmtest.cpp
@@ -851,8 +851,8 @@ void TestStartAuthSession()
     SESSION *authSession;
     TPM2B_NONCE nonceCaller;
     UINT16 i;
-#ifdef DEBUG_GAP_HANDLING    
-    UINT16 debugGapMax = DEBUG_GAP_MAX, debugMaxActiveSessions = DEBUG_MAX_ACTIVE_SESSIONS;    
+#ifdef DEBUG_GAP_HANDLING
+    UINT16 debugGapMax = DEBUG_GAP_MAX, debugMaxActiveSessions = DEBUG_MAX_ACTIVE_SESSIONS;
     TPMS_CONTEXT    evictedSessionContext;
     TPM_HANDLE   evictedHandle;
 #endif
@@ -6609,7 +6609,7 @@ void symmetricEncryptDecryptTest()
     TPMS_AUTH_COMMAND sessionData;
     TPMS_AUTH_RESPONSE sessionDataOut;
     TSS2_SYS_CMD_AUTHS sessionsData;
-    
+
     TSS2_SYS_RSP_AUTHS sessionsDataOut;
     TPM2B_NAME name= { { sizeof( TPM2B_NAME ) - 2, } };
     TPM2B_PRIVATE outPrivate = { { sizeof(TPM2B_PRIVATE)-2, } };
@@ -6734,13 +6734,13 @@ void symmetricEncryptDecryptTest()
     inPublic.t.publicArea.parameters.symDetail.sym.algorithm = TPM_ALG_AES;
     inPublic.t.publicArea.parameters.symDetail.sym.keyBits.sym = 128;
     inPublic.t.publicArea.parameters.symDetail.sym.mode.sym = TPM_ALG_CFB;
- 
+
     inPublic.t.publicArea.unique.sym.t.size = 0;
 
     outsideInfo.t.size = 0;
     outPublic.t.size = 0;
     creationData.t.size = 0;
-    creationPCR.count = 0; 
+    creationPCR.count = 0;
     rval = Tss2_Sys_Create( sysContext, symHandle, &sessionsData, &inSensitive, &inPublic,
             &outsideInfo, &creationPCR,
             &outPrivate, &outPublic, &creationData,
@@ -6754,7 +6754,7 @@ void symmetricEncryptDecryptTest()
     printf( "\nLoaded key handle:  %8.8x\n", loadedSymKeyHandle );
 
     const char msg[] = "message";
-    
+
     TPMI_YES_NO decryptVal = NO;
     TPM2B_MAX_BUFFER inData = { { sizeof(TPM2B_MAX_BUFFER)-2, } };
     // Inputs
@@ -6772,12 +6772,12 @@ void symmetricEncryptDecryptTest()
     memcpy(inData.t.buffer, msg, inData.t.size);
 
     printf("\nENCRYPTDECRYPT TESTS: ENCRYPT\n");
-    
+
     sessionData.sessionHandle = TPM_RS_PW;
     // Init nonce.
     sessionData.nonce.t.size = 0;
     sessionData.hmac.t.size = 0;
-	
+
     rval = Tss2_Sys_EncryptDecrypt(sysContext, loadedSymKeyHandle, &sessionsData, decryptVal, mode, &ivIn, &inData, &outData, &ivOut, &sessionsDataOut);
     if(rval == TPM_RC_SUCCESS)
 	{
@@ -6954,7 +6954,7 @@ void asymmetricEncryptDecryptTest()
 
     printf( "Name of loading key: " );
     PrintSizedBuffer( (TPM2B *)&name );
-    
+
     printf( "\nLoaded key handle:  %8.8x\n", loadedSha1KeyHandle );
 
     char buffer1contents[] = "test";
@@ -6963,7 +6963,7 @@ void asymmetricEncryptDecryptTest()
     TPM2B_PUBLIC_KEY_RSA messageOut = { { sizeof(TPM2B_PUBLIC_KEY_RSA)-2, } };
     TPM2B_PUBLIC_KEY_RSA outData = { { sizeof(TPM2B_PUBLIC_KEY_RSA)-2, } };
     TPM2B_MAX_BUFFER inData1, inData2;
-    TPM2B_DIGEST outHash1 = { { sizeof( TPM2B_DIGEST ) - 2,} }; 
+    TPM2B_DIGEST outHash1 = { { sizeof( TPM2B_DIGEST ) - 2,} };
     TPM2B_DIGEST outHash2 = { { sizeof( TPM2B_DIGEST ) - 2,} };
     TPMT_TK_HASHCHECK validation;
     TPMI_ALG_HASH  halg = TPM_ALG_SHA256;
@@ -7040,7 +7040,7 @@ void verifySignatureExternalTest()
     TPMT_TK_VERIFIED validation;
     TPMT_TK_HASHCHECK hashCheck;
     TPMT_SIG_SCHEME inScheme;
-    
+
     inSensitive.t.sensitive.userAuth = loadedSha1KeyAuth;
     inSensitive.t.sensitive.data.t.size = 0;
     inSensitive.t.size = loadedSha1KeyAuth.b.size + 2;
@@ -7149,7 +7149,7 @@ void verifySignatureExternalTest()
     buffer = (BYTE*)malloc(length*sizeof(BYTE));
     memset(buffer, 0, length*sizeof(BYTE));
     memcpy (buffer, SignMsg, length);
-    
+
     if(length%(MAX_DIGEST_BUFFER) != 0)
         numBuffers = length/(MAX_DIGEST_BUFFER) + 1;
     else
@@ -7244,7 +7244,7 @@ void verifySignatureCreatedTest()
     TPMT_TK_VERIFIED validation;
     TPMT_TK_HASHCHECK hashCheck;
     TPMT_SIG_SCHEME inScheme;
-    
+
     inSensitive.t.sensitive.userAuth = loadedSha1KeyAuth;
     inSensitive.t.sensitive.data.t.size = 0;
     inSensitive.t.size = loadedSha1KeyAuth.b.size + 2;
@@ -7529,7 +7529,7 @@ void nvExtensionTest()
 
     rval = Tss2_Sys_NV_DefineSpace( sysContext, TPM_RH_OWNER, &sessionsData, &nvAuth, &publicInfo, &sessionsDataOut );
     CheckPassed( rval );
-  
+
     printf("TPM 2.0 Test 1 Index:%x", publicInfo.t.nvPublic.nvIndex);
 
     nvPublic.t.size = 0;
@@ -7551,12 +7551,12 @@ void nvExtensionTest()
     for( i = 0; i < nvWriteData.t.size; i++ )
         nvWriteData.t.buffer[i] = nvName1.t.name[i];
 
-    rval = Tss2_Sys_NV_Write( sysContext, TPM_RH_OWNER, TPM20_INDEX_PASSWORD_TEST, &sessionsData, &nvWriteData, 0, &sessionsDataOut ); 
+    rval = Tss2_Sys_NV_Write( sysContext, TPM_RH_OWNER, TPM20_INDEX_PASSWORD_TEST, &sessionsData, &nvWriteData, 0, &sessionsDataOut );
     if (rval == TPM_RC_SUCCESS)
         CheckPassed( rval );
     else
         CheckFailed(rval, TPM_RC_NV_AUTHORIZATION);
-    
+
     INIT_SIMPLE_TPM2B_SIZE( nvData);
     rval = Tss2_Sys_NV_Read( sysContext, TPM_RH_OWNER, TPM20_INDEX_PASSWORD_TEST, &sessionsData, 20, 0, &nvData, &sessionsDataOut );
     CheckPassed( rval );
@@ -7593,7 +7593,7 @@ void pcrExtendedTest()
     TPML_DIGEST pcrValues;
     TPML_DIGEST_VALUES digests;
     TPML_PCR_SELECTION pcrSelectionOut;
-    
+
     TPMS_AUTH_COMMAND *sessionDataArray[1];
 
     sessionDataArray[0] = &sessionData;
@@ -7856,7 +7856,7 @@ void TpmTest()
         nvExtensionTest();
         pcrExtendedTest();
         TestClockTime();
-	
+
     // clear out rm entries for objects.
     rval = Tss2_Sys_FlushContext( sysContext, handle2048rsa );
     CheckPassed( rval );
@@ -8489,7 +8489,7 @@ void PrintVerifySignatureExternalTest()
            "  Name of loading key: 00 04 60 df d7 7a f7 fd 2c c8 2d 61 04 52 4c cc 6a 2d dc 18 ca 98\n"
            "  tpm performing hash :   PASSED!\n"
            "  digest(hex type):fe be a2 ef 8c ba 2e d7 6a 6e d4 40 31 fb a5 b1 26 a2 35 63\n"
-           "  sign the message:   PASSED!\n"	
+           "  sign the message:   PASSED!\n"
            "  verify signature using loaded key:   PASSED!\n");
 }
 void PrintVerifySignatureCreatedTest()
@@ -8516,7 +8516,7 @@ void PrintNvExtensionTest()
            "   Name of loaded key: 00 04 aa 6f 4a 8b 97 3a f7 3f d7 b4 e4 a4 fa 56 6c 96 79 b9 5d c8\n"
            "   Loaded key handle:  80000009\n"
 	   "   Define NV space:   PASSED!\n"
-	   "   TPM 2.0 Test 1 Index:1500020\n"    
+	   "   TPM 2.0 Test 1 Index:1500020\n"
 	   "   Failed to read NV because uninitialized:   PASSED!\n"
            "   Failed to define space because it is already defined:   PASSED!\n"
            "   Write into NV:   PASSED!\n"
@@ -8534,7 +8534,7 @@ void PrintPcrExtendedTest()
            "  Name of PCR Values Before Extend: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00\n"
            "  Extend PCR values:   PASSED!\n"
            "  Read PCR Values:   PASSED!\n"
-           "  Name of PCR Values After Extended: f8 7c fc 25 e0 47 ab 7f a1 c1 d2 cc a2 c7 ff aa 70 6c d2 3a\n" 
+           "  Name of PCR Values After Extended: f8 7c fc 25 e0 47 ab 7f a1 c1 d2 cc a2 c7 ff aa 70 6c d2 3a\n"
            "  Failed to read the PCR value because no PCR selection:   PASSED!\n"
            "  PCR Event:   PASSED!\n"
            "  Name of PCR Event Digests: 2d dd 5b 98 e2 09 56 cd d5 88 1f a8 0f df 7c 2a a7 da 72 78\n");
@@ -8895,7 +8895,7 @@ MENUS_SETUP firstLevelMenus[] =
     { "37", "NV EXTENSION TEST", 0, nvExtensionTestMenus, },
     { "38", "PCR EXTENDED TEST", 0, pcrExtendedTestMenus, },
     { "39", "CLOCK/TIME TEST", 0, clockTimeTestMenus, },
-	
+
     { NULL, NULL, 0, },
 };
 


### PR DESCRIPTION
This was automated with the following:
find ./ -type f \( -iname '*.cpp' -o -iname '*.c' -o -iname '*.h' \) | while read FILE; do sed -i 's/[[:space:]]\+$//' $FILE; done

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>