### PR TITLE
Tcti device null deref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
 ## Unreleased
+### Added
+- Unit test for device TCTI bug fixes.
 ### Fixed
+- NULL dereference bug in device TCTI init function.
 - Two race conditions in the resourcemgr.
 
 ## [1.0] - 2016-11-01

--- a/tcti/tcti_device.c
+++ b/tcti/tcti_device.c
@@ -239,6 +239,8 @@ TSS2_RC InitDeviceTcti (
 {
     TSS2_RC rval = TSS2_RC_SUCCESS;
 
+    if( tctiContext == NULL && contextSize == NULL )
+        return TSS2_TCTI_RC_BAD_VALUE;
     if( tctiContext == NULL )
     {
         *contextSize = sizeof( TSS2_TCTI_CONTEXT_INTEL );

--- a/test/tcti-device_unit.c
+++ b/test/tcti-device_unit.c
@@ -8,6 +8,18 @@
 #include "tcti/logging.h"
 #include "sysapi/include/tcti_util.h"
 
+/**
+ * When passed all NULL values ensure that we get back the expected RC
+ * indicating bad values.
+ */
+static void
+tcti_device_init_all_null_test (void **state)
+{
+    TSS2_RC rc;
+
+    rc = InitDeviceTcti (NULL, NULL, NULL);
+    assert_int_equal (rc, TSS2_TCTI_RC_BAD_VALUE);
+}
 /* Determine the size of a TCTI context structure. Requires calling the
  * initialization function for the device TCTI with the first parameter
  * (the TCTI context) NULL.
@@ -114,6 +126,7 @@ int
 main(int argc, char* argv[])
 {
     const UnitTest tests[] = {
+        unit_test (tcti_device_init_all_null_test),
         unit_test(tcti_device_init_size_test),
         unit_test (tcti_device_init_log_test),
         unit_test (tcti_device_log_called_test),


### PR DESCRIPTION
This resolves #297 and adds a unit test for the conditions that trigger the bug.