### PR TITLE
A set of fix for resourcemgr

### DIFF
--- a/resourcemgr/resourcemgr.c
+++ b/resourcemgr/resourcemgr.c
@@ -948,6 +948,7 @@ TSS2_RC EvictContext(TPM_HANDLE virtualHandle)
         if( !IsSessionHandle( virtualHandle ) )
         {
             foundEntryPtr->realHandle = 0;
+            foundEntryPtr->hierarchy = foundEntryPtr->context.hierarchy;
         }
     }
 


### PR DESCRIPTION
Fixed below issues:

1. if create/load with a persistent parent which was created before the current RM process was running, failed with 0xC1000. And if evictcontrol on a persistent object which was created before the current RM process was running, failed with 0xa000a.

2. the entries related to a specific connection was not deleted when the connection end.

3. entry.hierarchy might be TPM_RH_NULL sometime.