### PR TITLE
More flags fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,8 @@ depcomp
 install-sh
 libtool
 ltmain.sh
-m4/
+m4/libtool*
+m4/lt*.m4
 Makefile
 Makefile.in
 missing

--- a/configure.ac
+++ b/configure.ac
@@ -24,67 +24,19 @@ AS_IF([test "x$enable_unit" != xno],
                                     [1])])])
 AM_CONDITIONAL([UNIT], [test "x$enable_unit" != xno])
 
-dnl add_compiler_flag:
-dnl   A macro to add a CFLAG to the EXTRA_CFLAGS variable. This macro will
-dnl   check to be sure the compiler supprts the flag. Flags can be made
-dnl   mandatory (configure will fail).
-dnl $1: C compiler flag to add to EXTRA_CFLAGS.
-dnl $2: Set to "required" to cause configure failure if flag not supported..
-AC_DEFUN([add_compiler_flag],[
-    AX_CHECK_COMPILE_FLAG([$1],[
-        EXTRA_CFLAGS="$EXTRA_CFLAGS $1"],[
-        AS_IF([test x$2 != xrequired],[
-            AC_MSG_WARN([Optional CFLAG "$1" not supported by your compiler, continuing.])],[
-            AC_MSG_ERROR([Required CFLAG "$1" not supported by your compiler, aborting.])]
-        )]
-    )]
-)
-dnl add_preproc_flag
-dnl
-dnl $1: Preprocessor flag to add to EXTRA_CFLAGS.
-dnl $2: Set to "required" t ocause configure failure if preprocesor flag
-dnl     is not supported.
-AC_DEFUN([add_preproc_flag],[
-    AX_CHECK_PREPROC_FLAG([$1],[
-        EXTRA_CFLAGS="$EXTRA_CFLAGS $1"],[
-        AS_IF([test x$2 != xrequired],[
-            AC_MSG_WARN([Optional preprocessor flag "$1" not supported by your compiler, continuing.])],[
-            AC_MSG_ERROR([Required preprocessor flag "$1" not supported by your compiler, aborting.])]
-        )]
-    )]
-)
-dnl add_link_lag:
-dnl   A macro to add a LDLAG to the EXTRA_LDFLAGS variable. This macro will
-dnl   check to be sure the linker supprts the flag. Flags can be made
-dnl   mandatory (configure will fail).
-dnl $1: linker flag to add to EXTRA_LDFLAGS.
-dnl $2: Set to "required" to cause configure failure if flag not supported.
-AC_DEFUN([add_link_flag],[
-    AX_CHECK_LINK_FLAG([$1],[
-        EXTRA_CFLAGS="$EXTRA_LDFLAGS $1"],[
-        AS_IF([test x$2 != xrequired],[
-            AC_MSG_WARN([Optional LDFLAG "$1" not supported by your linker, continuing.])],[
-            AC_MSG_ERROR([Required LDFLAG "$1" not supported by your linker, aborting.])]
-        )]
-    )]
-)
-
-add_compiler_flag([-Wall])
-add_compiler_flag([-Werror])
-add_compiler_flag([-std=gnu99])
-add_compiler_flag([-Wformat])
-add_compiler_flag([-Wformat-security])
-add_compiler_flag([-fstack-protector-all])
-add_compiler_flag([-fpic])
-add_compiler_flag([-fPIC])
-add_preproc_flag([-D_FORTIFY_SOURCE=2])
-add_preproc_flag([-U_FORTIFY_SOURCE])
-add_link_flag([-Wl,--no-undefined])
-add_link_flag([-Wl,-z,noexecstack])
-add_link_flag([-Wl,-z,now])
-add_link_flag([-Wl,-z,relro])
-
-AC_SUBST([EXTRA_CFLAGS])
-AC_SUBST([EXTRA_LDFLAGS])
+AX_ADD_COMPILER_FLAG([-Wall])
+AX_ADD_COMPILER_FLAG([-Werror])
+AX_ADD_COMPILER_FLAG([-std=gnu99])
+AX_ADD_COMPILER_FLAG([-Wformat])
+AX_ADD_COMPILER_FLAG([-Wformat-security])
+AX_ADD_COMPILER_FLAG([-fstack-protector-all])
+AX_ADD_COMPILER_FLAG([-fpic])
+AX_ADD_COMPILER_FLAG([-fPIC])
+AX_ADD_PREPROC_FLAG([-D_FORTIFY_SOURCE=2])
+AX_ADD_PREPROC_FLAG([-U_FORTIFY_SOURCE])
+AX_ADD_LINK_FLAG([-Wl,--no-undefined])
+AX_ADD_LINK_FLAG([-Wl,-z,noexecstack])
+AX_ADD_LINK_FLAG([-Wl,-z,now])
+AX_ADD_LINK_FLAG([-Wl,-z,relro])
 
 AC_OUTPUT

--- a/m4/flags.m4
+++ b/m4/flags.m4
@@ -1,0 +1,50 @@
+dnl AX_ADD_COMPILER_FLAG:
+dnl   A macro to add a CFLAG to the EXTRA_CFLAGS variable. This macro will
+dnl   check to be sure the compiler supprts the flag. Flags can be made
+dnl   mandatory (configure will fail).
+dnl $1: C compiler flag to add to EXTRA_CFLAGS.
+dnl $2: Set to "required" to cause configure failure if flag not supported..
+AC_DEFUN([AX_ADD_COMPILER_FLAG],[
+    AX_CHECK_COMPILE_FLAG([$1],[
+        EXTRA_CFLAGS="$EXTRA_CFLAGS $1"
+        AC_SUBST([EXTRA_CFLAGS])],[
+        AS_IF([test x$2 != xrequired],[
+            AC_MSG_WARN([Optional CFLAG "$1" not supported by your compiler, continuing.])],[
+            AC_MSG_ERROR([Required CFLAG "$1" not supported by your compiler, aborting.])]
+        )]
+    )]
+)
+dnl AX_ADD_PREPROC_FLAG:
+dnl   Add the provided preprocessor flag to the EXTRA_CFLAGS variable. This
+dnl   macro will check to be sure the preprocessor supports the flag.
+dnl   The flag can be made mandatory by provideing the string 'required' as
+dnl   the second parameter.
+dnl $1: Preprocessor flag to add to EXTRA_CFLAGS.
+dnl $2: Set to "required" t ocause configure failure if preprocesor flag
+dnl     is not supported.
+AC_DEFUN([AX_ADD_PREPROC_FLAG],[
+    AX_CHECK_PREPROC_FLAG([$1],[
+        EXTRA_CFLAGS="$EXTRA_CFLAGS $1"
+        AC_SUBST([EXTRA_CFLAGS])],[
+        AS_IF([test x$2 != xrequired],[
+            AC_MSG_WARN([Optional preprocessor flag "$1" not supported by your compiler, continuing.])],[
+            AC_MSG_ERROR([Required preprocessor flag "$1" not supported by your compiler, aborting.])]
+        )]
+    )]
+)
+dnl AX_ADD_LINK_FLAG:
+dnl   A macro to add a LDLAG to the EXTRA_LDFLAGS variable. This macro will
+dnl   check to be sure the linker supprts the flag. Flags can be made
+dnl   mandatory (configure will fail).
+dnl $1: linker flag to add to EXTRA_LDFLAGS.
+dnl $2: Set to "required" to cause configure failure if flag not supported.
+AC_DEFUN([AX_ADD_LINK_FLAG],[
+    AX_CHECK_LINK_FLAG([$1],[
+        EXTRA_LDFLAGS="$EXTRA_LDFLAGS $1"
+        AC_SUBST([EXTRA_LDFLAGS])],[
+        AS_IF([test x$2 != xrequired],[
+            AC_MSG_WARN([Optional LDFLAG "$1" not supported by your linker, continuing.])],[
+            AC_MSG_ERROR([Required LDFLAG "$1" not supported by your linker, aborting.])]
+        )]
+    )]
+)

--- a/marshal/base-types.c
+++ b/marshal/base-types.c
@@ -26,6 +26,7 @@
 //**********************************************************************;
 
 #include <inttypes.h>
+#include <string.h>
 
 #include "sapi/marshal.h"
 #include "sapi/tpm20.h"
@@ -75,7 +76,8 @@ type##_Marshal ( \
          (uintptr_t)src, \
          (uintptr_t)buffer, \
          local_offset); \
-    CAST_TO_##type (&buffer [local_offset]) = marshal_func (*src); \
+    type tmp = marshal_func (*src); \
+    memcpy (&buffer [local_offset], &tmp, sizeof (tmp)); \
     if (offset != NULL) { \
         *offset = local_offset + sizeof (*src); \
         LOG (DEBUG, "offset parameter non-NULL, updated to %zu", *offset); \
@@ -127,7 +129,9 @@ type##_Unmarshal ( \
          (uintptr_t)buffer, \
          (uintptr_t)dest, \
          local_offset); \
-    *dest = unmarshal_func (CAST_TO_##type (&buffer [local_offset])); \
+    type tmp = 0; \
+    memcpy (&tmp, &buffer [local_offset], sizeof (tmp)); \
+    *dest = unmarshal_func (tmp); \
     if (offset != NULL) { \
         *offset = local_offset + sizeof (*dest); \
         LOG (DEBUG, "offset parameter non-NULL, updated to %zu", *offset); \

--- a/marshal/base-types.h
+++ b/marshal/base-types.h
@@ -30,17 +30,6 @@
 
 #include "sapi/tpm20.h"
 
-#define CAST_TO_TYPE(ptr, type) (*(type*)ptr)
-#define CAST_TO_BYTE(ptr)       CAST_TO_TYPE(ptr, BYTE)
-#define CAST_TO_INT8(ptr)       CAST_TO_TYPE(ptr, INT8)
-#define CAST_TO_INT16(ptr)      CAST_TO_TYPE(ptr, INT16)
-#define CAST_TO_INT32(ptr)      CAST_TO_TYPE(ptr, INT32)
-#define CAST_TO_INT64(ptr)      CAST_TO_TYPE(ptr, INT64)
-#define CAST_TO_UINT8(ptr)      CAST_TO_TYPE(ptr, UINT8)
-#define CAST_TO_UINT16(ptr)     CAST_TO_TYPE(ptr, UINT16)
-#define CAST_TO_UINT32(ptr)     CAST_TO_TYPE(ptr, UINT32)
-#define CAST_TO_UINT64(ptr)     CAST_TO_TYPE(ptr, UINT64)
-
 /*
  * These no-op functions are used on big endian (BE) systems for the host
  * to / from BE macros. We need them so that we have a valid function
@@ -81,5 +70,4 @@ UINT64 endian_conv_64 (UINT64 value);
 #define BE_TO_HOST_32(value) endian_conv_32 (value)
 #define BE_TO_HOST_64(value) endian_conv_64 (value)
 #endif /* WORDS_BIGENDIAN */
-
 #endif /* BASE_TYPES_H  */

--- a/resourcemgr/resourcemgr.c
+++ b/resourcemgr/resourcemgr.c
@@ -32,7 +32,7 @@
 #include "sapi/tpm20.h"
 #include "tcti/tcti_device.h"
 #include "tcti/tcti_socket.h"
-#include "tcti_util.h"
+#include "common/tcti_util.h"
 #include "resourcemgr.h"
 //#include <sample.h>
 #include "common/sockets.h"
@@ -2287,7 +2287,7 @@ UINT8 TpmCmdServer( SERVER_STRUCT *serverStruct )
     fd_set readFds;
     int iResult;
     char functionString[sizeof( MUTEX_DBG_FUNCTION_STR ) + 1 ];
-    UINT8 criticalSectionEntered;
+    UINT8 criticalSectionEntered = 0;
 
     // buffer to hold TPM command from client
     UINT8 *cmdBuffer;

--- a/test/tpmclient/tpmclient.c
+++ b/test/tpmclient/tpmclient.c
@@ -48,7 +48,7 @@
 #include "test/common/sample/sample.h"
 #include "resourcemgr/resourcemgr.h"
 #include "tpmclient.h"
-#include "tcti_util.h"
+#include "common/tcti_util.h"
 
 // This is done to allow the tests to access fields
 // in the sysContext structure that are needed for

--- a/test/unit/UINT32-marshal.c
+++ b/test/unit/UINT32-marshal.c
@@ -13,15 +13,16 @@
 void
 UINT32_marshal_success (void **state)
 {
-    UINT32   src = 0xdeadbeef;
+    UINT32   src = 0xdeadbeef, tmp = 0;
     uint8_t buffer [4] = { 0 };
     size_t  buffer_size = sizeof (buffer);
     TSS2_RC rc;
 
     rc = UINT32_Marshal (&src, buffer, buffer_size, NULL);
 
+    tmp = HOST_TO_BE_32 (src);
     assert_int_equal (rc, TSS2_RC_SUCCESS);
-    assert_int_equal (HOST_TO_BE_32 (src), CAST_TO_UINT32 (&buffer [0]));
+    assert_memory_equal (&tmp, buffer, sizeof (tmp));
 }
 /*
  * Test case for successful UINT32 marshaling with offset.
@@ -29,16 +30,17 @@ UINT32_marshal_success (void **state)
 void
 UINT32_marshal_success_offset (void **state)
 {
-    UINT32 src = 0xdeadbeef;
+    UINT32 src = 0xdeadbeef, tmp = 0;
     uint8_t buffer [5] = { 0 };
     size_t  buffer_size = sizeof (buffer);
     size_t  offset = 1;
     TSS2_RC rc;
 
     rc = UINT32_Marshal (&src, buffer, buffer_size, &offset);
+    tmp = HOST_TO_BE_32 (src);
 
     assert_int_equal (rc, TSS2_RC_SUCCESS);
-    assert_int_equal (HOST_TO_BE_32 (src), CAST_TO_UINT32 (&buffer [1]));
+    assert_memory_equal (&tmp, &buffer [1], sizeof (tmp));
     assert_int_equal (offset, sizeof (buffer));
 }
 /*
@@ -129,13 +131,14 @@ UINT32_unmarshal_success (void **state)
 {
     uint8_t buffer [4] = { 0xde, 0xad, 0xbe, 0xef };
     uint8_t buffer_size = sizeof (buffer);
-    UINT32   dest = 0;
+    UINT32   dest = 0, tmp = 0;
     TSS2_RC rc;
 
     rc = UINT32_Unmarshal (buffer, buffer_size, NULL, &dest);
+    tmp = HOST_TO_BE_32 (dest);
 
     assert_int_equal (rc, TSS2_RC_SUCCESS);
-    assert_int_equal (HOST_TO_BE_32 (dest), CAST_TO_UINT32 (buffer));
+    assert_memory_equal (&tmp, buffer, sizeof (tmp));
 }
 /*
  * Test case for successful UINT32 unmarshaling with offset.
@@ -143,16 +146,17 @@ UINT32_unmarshal_success (void **state)
 void
 UINT32_unmarshal_success_offset (void **state)
 {
-    UINT32   dest = 0;
+    UINT32   dest = 0, tmp = 0;
     uint8_t buffer [5] = { 0xff, 0xde, 0xad, 0xbe, 0xef };
     size_t  buffer_size = sizeof (buffer);
     size_t  offset = 1;
     TSS2_RC rc;
 
     rc = UINT32_Unmarshal (buffer, buffer_size, &offset, &dest);
+    tmp = HOST_TO_BE_32 (dest);
 
     assert_int_equal (rc, TSS2_RC_SUCCESS);
-    assert_int_equal (HOST_TO_BE_32 (dest), CAST_TO_UINT32 (&buffer [1]));
+    assert_memory_equal (&tmp, &buffer [1], sizeof (tmp));
     assert_int_equal (offset, 5);
 }
 /*

--- a/test/unit/UINT64-marshal.c
+++ b/test/unit/UINT64-marshal.c
@@ -13,15 +13,16 @@
 void
 UINT64_marshal_success (void **state)
 {
-    UINT64   src = 0xdeadbeefdeadbeef;
+    UINT64   src = 0xdeadbeefdeadbeef, tmp;
     uint8_t buffer [8] = { 0 };
     size_t  buffer_size = sizeof (buffer);
     TSS2_RC rc;
 
     rc = UINT64_Marshal (&src, buffer, buffer_size, NULL);
+    tmp = HOST_TO_BE_64 (src);
 
     assert_int_equal (rc, TSS2_RC_SUCCESS);
-    assert_int_equal (HOST_TO_BE_64 (src), CAST_TO_UINT64 (&buffer [0]));
+    assert_memory_equal (&tmp, &buffer [0], sizeof (tmp));
 }
 /*
  * Test case for successful UINT64 marshaling with offset.
@@ -29,16 +30,17 @@ UINT64_marshal_success (void **state)
 void
 UINT64_marshal_success_offset (void **state)
 {
-    UINT64 src = 0xdeadbeefdeadbeef;
+    UINT64 src = 0xdeadbeefdeadbeef, tmp = 0;
     uint8_t buffer [9] = { 0 };
     size_t  buffer_size = sizeof (buffer);
     size_t  offset = 1;
     TSS2_RC rc;
 
     rc = UINT64_Marshal (&src, buffer, buffer_size, &offset);
+    tmp = HOST_TO_BE_64 (src);
 
     assert_int_equal (rc, TSS2_RC_SUCCESS);
-    assert_int_equal (HOST_TO_BE_64 (src), CAST_TO_UINT64 (&buffer [1]));
+    assert_memory_equal (&tmp, &buffer [1], sizeof (tmp));
     assert_int_equal (offset, sizeof (buffer));
 }
 /*
@@ -129,13 +131,14 @@ UINT64_unmarshal_success (void **state)
 {
     uint8_t buffer [8] = { 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef };
     uint8_t buffer_size = sizeof (buffer);
-    UINT64   dest = 0;
+    UINT64   dest = 0, tmp = 0;
     TSS2_RC rc;
 
     rc = UINT64_Unmarshal (buffer, buffer_size, NULL, &dest);
+    tmp = HOST_TO_BE_64 (dest);
 
     assert_int_equal (rc, TSS2_RC_SUCCESS);
-    assert_int_equal (HOST_TO_BE_64 (dest), CAST_TO_UINT64 (buffer));
+    assert_memory_equal (&tmp, buffer, sizeof (tmp));
 }
 /*
  * Test case for successful UINT64 unmarshaling with offset.
@@ -143,16 +146,17 @@ UINT64_unmarshal_success (void **state)
 void
 UINT64_unmarshal_success_offset (void **state)
 {
-    UINT64   dest = 0;
+    UINT64   dest = 0, tmp = 0;
     uint8_t buffer [9] = { 0xff, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef };
     size_t  buffer_size = sizeof (buffer);
     size_t  offset = 1;
     TSS2_RC rc;
 
     rc = UINT64_Unmarshal (buffer, buffer_size, &offset, &dest);
+    tmp = HOST_TO_BE_64 (dest);
 
     assert_int_equal (rc, TSS2_RC_SUCCESS);
-    assert_int_equal (HOST_TO_BE_64 (dest), CAST_TO_UINT64 (&buffer [1]));
+    assert_memory_equal (&tmp, &buffer [1], sizeof (tmp));
     assert_int_equal (offset, 9);
 }
 /*


### PR DESCRIPTION
This also includes a fix for a type-punning issue. The CAST_TO_* macros were a convenient way to convert from a primitive type to a byte array. But as we're dialing up the hardening of the compiler / preprocessor / linker flags GCC gets increasingly strict about things like aliasing. Using `memcpy` is the right way to do this regardless.

Note to future self: enable these flags before you write a single line of code.