### PR TITLE
libmarshal: Add functions to (un)?marshal TPM_ST and use them.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -107,7 +107,7 @@ test_unit_GetNumHandles_SOURCES = \
 test_unit_CopyCommandHeader_CFLAGS = $(CMOCKA_CFLAGS) -I$(srcdir)/include \
     -I$(srcdir)/include/sapi -I$(srcdir)/sysapi/include/
 test_unit_CopyCommandHeader_LDFLAGS = -Wl,--unresolved-symbols=ignore-all
-test_unit_CopyCommandHeader_LDADD = $(CMOCKA_LIBS)
+test_unit_CopyCommandHeader_LDADD = $(CMOCKA_LIBS) $(libmarshal)
 test_unit_CopyCommandHeader_SOURCES = \
     test/unit/CopyCommandHeader.c sysapi/sysapi_util/CommandUtil.c \
     sysapi/sysapi/ContextManagement.c sysapi/sysapi_util/changeEndian.c

--- a/include/sapi/marshal.h
+++ b/include/sapi/marshal.h
@@ -185,6 +185,22 @@ UINT64_Unmarshal (
     UINT64         *dest
     );
 
+TSS2_RC
+TPM_ST_Marshal (
+    TPM_ST const   *src,
+    uint8_t         buffer [],
+    size_t          buffer_size,
+    size_t         *offset
+    );
+
+TSS2_RC
+TPM_ST_Unmarshal (
+    uint8_t const   buffer[],
+    size_t          buffer_size,
+    size_t         *offset,
+    TPM_ST         *dest
+    );
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/libmarshal.map
+++ b/lib/libmarshal.map
@@ -24,6 +24,8 @@
         UINT32_Unmarshal;
         UINT64_Marshal;
         UINT64_Unmarshal;
+        TPM_ST_Marshal;
+        TPM_ST_Unmarshal;
     local:
         *;
 };

--- a/marshal/base-types.c
+++ b/marshal/base-types.c
@@ -190,3 +190,25 @@ endian_conv_64 (UINT64 value)
            ((value & (0xffL << 48)) >> 40) | \
            ((value & (0xffL << 56)) >> 56);
 }
+TSS2_RC
+TPM_ST_Marshal (
+    TPM_ST const   *src,
+    uint8_t         buffer [],
+    size_t          buffer_size,
+    size_t         *offset
+    )
+{
+    LOG (DEBUG, "Marshalling TPM_ST as UINT16");
+    return UINT16_Marshal ((UINT16*)src, buffer, buffer_size, offset);
+}
+TSS2_RC
+TPM_ST_Unmarshal (
+    uint8_t const   buffer[],
+    size_t          buffer_size,
+    size_t         *offset,
+    TPM_ST         *dest
+    )
+{
+    LOG (DEBUG, "Unmarshalling TPM_ST as UINT16");
+    return UINT16_Unmarshal (buffer, buffer_size, offset, (UINT16*)dest);
+}

--- a/sysapi/include/sys_api_marshalUnmarshal.h
+++ b/sysapi/include/sys_api_marshalUnmarshal.h
@@ -80,6 +80,8 @@ void Unmarshal_Simple_TPM2B_NoSizeCheck( UINT8 *outBuffPtr, UINT32 maxResponseSi
  * - rval (TSS2_RC*): Pointer to TSS2_RC instace where the response code
  *     is stored.
  */
+#define Marshal_TPM_ST(inBuffPtr, maxCommandSize, nextData, src, rval) \
+    MARSHAL_ADAPTER(TPM_ST, inBuffPtr, maxCommandSize, nextData, src, rval)
 #define Marshal_UINT64(inBuffPtr, maxCommandSize, nextData, src, rval) \
     MARSHAL_ADAPTER(UINT64, inBuffPtr, maxCommandSize, nextData, src, rval)
 #define Marshal_UINT32(inBuffPtr, maxCommandSize, nextData, src, rval) \
@@ -104,6 +106,8 @@ void Unmarshal_Simple_TPM2B_NoSizeCheck( UINT8 *outBuffPtr, UINT32 maxResponseSi
  * - rval (TSS2_RC*): Pointer to TSS2_RC instace where the response code
  *     is stored
  */
+#define Unmarshal_TPM_ST(outBuffPtr, maxResponseSize, nextData, dest, rval) \
+    UNMARSHAL_ADAPTER(TPM_ST, outBuffPtr, maxResponseSize, nextData, dest, rval)
 #define Unmarshal_UINT64(outBuffPtr, maxResponseSize, nextData, dest, rval) \
     UNMARSHAL_ADAPTER(UINT64, outBuffPtr, maxResponseSize, nextData, dest, rval)
 #define Unmarshal_UINT32(outBuffPtr, maxResponseSize, nextData, dest, rval) \

--- a/sysapi/sysapi_util/CommandUtil.c
+++ b/sysapi/sysapi_util/CommandUtil.c
@@ -92,9 +92,16 @@ UINT32 GetCommandSize( TSS2_SYS_CONTEXT *sysContext )
 
 void CopyCommandHeader( _TSS2_SYS_CONTEXT_BLOB *sysContext, TPM_CC commandCode )
 {
-   SYS_CONTEXT->rval = TSS2_RC_SUCCESS;
+    TPM_ST st_no_sessions = TPM_ST_NO_SESSIONS;
 
-  ((TPM20_Header_In *) sysContext->tpmInBuffPtr)->tag = CHANGE_ENDIAN_WORD( TPM_ST_NO_SESSIONS );
+   SYS_CONTEXT->rval = TSS2_RC_SUCCESS;
+    SYS_CONTEXT->nextData = SYS_CONTEXT->tpmInBuffPtr;
+
+    Marshal_TPM_ST (SYS_CONTEXT->tpmInBuffPtr,
+                    SYS_CONTEXT->maxCommandSize,
+                    &(SYS_CONTEXT->nextData),
+                    st_no_sessions,
+                    &(SYS_CONTEXT->rval));
 
   ((TPM20_Header_In *) sysContext->tpmInBuffPtr)->commandCode = CHANGE_ENDIAN_DWORD( commandCode );
 
@@ -200,10 +207,17 @@ TSS2_RC CommonComplete( TSS2_SYS_CONTEXT *sysContext )
     }
     else
     {
+        TPM_ST tag;
         SYS_CONTEXT->nextData = (UINT8 *)( SYS_CONTEXT->rspParamsSize );
 
         // Save response params size if command has authorization area.
-        if( CHANGE_ENDIAN_WORD( ( (TPM20_Header_Out *)( SYS_CONTEXT->tpmOutBuffPtr )  )->tag ) == TPM_ST_SESSIONS )
+        UINT8 *tmp_ptr = SYS_CONTEXT->tpmOutBuffPtr;
+        Unmarshal_TPM_ST (SYS_CONTEXT->tpmOutBuffPtr,
+                          SYS_CONTEXT->maxResponseSize,
+                          &tmp_ptr,
+                          &tag,
+                          &(SYS_CONTEXT->rval));
+        if( tag == TPM_ST_SESSIONS )
         {
             Unmarshal_UINT32( SYS_CONTEXT->tpmOutBuffPtr, SYS_CONTEXT->maxResponseSize, &( SYS_CONTEXT->nextData ),
                     &( SYS_CONTEXT->rpBufferUsedSize ), &(SYS_CONTEXT->rval ) );

--- a/test/unit/CopyCommandHeader.c
+++ b/test/unit/CopyCommandHeader.c
@@ -27,6 +27,8 @@ CopyCommandHeader_sys_setup (void **state)
      *  must point to the data after the context structure.
      */
     sys_ctx->tpmInBuffPtr = (UINT8*) (sys_ctx + sizeof (_TSS2_SYS_CONTEXT_BLOB));
+    InitSysContextFields ((TSS2_SYS_CONTEXT*)sys_ctx);
+    InitSysContextPtrs ((TSS2_SYS_CONTEXT*)sys_ctx, size_ctx);
 
     *state = sys_ctx;
 }


### PR DESCRIPTION
This commit adds the marshalling functions as well as replaces some
convoluted access to said types in the CommandUtil module.

Use of these functions shows that having the Marshal function take a
reference to the type being marshalled makes using constants awkward. It
requires that the constant be assigned to a variable first which isn't
ideal or necessary. Probably worth fixing the API early if this turns
out to be a good change.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>