### PR TITLE
CommandUtil: Check rval from sysContext CommonOneCall.

### DIFF
--- a/sysapi/sysapi_util/CommandUtil.c
+++ b/sysapi/sysapi_util/CommandUtil.c
@@ -227,7 +227,6 @@ TSS2_RC CommonOneCall(
     TSS2_SYS_RSP_AUTHS *rspAuthsArray
     )
 {
-    TSS2_RC     rval = TSS2_RC_SUCCESS;
     UINT32      responseSize;
 
     if( SYS_CONTEXT->rval != TSS2_RC_SUCCESS )
@@ -238,7 +237,7 @@ TSS2_RC CommonOneCall(
         SYS_CONTEXT->rval = Tss2_Sys_SetCmdAuths( sysContext, cmdAuthsArray );
     }
 
-    if( rval == TSS2_RC_SUCCESS )
+    if( SYS_CONTEXT->rval == TSS2_RC_SUCCESS )
     {
         SYS_CONTEXT->rval = FinishCommand( SYS_CONTEXT, cmdAuthsArray, &responseSize );
 


### PR DESCRIPTION
The local variable being checked previously was initialized to the value
in the conditional which made it a no-op. After this change the
variable was unused and thus removed.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>