### PR TITLE
Fix memory leaks on error conditions in InitSysContext & SockServer.

### DIFF
--- a/common/syscontext.c
+++ b/common/syscontext.c
@@ -58,10 +58,12 @@ TSS2_SYS_CONTEXT *InitSysContext(
         // Initialized the system context structure.
         rval = Tss2_Sys_Initialize( sysContext, contextSize, tctiContext, abiVersion );
 
-        if( rval == TSS2_RC_SUCCESS )
+        if( rval == TSS2_RC_SUCCESS ) {
             return sysContext;
-        else
-            return 0;
+        } else {
+            free (sysContext);
+            return NULL;
+        }
     }
     else
     {

--- a/resourcemgr/resourcemgr.c
+++ b/resourcemgr/resourcemgr.c
@@ -2724,6 +2724,7 @@ UINT32 WINAPI SockServer( LPVOID servStruct )
         if( cmdServerStruct->connectSock == INVALID_SOCKET )
         {
             printf( "Accept failed.  Error is 0x%x\n", WSAGetLastError() );
+            (*rmFree)( cmdServerStruct );
             continue;
         }
 
@@ -2768,6 +2769,7 @@ UINT32 WINAPI SockServer( LPVOID servStruct )
     if( 0 == strcmp( &otherCmdStr[0], serverStruct->serverName ) )
     {
         printf( "SockServer died (%s), socket: 0x%x.\n", serverStruct->serverName, serverStruct->connectSock );
+        (*rmFree)( cmdServerStruct );
         ExitThread( 0 );
     }
 


### PR DESCRIPTION
Resolves #331.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>