### PR TITLE
build: build with gnu99 & cleanup OS detection preprocessor macros

### DIFF
--- a/include/sapi/tss2_tcti.h
+++ b/include/sapi/tss2_tcti.h
@@ -54,11 +54,11 @@ extern "C" {
 #include "tss2_common.h"
 #include <stddef.h>
 
-#if defined _WIN32
+#if defined(_WIN32)
 #include <winsock2.h>
 #include <windows.h>
 typedef HANDLE TSS2_TCTI_POLL_HANDLE;
-#elif defined linux || defined unix
+#elif defined(__linux__) || defined(__unix__)
 #include <poll.h>
 typedef struct pollfd TSS2_TCTI_POLL_HANDLE;
 #else

--- a/lib/default_config.site
+++ b/lib/default_config.site
@@ -1,2 +1,2 @@
-CFLAGS="-Wall -Werror"
+CFLAGS="-Wall -Werror -std=gnu99"
 CXXFLAGS="-Wall -Werror"

--- a/resourcemgr/criticalsection.h
+++ b/resourcemgr/criticalsection.h
@@ -28,9 +28,9 @@
 #ifndef CRITICALSECTION_H
 #define CRITICALSECTION_H
 
-#ifdef  _WIN32
+#if defined(_WIN32)
 typedef HANDLE TPM_MUTEX;
-#elif __linux || __unix
+#elif defined(__linux__) || defined(__unix__)
 #include <time.h>
 #include <semaphore.h>
 typedef sem_t TPM_MUTEX;
@@ -48,4 +48,3 @@ TSS2_RC StartCriticalSection( TPM_MUTEX *tpmMutex, char *dbgString );
 TSS2_RC EndCriticalSection( TPM_MUTEX *tpmMutex, char *dbgString );
 
 #endif
-

--- a/resourcemgr/criticalsection_linux.c
+++ b/resourcemgr/criticalsection_linux.c
@@ -31,7 +31,7 @@
 #include "criticalsection.h"
 #include "debug.h"
 
-#if __linux || __unix
+#if defined(__linux__) || defined(__unix__)
 
 //
 // This function starts a critical section, e.g. some code that must

--- a/resourcemgr/resourcemgr.c
+++ b/resourcemgr/resourcemgr.c
@@ -39,13 +39,14 @@
 #include "syscontext.h"
 #include "debug.h"
 
-#ifdef _WIN32
+#if defined(_WIN32)
 
 typedef HANDLE THREAD_TYPE;
 #define MAX_COMMAND_LINE_ARGS 6
 
-#elif __linux || __unix
+#elif defined(__linux__) || defined(__unix__)
 
+#include <sys/select.h>
 #include <time.h>
 #include <stdarg.h>
 #define sprintf_s   snprintf

--- a/sysapi/include/tcti_util.h
+++ b/sysapi/include/tcti_util.h
@@ -39,7 +39,7 @@
 #ifndef TSS2_TCTI_UTIL_H
 #define TSS2_TCTI_UTIL_H
 
-#if defined linux || defined unix
+#if defined(__linux__) || defined(__unix__)
 #include <sys/socket.h>
 #define SOCKET int
 #endif


### PR DESCRIPTION
Our use of __linux / __unix / linux / unix are all obsolete. The modern
equivalent is __linux__ and __unix__. We were also using an inconsistent
mess of '#if defined' '#ifdef' and '#if' when checking for these. We're
now consistently using '#if defined(__blah__)'. This allows us to use
logical operators easily since we're checking for two symbols.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>