### PR TITLE
[Resource Manager] Use SO_REUSEPORT

### DIFF
--- a/common/sockets.cpp
+++ b/common/sockets.cpp
@@ -56,6 +56,9 @@ InitSockets( const char *hostName,
 {
     sockaddr_in otherService;
     sockaddr_in tpmService;
+#ifndef _WIN32
+    int optval = 1;
+#endif
     int iResult = 0;            // used to return function results
 
 #ifdef _WIN32
@@ -80,6 +83,13 @@ InitSockets( const char *hostName,
         return(1);
     }
     else {
+#ifndef _WIN32
+        iResult = setsockopt(*otherSock, SOL_SOCKET, SO_REUSEPORT, &optval, sizeof(optval));
+        if (iResult) {
+          SAFE_CALL( debugfunc, data, NO_PREFIX, "setsockopt failed with error = %d\n", WSAGetLastError() );
+          return(1);
+        }
+#endif
         SAFE_CALL( debugfunc, data, NO_PREFIX, "socket created:  0x%x\n", *otherSock );
         otherService.sin_family = AF_INET;
         otherService.sin_addr.s_addr = inet_addr( hostName );
@@ -122,6 +132,15 @@ InitSockets( const char *hostName,
         return(1);
     }
     else {
+#ifndef _WIN32
+        iResult = setsockopt(*tpmSock, SOL_SOCKET, SO_REUSEPORT, &optval, sizeof(optval));
+        if (iResult) {
+          SAFE_CALL( debugfunc, data, NO_PREFIX, "setsockopt failed with error = %d\n", WSAGetLastError() );
+          closesocket(*otherSock);
+          WSACleanup();
+          return(1);
+        }
+#endif
         SAFE_CALL( debugfunc, data, NO_PREFIX, "socket created:  0x%x\n", *tpmSock );
         tpmService.sin_family = AF_INET;
         tpmService.sin_addr.s_addr = inet_addr( hostName );


### PR DESCRIPTION
Fix #317 

I understand that using SO_REUSEPORT could have security implications as another application can bind to the port used by resource manager in order to capture some of its incoming connections.
In Linux, to prevent unwanted processes from hijacking a port that has already been bound by a server using SO_REUSEPORT, all of the servers that later bind to that port must have an effective user ID that matches the effective user ID used to perform the first bind on the socket.
So that can be mitigate running the resource manager with an ad-hoc user. If it is run as root, root would be required to bind, but in that case there is very little we can do.

Apparently, this don't work in the same way on Windows so I would recommend against using SO_REUSEADDR (there is not SO_REUSEPORT on Windows) for the security issues that it implies.