### PR TITLE
libmarshal: Pass source parameter by value for *_Marshal functions.

### DIFF
--- a/include/sapi/marshal.h
+++ b/include/sapi/marshal.h
@@ -43,7 +43,7 @@ extern "C" {
 
 TSS2_RC
 BYTE_Marshal (
-    BYTE const     *src,
+    BYTE           src,
     uint8_t         buffer [],
     size_t          buffer_size,
     size_t         *offset
@@ -59,7 +59,7 @@ BYTE_Unmarshal (
 
 TSS2_RC
 INT8_Marshal (
-    INT8 const     *src,
+    INT8            src,
     uint8_t         buffer [],
     size_t          buffer_size,
     size_t         *offset
@@ -75,7 +75,7 @@ INT8_Unmarshal (
 
 TSS2_RC
 INT16_Marshal (
-    INT16 const    *src,
+    INT16           src,
     uint8_t         buffer [],
     size_t          buffer_size,
     size_t         *offset
@@ -91,7 +91,7 @@ INT16_Unmarshal (
 
 TSS2_RC
 INT32_Marshal (
-    INT32 const    *src,
+    INT32           src,
     uint8_t         buffer [],
     size_t          buffer_size,
     size_t         *offset
@@ -107,7 +107,7 @@ INT32_Unmarshal (
 
 TSS2_RC
 INT64_Marshal (
-    INT64 const    *src,
+    INT64           src,
     uint8_t         buffer [],
     size_t          buffer_size,
     size_t         *offset
@@ -123,7 +123,7 @@ INT64_Unmarshal (
 
 TSS2_RC
 UINT8_Marshal (
-    UINT8 const    *src,
+    UINT8           src,
     uint8_t         buffer [],
     size_t          buffer_size,
     size_t         *offset
@@ -139,7 +139,7 @@ UINT8_Unmarshal (
 
 TSS2_RC
 UINT16_Marshal (
-    UINT16 const   *src,
+    UINT16          src,
     uint8_t         buffer [],
     size_t          buffer_size,
     size_t         *offset
@@ -155,7 +155,7 @@ UINT16_Unmarshal (
 
 TSS2_RC
 UINT32_Marshal (
-    UINT32 const   *src,
+    UINT32          src,
     uint8_t         buffer [],
     size_t          buffer_size,
     size_t         *offset
@@ -171,7 +171,7 @@ UINT32_Unmarshal (
 
 TSS2_RC
 UINT64_Marshal (
-    UINT64 const   *src,
+    UINT64          src,
     uint8_t         buffer [],
     size_t          buffer_size,
     size_t         *offset
@@ -187,7 +187,7 @@ UINT64_Unmarshal (
 
 TSS2_RC
 TPM_ST_Marshal (
-    TPM_ST const   *src,
+    TPM_ST          src,
     uint8_t         buffer [],
     size_t          buffer_size,
     size_t         *offset

--- a/marshal/base-types.c
+++ b/marshal/base-types.c
@@ -37,7 +37,7 @@
 #define BASE_MARSHAL(type, marshal_func) \
 TSS2_RC \
 type##_Marshal ( \
-    type    const *src, \
+    type           src, \
     uint8_t        buffer [], \
     size_t         buffer_size, \
     size_t        *offset \
@@ -50,36 +50,36 @@ type##_Marshal ( \
         local_offset = *offset; \
     } \
 \
-    if (src == NULL || (buffer == NULL && offset == NULL)) { \
-        LOG (WARNING, "src or buffer and offset parameter are NULL"); \
+    if (buffer == NULL && offset == NULL) { \
+        LOG (WARNING, "buffer and offset parameter are NULL"); \
         return TSS2_TYPES_RC_BAD_REFERENCE; \
     } else if (buffer == NULL && offset != NULL) { \
-        *offset += sizeof (*src); \
+        *offset += sizeof (src); \
         LOG (INFO, "buffer NULL and offset non-NULL, updating offset to %zu", \
              *offset); \
         return TSS2_RC_SUCCESS; \
     } else if (buffer_size < local_offset || \
-               buffer_size - local_offset < sizeof (*src)) \
+               buffer_size - local_offset < sizeof (src)) \
     { \
         LOG (WARNING, \
              "buffer_size: %zu with offset: %zu are insufficient for object " \
              "of size %zu", \
              buffer_size, \
              local_offset, \
-             sizeof (*src)); \
+             sizeof (src)); \
         return TSS2_TYPES_RC_INSUFFICIENT_BUFFER; \
     } \
 \
     LOG (DEBUG, \
          "Marshalling " #type " from 0x%" PRIxPTR " to buffer 0x%" PRIxPTR \
          " at index 0x%zx", \
-         (uintptr_t)src, \
+         (uintptr_t)&src, \
          (uintptr_t)buffer, \
          local_offset); \
-    type tmp = marshal_func (*src); \
-    memcpy (&buffer [local_offset], &tmp, sizeof (tmp)); \
+    src = marshal_func (src); \
+    memcpy (&buffer [local_offset], &src, sizeof (src)); \
     if (offset != NULL) { \
-        *offset = local_offset + sizeof (*src); \
+        *offset = local_offset + sizeof (src); \
         LOG (DEBUG, "offset parameter non-NULL, updated to %zu", *offset); \
     } \
 \
@@ -196,14 +196,14 @@ endian_conv_64 (UINT64 value)
 }
 TSS2_RC
 TPM_ST_Marshal (
-    TPM_ST const   *src,
+    TPM_ST          src,
     uint8_t         buffer [],
     size_t          buffer_size,
     size_t         *offset
     )
 {
     LOG (DEBUG, "Marshalling TPM_ST as UINT16");
-    return UINT16_Marshal ((UINT16*)src, buffer, buffer_size, offset);
+    return UINT16_Marshal ((UINT16)src, buffer, buffer_size, offset);
 }
 TSS2_RC
 TPM_ST_Unmarshal (

--- a/sysapi/include/sys_api_marshalUnmarshal.h
+++ b/sysapi/include/sys_api_marshalUnmarshal.h
@@ -40,8 +40,7 @@
             break;\
         } \
         size_t index = *nextData - inBuffPtr; \
-        type floop = src; \
-        *rval = type##_Marshal (&floop, \
+        *rval = type##_Marshal (src, \
                                 inBuffPtr, \
                                 maxCommandSize, \
                                 &index); \

--- a/sysapi/sysapi_util/CommandUtil.c
+++ b/sysapi/sysapi_util/CommandUtil.c
@@ -92,15 +92,13 @@ UINT32 GetCommandSize( TSS2_SYS_CONTEXT *sysContext )
 
 void CopyCommandHeader( _TSS2_SYS_CONTEXT_BLOB *sysContext, TPM_CC commandCode )
 {
-    TPM_ST st_no_sessions = TPM_ST_NO_SESSIONS;
-
    SYS_CONTEXT->rval = TSS2_RC_SUCCESS;
     SYS_CONTEXT->nextData = SYS_CONTEXT->tpmInBuffPtr;
 
     Marshal_TPM_ST (SYS_CONTEXT->tpmInBuffPtr,
                     SYS_CONTEXT->maxCommandSize,
                     &(SYS_CONTEXT->nextData),
-                    st_no_sessions,
+                    TPM_ST_NO_SESSIONS,
                     &(SYS_CONTEXT->rval));
 
   ((TPM20_Header_In *) sysContext->tpmInBuffPtr)->commandCode = CHANGE_ENDIAN_DWORD( commandCode );

--- a/test/unit/UINT16-marshal.c
+++ b/test/unit/UINT16-marshal.c
@@ -17,7 +17,7 @@ UINT16_marshal_success (void **state)
     size_t  buffer_size = sizeof (buffer);
     TSS2_RC rc;
 
-    rc = UINT16_Marshal (&src, buffer, buffer_size, NULL);
+    rc = UINT16_Marshal (src, buffer, buffer_size, NULL);
 
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     assert_int_equal (0xde, buffer [0]);
@@ -35,28 +35,12 @@ UINT16_marshal_success_offset (void **state)
     size_t  offset = 1;
     TSS2_RC rc;
 
-    rc = UINT16_Marshal (&src, buffer, buffer_size, &offset);
+    rc = UINT16_Marshal (src, buffer, buffer_size, &offset);
 
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     assert_int_equal ((src & 0xff00) >> 8, buffer [1]);
     assert_int_equal (src & 0xff, buffer [2]);
     assert_int_equal (offset, sizeof (buffer));
-}
-/*
- * Test case passing NULL src. Test to be sure offset and buffer aren't changed.
- */
-void
-UINT16_marshal_src_null (void **state)
-{
-    uint8_t buffer [2] = { 0 };
-    size_t  buffer_size = sizeof (buffer);
-    size_t  offset = 1;
-    TSS2_RC rc;
-
-    rc = UINT16_Marshal (NULL, buffer, buffer_size, &offset);
-
-    assert_int_equal (rc, TSS2_TYPES_RC_BAD_REFERENCE);
-    assert_int_equal (offset, 1);
 }
 /*
  * Test case passing NULL buffer and non-NULL offset. Test to be sure offset
@@ -69,7 +53,7 @@ UINT16_marshal_buffer_null_with_offset (void **state)
     size_t offset = 100;
     TSS2_RC rc;
 
-    rc = UINT16_Marshal (&src, NULL, 2, &offset);
+    rc = UINT16_Marshal (src, NULL, 2, &offset);
 
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     assert_int_equal (offset, 100 + sizeof (src));
@@ -83,7 +67,7 @@ UINT16_marshal_buffer_null_offset_null (void **state)
     UINT16 src = 0xbeef;
     TSS2_RC rc;
 
-    rc = UINT16_Marshal (&src, NULL, sizeof (src), NULL);
+    rc = UINT16_Marshal (src, NULL, sizeof (src), NULL);
 
     assert_int_equal (rc, TSS2_TYPES_RC_BAD_REFERENCE);
 }
@@ -99,7 +83,7 @@ UINT16_marshal_buffer_size_lt_data (void **state)
     size_t  offset = 2;
     TSS2_RC rc;
 
-    rc = UINT16_Marshal (&src, buffer, sizeof (src), &offset);
+    rc = UINT16_Marshal (src, buffer, sizeof (src), &offset);
 
     assert_int_equal (rc, TSS2_TYPES_RC_INSUFFICIENT_BUFFER);
     assert_int_equal (offset, 2);
@@ -117,7 +101,7 @@ UINT16_marshal_buffer_size_lt_offset (void **state)
     size_t  offset = sizeof (buffer) + 1;
     TSS2_RC rc;
 
-    rc = UINT16_Marshal (&src, buffer, buffer_size, &offset);
+    rc = UINT16_Marshal (src, buffer, buffer_size, &offset);
 
     assert_int_equal (rc, TSS2_TYPES_RC_INSUFFICIENT_BUFFER);
     assert_int_equal (offset, sizeof (buffer) + 1);
@@ -226,7 +210,6 @@ main (void)
     const UnitTest tests [] = {
         unit_test (UINT16_marshal_success),
         unit_test (UINT16_marshal_success_offset),
-        unit_test (UINT16_marshal_src_null),
         unit_test (UINT16_marshal_buffer_null_with_offset),
         unit_test (UINT16_marshal_buffer_null_offset_null),
         unit_test (UINT16_marshal_buffer_size_lt_data),

--- a/test/unit/UINT32-marshal.c
+++ b/test/unit/UINT32-marshal.c
@@ -18,7 +18,7 @@ UINT32_marshal_success (void **state)
     size_t  buffer_size = sizeof (buffer);
     TSS2_RC rc;
 
-    rc = UINT32_Marshal (&src, buffer, buffer_size, NULL);
+    rc = UINT32_Marshal (src, buffer, buffer_size, NULL);
 
     tmp = HOST_TO_BE_32 (src);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
@@ -36,28 +36,12 @@ UINT32_marshal_success_offset (void **state)
     size_t  offset = 1;
     TSS2_RC rc;
 
-    rc = UINT32_Marshal (&src, buffer, buffer_size, &offset);
+    rc = UINT32_Marshal (src, buffer, buffer_size, &offset);
     tmp = HOST_TO_BE_32 (src);
 
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     assert_memory_equal (&tmp, &buffer [1], sizeof (tmp));
     assert_int_equal (offset, sizeof (buffer));
-}
-/*
- * Test case passing NULL src. Test to be sure offset and buffer aren't changed.
- */
-void
-UINT32_marshal_src_null (void **state)
-{
-    uint8_t buffer [4] = { 0 };
-    size_t  buffer_size = sizeof (buffer);
-    size_t  offset = 1;
-    TSS2_RC rc;
-
-    rc = UINT32_Marshal (NULL, buffer, buffer_size, &offset);
-
-    assert_int_equal (rc, TSS2_TYPES_RC_BAD_REFERENCE);
-    assert_int_equal (offset, 1);
 }
 /*
  * Test case passing NULL buffer and non-NULL offset. Test to be sure offset
@@ -70,7 +54,7 @@ UINT32_marshal_buffer_null_with_offset (void **state)
     size_t offset = 100;
     TSS2_RC rc;
 
-    rc = UINT32_Marshal (&src, NULL, 2, &offset);
+    rc = UINT32_Marshal (src, NULL, 2, &offset);
 
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     assert_int_equal (offset, 100 + sizeof (src));
@@ -84,7 +68,7 @@ UINT32_marshal_buffer_null_offset_null (void **state)
     UINT32 src = 0xdeadbeef;
     TSS2_RC rc;
 
-    rc = UINT32_Marshal (&src, NULL, sizeof (src), NULL);
+    rc = UINT32_Marshal (src, NULL, sizeof (src), NULL);
 
     assert_int_equal (rc, TSS2_TYPES_RC_BAD_REFERENCE);
 }
@@ -100,7 +84,7 @@ UINT32_marshal_buffer_size_lt_data (void **state)
     size_t  offset = 2;
     TSS2_RC rc;
 
-    rc = UINT32_Marshal (&src, buffer, sizeof (src), &offset);
+    rc = UINT32_Marshal (src, buffer, sizeof (src), &offset);
 
     assert_int_equal (rc, TSS2_TYPES_RC_INSUFFICIENT_BUFFER);
     assert_int_equal (offset, 2);
@@ -118,7 +102,7 @@ UINT32_marshal_buffer_size_lt_offset (void **state)
     size_t  offset = sizeof (buffer) + 1;
     TSS2_RC rc;
 
-    rc = UINT32_Marshal (&src, buffer, buffer_size, &offset);
+    rc = UINT32_Marshal (src, buffer, buffer_size, &offset);
 
     assert_int_equal (rc, TSS2_TYPES_RC_INSUFFICIENT_BUFFER);
     assert_int_equal (offset, sizeof (buffer) + 1);
@@ -227,7 +211,6 @@ main (void)
     const UnitTest tests [] = {
         unit_test (UINT32_marshal_success),
         unit_test (UINT32_marshal_success_offset),
-        unit_test (UINT32_marshal_src_null),
         unit_test (UINT32_marshal_buffer_null_with_offset),
         unit_test (UINT32_marshal_buffer_null_offset_null),
         unit_test (UINT32_marshal_buffer_size_lt_data),

--- a/test/unit/UINT64-marshal.c
+++ b/test/unit/UINT64-marshal.c
@@ -18,7 +18,7 @@ UINT64_marshal_success (void **state)
     size_t  buffer_size = sizeof (buffer);
     TSS2_RC rc;
 
-    rc = UINT64_Marshal (&src, buffer, buffer_size, NULL);
+    rc = UINT64_Marshal (src, buffer, buffer_size, NULL);
     tmp = HOST_TO_BE_64 (src);
 
     assert_int_equal (rc, TSS2_RC_SUCCESS);
@@ -36,28 +36,12 @@ UINT64_marshal_success_offset (void **state)
     size_t  offset = 1;
     TSS2_RC rc;
 
-    rc = UINT64_Marshal (&src, buffer, buffer_size, &offset);
+    rc = UINT64_Marshal (src, buffer, buffer_size, &offset);
     tmp = HOST_TO_BE_64 (src);
 
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     assert_memory_equal (&tmp, &buffer [1], sizeof (tmp));
     assert_int_equal (offset, sizeof (buffer));
-}
-/*
- * Test case passing NULL src. Test to be sure offset and buffer aren't changed.
- */
-void
-UINT64_marshal_src_null (void **state)
-{
-    uint8_t buffer [8] = { 0 };
-    size_t  buffer_size = sizeof (buffer);
-    size_t  offset = 1;
-    TSS2_RC rc;
-
-    rc = UINT64_Marshal (NULL, buffer, buffer_size, &offset);
-
-    assert_int_equal (rc, TSS2_TYPES_RC_BAD_REFERENCE);
-    assert_int_equal (offset, 1);
 }
 /*
  * Test case passing NULL buffer and non-NULL offset. Test to be sure offset
@@ -70,7 +54,7 @@ UINT64_marshal_buffer_null_with_offset (void **state)
     size_t offset = 100;
     TSS2_RC rc;
 
-    rc = UINT64_Marshal (&src, NULL, 2, &offset);
+    rc = UINT64_Marshal (src, NULL, 2, &offset);
 
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     assert_int_equal (offset, 100 + sizeof (src));
@@ -84,7 +68,7 @@ UINT64_marshal_buffer_null_offset_null (void **state)
     UINT64 src = 0xdeadbeefdeadbeef;
     TSS2_RC rc;
 
-    rc = UINT64_Marshal (&src, NULL, sizeof (src), NULL);
+    rc = UINT64_Marshal (src, NULL, sizeof (src), NULL);
 
     assert_int_equal (rc, TSS2_TYPES_RC_BAD_REFERENCE);
 }
@@ -100,7 +84,7 @@ UINT64_marshal_buffer_size_lt_data (void **state)
     size_t  offset = 2;
     TSS2_RC rc;
 
-    rc = UINT64_Marshal (&src, buffer, sizeof (src), &offset);
+    rc = UINT64_Marshal (src, buffer, sizeof (src), &offset);
 
     assert_int_equal (rc, TSS2_TYPES_RC_INSUFFICIENT_BUFFER);
     assert_int_equal (offset, 2);
@@ -118,7 +102,7 @@ UINT64_marshal_buffer_size_lt_offset (void **state)
     size_t  offset = sizeof (buffer) + 1;
     TSS2_RC rc;
 
-    rc = UINT64_Marshal (&src, buffer, buffer_size, &offset);
+    rc = UINT64_Marshal (src, buffer, buffer_size, &offset);
 
     assert_int_equal (rc, TSS2_TYPES_RC_INSUFFICIENT_BUFFER);
     assert_int_equal (offset, sizeof (buffer) + 1);
@@ -227,7 +211,6 @@ main (void)
     const UnitTest tests [] = {
         unit_test (UINT64_marshal_success),
         unit_test (UINT64_marshal_success_offset),
-        unit_test (UINT64_marshal_src_null),
         unit_test (UINT64_marshal_buffer_null_with_offset),
         unit_test (UINT64_marshal_buffer_null_offset_null),
         unit_test (UINT64_marshal_buffer_size_lt_data),

--- a/test/unit/UINT8-marshal.c
+++ b/test/unit/UINT8-marshal.c
@@ -17,7 +17,7 @@ UINT8_marshal_success (void **state)
     size_t  buffer_size = sizeof (buffer);
     TSS2_RC rc;
 
-    rc = UINT8_Marshal (&src, buffer, buffer_size, NULL);
+    rc = UINT8_Marshal (src, buffer, buffer_size, NULL);
 
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     assert_int_equal (src, buffer [0]);
@@ -34,27 +34,11 @@ UINT8_marshal_success_offset (void **state)
     size_t  offset = 1;
     TSS2_RC rc;
 
-    rc = UINT8_Marshal (&src, buffer, buffer_size, &offset);
+    rc = UINT8_Marshal (src, buffer, buffer_size, &offset);
 
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     assert_int_equal (src, buffer [1]);
     assert_int_equal (offset, sizeof (buffer));
-}
-/*
- * Test case passing NULL src. Test to be sure offset and buffer aren't changed.
- */
-void
-UINT8_marshal_src_null (void **state)
-{
-    uint8_t buffer [2] = { 0 };
-    size_t  buffer_size = sizeof (buffer);
-    size_t  offset = 1;
-    TSS2_RC rc;
-
-    rc = UINT8_Marshal (NULL, buffer, buffer_size, &offset);
-
-    assert_int_equal (rc, TSS2_TYPES_RC_BAD_REFERENCE);
-    assert_int_equal (offset, 1);
 }
 /*
  * Test case passing NULL buffer and non-NULL offset. Test to be sure offset
@@ -67,7 +51,7 @@ UINT8_marshal_buffer_null_with_offset (void **state)
     size_t offset = 100;
     TSS2_RC rc;
 
-    rc = UINT8_Marshal (&src, NULL, 2, &offset);
+    rc = UINT8_Marshal (src, NULL, 2, &offset);
 
     assert_int_equal (rc, TSS2_RC_SUCCESS);
     assert_int_equal (offset, 100 + sizeof (src));
@@ -81,7 +65,7 @@ UINT8_marshal_buffer_null_offset_null (void **state)
     UINT8 src = 0x1a;
     TSS2_RC rc;
 
-    rc = UINT8_Marshal (&src, NULL, sizeof (src), NULL);
+    rc = UINT8_Marshal (src, NULL, sizeof (src), NULL);
 
     assert_int_equal (rc, TSS2_TYPES_RC_BAD_REFERENCE);
 }
@@ -97,7 +81,7 @@ UINT8_marshal_buffer_size_lt_data (void **state)
     size_t  offset = 2;
     TSS2_RC rc;
 
-    rc = UINT8_Marshal (&src, buffer, sizeof (src), &offset);
+    rc = UINT8_Marshal (src, buffer, sizeof (src), &offset);
 
     assert_int_equal (rc, TSS2_TYPES_RC_INSUFFICIENT_BUFFER);
     assert_int_equal (offset, 2);
@@ -115,7 +99,7 @@ UINT8_marshal_buffer_size_lt_offset (void **state)
     size_t  offset = sizeof (buffer) + 1;
     TSS2_RC rc;
 
-    rc = UINT8_Marshal (&src, buffer, buffer_size, &offset);
+    rc = UINT8_Marshal (src, buffer, buffer_size, &offset);
 
     assert_int_equal (rc, TSS2_TYPES_RC_INSUFFICIENT_BUFFER);
     assert_int_equal (offset, sizeof (buffer) + 1);
@@ -222,7 +206,6 @@ main (void)
     const UnitTest tests [] = {
         unit_test (UINT8_marshal_success),
         unit_test (UINT8_marshal_success_offset),
-        unit_test (UINT8_marshal_src_null),
         unit_test (UINT8_marshal_buffer_null_with_offset),
         unit_test (UINT8_marshal_buffer_null_offset_null),
         unit_test (UINT8_marshal_buffer_size_lt_data),


### PR DESCRIPTION
Passing these by reference made no sense and made using the functions
awkward (couldn't marshal constants).

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>