### PR TITLE
tcti_socket: Move simulator initialization code into the context init…

### DIFF
--- a/resourcemgr/resourcemgr.c
+++ b/resourcemgr/resourcemgr.c
@@ -2773,23 +2773,6 @@ TSS2_RC InitResourceMgr( int debugLevel)
         freedSessionHandles[i] = freedObjectHandles[i] = UNAVAILABLE_FREED_HANDLE;
     }
 
-    if ( simulator )
-    {
-        rval = PlatformCommand( downstreamTctiContext, MS_SIM_POWER_ON );
-        if( rval != TPM_RC_SUCCESS )
-        {
-            SetRmErrorLevel( &rval, TSS2_RESMGR_ERROR_LEVEL );
-            goto returnFromInitResourceMgr;
-        }
-
-        rval = PlatformCommand( downstreamTctiContext, MS_SIM_NV_ON );
-        if( rval != TPM_RC_SUCCESS )
-        {
-            SetRmErrorLevel( &rval, TSS2_RESMGR_ERROR_LEVEL );
-            goto returnFromInitResourceMgr;
-        }
-    }
-
     // This one should pass.
     rval = Tss2_Sys_Startup( resMgrSysContext, TPM_SU_CLEAR );
     if( rval != TPM_RC_SUCCESS && rval != TPM_RC_INITIALIZE )

--- a/tcti/tcti_socket.cpp
+++ b/tcti/tcti_socket.cpp
@@ -473,6 +473,26 @@ retSocketReceiveTpmResponse:
 #define HOSTNAME_LENGTH 200
 #define PORT_LENGTH 4
 
+static TSS2_RC InitializeMsTpm2Simulator(
+    TSS2_TCTI_CONTEXT *tctiContext
+    )
+{
+    TSS2_TCTI_CONTEXT_INTEL *intel_tctiCtx;
+    TSS2_RC rval;
+
+    intel_tctiCtx = (TSS2_TCTI_CONTEXT_INTEL*)tctiContext;
+    rval = PlatformCommand( tctiContext ,MS_SIM_POWER_ON );
+    if( rval != TSS2_RC_SUCCESS ) {
+        CloseSockets( intel_tctiCtx->otherSock, intel_tctiCtx->tpmSock );
+        return rval;
+    }
+    rval = PlatformCommand( tctiContext, MS_SIM_NV_ON );
+    if( rval != TSS2_RC_SUCCESS )
+        CloseSockets( intel_tctiCtx->otherSock, intel_tctiCtx->tpmSock );
+
+    return rval;
+}
+
 TSS2_RC InitSocketTcti (
     TSS2_TCTI_CONTEXT *tctiContext, // OUT
     size_t *contextSize,            // IN/OUT
@@ -518,6 +538,7 @@ TSS2_RC InitSocketTcti (
         {
             ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->otherSock = otherSock;
             ((TSS2_TCTI_CONTEXT_INTEL *)tctiContext)->tpmSock = tpmSock;
+            rval = InitializeMsTpm2Simulator( tctiContext );
         }
         else
         {

--- a/test/tpmclient/tpmclient.cpp
+++ b/test/tpmclient/tpmclient.cpp
@@ -7210,11 +7210,6 @@ void TpmTest()
     RmZeroSizedResponseTest();
 #endif
 
-    rval = PlatformCommand( resMgrTctiContext, MS_SIM_POWER_ON );
-    CheckPassed( rval );
-
-    rval = PlatformCommand( resMgrTctiContext, MS_SIM_NV_ON );
-    CheckPassed( rval );
     TestTpmStartup();
 
     // Run this directly after Startup tests to test for

--- a/test/tpmtest/tpmtest.cpp
+++ b/test/tpmtest/tpmtest.cpp
@@ -9059,8 +9059,6 @@ void InitTpmTest()
 
     GetSetDecryptParamTests();
 
-    PlatformCommand( resMgrTctiContext, MS_SIM_POWER_ON );
-    PlatformCommand(  resMgrTctiContext, MS_SIM_NV_ON );
     Tss2_Sys_Startup ( sysContext, TPM_SU_CLEAR );
     CheckTpmType();
     CheckHierarchy();


### PR DESCRIPTION
… function.

This is something that every application has to do to be sure that the
simulator has been initialized. Running these commands multiple time has
no negative effect (AFAIK). Might as well just run this each time we
initialize a connection to the simulator. Save everyone else the
headache.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>