### PR TITLE
Resourcemgr races

### DIFF
--- a/resourcemgr/resourcemgr.c
+++ b/resourcemgr/resourcemgr.c
@@ -2368,10 +2368,6 @@ UINT8 TpmCmdServer( SERVER_STRUCT *serverStruct )
                 SendErrorResponse( serverStruct->connectSock );
                 continue;
             }
-            (( TSS2_TCTI_CONTEXT_INTEL *)downstreamTctiContext )->status.locality = locality;
-            (( TSS2_TCTI_CONTEXT_INTEL *)downstreamTctiContext )->status.commandSent = 1;
-            (( TSS2_TCTI_CONTEXT_INTEL *)downstreamTctiContext )->status.rmDebugPrefix = NO_PREFIX;
-
             // Receive number of bytes.
             rval = rmRecvBytes( serverStruct->connectSock, (unsigned char*) &numBytes, 4);
             if( rval != TSS2_RC_SUCCESS )
@@ -2409,6 +2405,11 @@ UINT8 TpmCmdServer( SERVER_STRUCT *serverStruct )
             {
                 criticalSectionEntered = 1;
             }
+
+            // Set client specific locality for command we're about to send
+            (( TSS2_TCTI_CONTEXT_INTEL *)downstreamTctiContext )->status.locality = locality;
+            (( TSS2_TCTI_CONTEXT_INTEL *)downstreamTctiContext )->status.commandSent = 1;
+            (( TSS2_TCTI_CONTEXT_INTEL *)downstreamTctiContext )->status.rmDebugPrefix = NO_PREFIX;
 
             // Send TPM command to TPM.
             ((TSS2_TCTI_CONTEXT_INTEL *)downstreamTctiContext)->currentConnectSock = serverStruct->connectSock;


### PR DESCRIPTION
This is a re-packaging of the commits from PR #296. Specifically I've broken the patch up into two, one that fixes the race condition on the cmdBuffer, and a second that fixes the race on the downstream TCTI context. I've also added descriptive commit messages for each.

See #295 for description of the original issue.

@medition: since these are a re-write of your original patch can you please review this to be sure that you agree with my changes? I'll hold off pushing till you review.