### PR TITLE
Add example systemd service file for resourcemgr and udev rules for t…

### DIFF
--- a/contrib/resourcemgr.service
+++ b/contrib/resourcemgr.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=TPM2 resource manager & access broker
+Documentation=http://www.github.com/01org/TPM2.0-TSS
+
+[Service]
+ExecStart=/usr/local/sbin/resourcemgr
+StandardOutput=null
+User=tss
+Group=tss
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/tpm-udev.rules
+++ b/contrib/tpm-udev.rules
@@ -1,0 +1,1 @@
+KERNEL=="tpm[0-9]*", MODE="0600", OWNER="tss", GROUP="tss"


### PR DESCRIPTION
…pm device node.

These work as-is on Debian provided there's a system user named 'tss'
already and the PREFIX is '/usr/local'. Integrating these files into
the build shouldn't be too hard but the only systemd module for autoconf
that I can find is out of tree and not in the archive either.

This resolves #244 and #243.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>