### PR TITLE
configure.ac: Allow for the unit tests to be enabled selectively.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 Unreleased
 Added
+* Allow for unit tests to be enabled selectively.
 * added pkg-config files for libraries
 Changed
 * rename libtss2 to libsapi

--- a/Makefile.am
+++ b/Makefile.am
@@ -36,12 +36,16 @@ AM_CXXFLAGS     = $(AM_CFLAGS)
 sbin_PROGRAMS   = $(resourcemgr)
 noinst_PROGRAMS = $(tpmclient) $(tpmtest)
 lib_LTLIBRARIES = $(libsapi) $(libtcti_device) $(libtcti_socket)
+
 # unit tests
+if UNIT
 check_PROGRAMS  = \
     test/tcti_device \
     test/getcommands-malloc-mock_unit \
     test/CommonPreparePrologue_unit \
     test/GetNumHandles_unit
+endif #UNIT
+
 TESTS = $(check_PROGRAMS)
 CLEANFILES = $(nodist_pkgconfig_DATA)
 
@@ -54,6 +58,7 @@ libtcti_HEADERS = $(srcdir)/include/tcti/*.h
 pkgconfigdir          = $(libdir)/pkgconfig
 nodist_pkgconfig_DATA = lib/sapi.pc lib/tcti-device.pc lib/tcti-socket.pc
 
+if UNIT
 test_tcti_device_CFLAGS  = $(CMOCKA_CFLAGS) -I$(srcdir) -I$(srcdir)/sysapi/include
 test_tcti_device_LDADD   = $(libsapi) $(libtcti_device) $(CMOCKA_LIBS)
 test_tcti_device_SOURCES = test/tcti_device.c test/tcti_device_test.c
@@ -79,6 +84,7 @@ test_GetNumHandles_unit_CFLAGS  = $(CMOCKA_CFLAGS) \
 test_GetNumHandles_unit_LDADD   = $(CMOCKA_LIBS)
 test_GetNumHandles_unit_SOURCES = \
     test/GetNumHandles_unit.c sysapi/sysapi_util/GetNumHandles.c
+endif # UNIT
 
 # how to build stuff
 resourcemgr_resourcemgr_CFLAGS   = $(RESOURCEMGR_INC) $(PTHREAD_CFLAGS) $(AM_CFLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -11,5 +11,15 @@ AX_PTHREAD([], [AC_MSG_ERROR([requires pthread])])
 AM_INIT_AUTOMAKE([foreign
                   subdir-objects])
 AC_CONFIG_FILES([Makefile])
-PKG_CHECK_MODULES([CMOCKA],[cmocka])
+AC_ARG_ENABLE([unit],
+            [AS_HELP_STRING([--enable-unit],
+                            [build cmocka unit tests (default is no)])],
+            [enable_unit=$enableval],
+            [enable_unit=no])
+AS_IF([test "x$enable_unit" != xno],
+      [PKG_CHECK_MODULES([CMOCKA],
+                         [cmocka],
+                         [AC_DEFINE([HAVE_CMOCKA],
+                                    [1])])])
+AM_CONDITIONAL([UNIT], [test "x$enable_unit" != xno])
 AC_OUTPUT


### PR DESCRIPTION
This makes the dependency on libcmocka optional.

Signed-off-by: Philip Tricca <flihp@twobit.us>