### PR TITLE
Fix #286

### DIFF
--- a/common/sockets.cpp
+++ b/common/sockets.cpp
@@ -22,7 +22,7 @@ TSS2_RC recvBytes( SOCKET tpmSock, unsigned char *data, int len )
     for( bytesRead = 0, length = len; bytesRead != len; length -= iResult, bytesRead += iResult )
     {
         iResult = recv( tpmSock, (char *)&( data[bytesRead] ), length, 0);
-        if (iResult == SOCKET_ERROR)
+        if ((iResult == SOCKET_ERROR) || (!iResult))
             return TSS2_TCTI_RC_IO_ERROR;
     }
 


### PR DESCRIPTION
resource manager eats up more that 100% CPU if client disconnects without freeing resources

As it turns out, the resource manager doesn't close the socket when it receives 0 from recv.
From man recv:

  Return Value

  These calls return the number of bytes received, or -1 if an error occurred.
  The return value will be 0 when the peer has performed an orderly shutdown.

Instead of detecting that the client has closed the connection, resoucemgr keeps calling recv in an infinite for loop (see common/sockets.cpp)