### PR TITLE
tss2_tpm2_types: Fix definition of PCR_LAST.

### DIFF
--- a/include/sapi/tss2_tpm2_types.h
+++ b/include/sapi/tss2_tpm2_types.h
@@ -442,7 +442,7 @@ typedef	TPM_HANDLE TPM_HC;
 #define	HR_NV_INDEX	(TPM_HT_NV_INDEX << HR_SHIFT )	 /*   */
 #define	HR_PERMANENT	(TPM_HT_PERMANENT << HR_SHIFT )	 /*   */
 #define	PCR_FIRST	(HR_PCR + 0 )	 /* first PCR  */
-#define	PCR_LAST	(PCR_FIRST + IMPLEMENTATION_PCR1 )	 /* last PCR  */
+#define	PCR_LAST	(PCR_FIRST + IMPLEMENTATION_PCR - 1 )	 /* last PCR  */
 #define	HMAC_SESSION_FIRST	(HR_HMAC_SESSION + 0 )	 /* first HMAC session  */
 #define	HMAC_SESSION_LAST	(HMAC_SESSION_FIRST+MAX_ACTIVE_SESSIONS1 )	 /* last HMAC session  */
 #define	LOADED_SESSION_FIRST	(HMAC_SESSION_FIRST )	 /* used in GetCapability  */


### PR DESCRIPTION
See part 2 of the spec, table 30. In its previous form any use of the
PCR_LAST macro produced an error since IMPLEMENTATION_PCR1 was
undefined. Should have been IMPLEMENTATION_PCR - 1.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>