### PR TITLE
Ensure the command size from the client does not exceed the cmdBuffer…

### DIFF
--- a/resourcemgr/resourcemgr.c
+++ b/resourcemgr/resourcemgr.c
@@ -2372,6 +2372,12 @@ UINT8 TpmCmdServer( SERVER_STRUCT *serverStruct )
             }
 
             numBytes = CHANGE_ENDIAN_DWORD( numBytes );
+            if( numBytes > maxCmdSize )
+            {
+                CreateErrorResponse( TSS2_TCTI_RC_INSUFFICIENT_BUFFER );
+                SendErrorResponse( serverStruct->connectSock );
+                continue;
+            }
 
             // Receive the TPM command bytes from calling application.
             rval = rmRecvBytes( serverStruct->connectSock, (unsigned char *)cmdBuffer, numBytes);


### PR DESCRIPTION
… capacity.

This resolves a buffer overflow that is the result of trusting the
size of the TPM command provided by the client in the TpmCmdServer
thread. The resourcemgr recv's the size as a uint32, and then blindly
reads however many bytes the user specified into the cmdBuffer.
The cmdBuffer in the resourcemgr is a fixed size determined by the
TPM (through a call to GetCapability). This is a classic OWASP "top
10" data validation bug:
https://www.owasp.org/index.php/Data_Validation

We resolve this by comparing the size of the command provided by the
client to the maxCmdSize variable. At the time of initialization,
the resourcemgr queries the TPM for the maximum command buffer size
that it supports and sets maxCmdSize to this value. If the client
attempts to send a command buffer larger than this size, the
resourcemgr will now send a response buffer indicating that
the buffer available is insufficient:
TSS2_TCTI_RC_INSUFFICIENT_BUFFER.

This resolves #291 

Signed-off-by: Philip Tricca philip.b.tricca@intel.com
