### PR TITLE
Fix resourcemgr shutdown caused by client disconnection

### DIFF
--- a/common/sockets.cpp
+++ b/common/sockets.cpp
@@ -36,7 +36,7 @@ TSS2_RC sendBytes( SOCKET tpmSock, const unsigned char *data, int len )
 
     for( sentLength = 0; sentLength < len; len -= iResult, sentLength += iResult )
     {
-        iResult = send( tpmSock, (char *)data, len, 0  );
+        iResult = send( tpmSock, (char *)data, len, MSG_NOSIGNAL );
         if (iResult == SOCKET_ERROR)
             return TSS2_TCTI_RC_IO_ERROR;
     }

--- a/resourcemgr/resourcemgr.c
+++ b/resourcemgr/resourcemgr.c
@@ -159,7 +159,7 @@ static TSS2_RC rmSendBytes( SOCKET sock, const unsigned char *data, int len )
 
     ret = sendBytes( sock, data, len);
     if (ret != TSS2_RC_SUCCESS)
-        DebugPrintf( NO_PREFIX, "In recvBytes, recv failed (socket: 0x%x) with error: %d\n", sock, WSAGetLastError() );
+        DebugPrintf( NO_PREFIX, "In rmSendBytes, send failed (socket: 0x%x) with error: %d\n", sock, WSAGetLastError() );
     return ret;
 }
 

--- a/tcti/platformcommand.c
+++ b/tcti/platformcommand.c
@@ -61,7 +61,7 @@ TSS2_RC PlatformCommand(
     sendbuf[3] = cmd;
 
     // Send the command
-    iResult = send( TCTI_CONTEXT_INTEL->otherSock, sendbuf, 4, 0 );
+    iResult = send( TCTI_CONTEXT_INTEL->otherSock, sendbuf, 4, MSG_NOSIGNAL );
     if (iResult == SOCKET_ERROR) {
         TCTI_LOG( tctiContext, NO_PREFIX, "send failed with error: %d\n", WSAGetLastError() );
         rval = TSS2_TCTI_RC_IO_ERROR;


### PR DESCRIPTION
Fix #288.

Check the exit code after resourcemgr exit, we can see 141, which means SIGPIPE was received. This was caused by send() without MSG_NOSIGNAL flag.

Add MSG_NOSIGNAL flag to avoid this unexpected behavior.