### PR TITLE
test: Add integration test for Tss2_Sys_StartAuthSession.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,8 @@ missing
 NVChip
 src_vars.mk
 resourcemgr/resourcemgr
+test/integration/*
+!test/integration/*.[ch]
 test/integration/get-random
 test/integration/self-test
 test/integration/pcr-extension

--- a/Makefile.am
+++ b/Makefile.am
@@ -59,7 +59,8 @@ TESTS_INTEGRATION = \
     test/integration/get-random \
     test/integration/self-test \
     test/integration/pcr-extension \
-    test/integration/asymmetric-encrypt-decrypt
+    test/integration/asymmetric-encrypt-decrypt \
+    test/integration/start-auth-session
 
 TESTS = $(check_PROGRAMS)
 CLEANFILES = $(nodist_pkgconfig_DATA)
@@ -169,6 +170,10 @@ test_integration_get_random_SOURCES = test/integration/get-random.c \
 test_integration_self_test_LDADD   = $(TESTS_LDADD)
 test_integration_self_test_SOURCES = test/integration/self-test.c \
     test/integration/main.c
+
+test_integration_start_auth_session_LDADD = $(TESTS_LDADD)
+test_integration_start_auth_session_SOURCES = test/integration/main.c \
+    test/integration/start-auth-session.c
 
 test_integration_pcr_extension_LDADD   = $(TESTS_LDADD)
 test_integration_pcr_extension_SOURCES = test/integration/pcr-extension.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -81,8 +81,10 @@ nodist_pkgconfig_DATA = lib/sapi.pc lib/tcti-device.pc lib/tcti-socket.pc
 
 if UNIT
 test_unit_tcti_device_CFLAGS  = $(CMOCKA_CFLAGS) $(AM_CFLAGS)
-test_unit_tcti_device_LDADD   = $(libsapi) $(libtcti_device) $(CMOCKA_LIBS)
-test_unit_tcti_device_SOURCES = test/unit/tcti-device.c
+test_unit_tcti_device_LDADD   = $(CMOCKA_LIBS) $(libmarshal)
+test_unit_tcti_device_LDFLAGS = -Wl,--wrap=read -Wl,-wrap=write
+test_unit_tcti_device_SOURCES = tcti/commonchecks.c tcti/tcti_device.c \
+    test/unit/tcti-device.c
 
 test_unit_getcommands_malloc_mock_CFLAGS  = $(CMOCKA_CFLAGS) $(AM_CFLAGS)
 test_unit_getcommands_malloc_mock_LDADD   = $(CMOCKA_LIBS)

--- a/configure.ac
+++ b/configure.ac
@@ -39,4 +39,8 @@ AX_ADD_LINK_FLAG([-Wl,-z,noexecstack])
 AX_ADD_LINK_FLAG([-Wl,-z,now])
 AX_ADD_LINK_FLAG([-Wl,-z,relro])
 
+# work around GCC bug #53119
+#   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53119
+AX_ADD_COMPILER_FLAG([-Wno-missing-braces])
+
 AC_OUTPUT

--- a/test/integration/start-auth-session.c
+++ b/test/integration/start-auth-session.c
@@ -1,0 +1,66 @@
+#include <inttypes.h>
+#include <stdio.h>
+
+#include "sapi/tpm20.h"
+
+#include "log.h"
+#include "test.h"
+/*
+ * This is an incredibly simple test to create the most simple session
+ * (which ends up being a trial policy) and then just tear it down.
+ */
+int
+test_invoke (TSS2_SYS_CONTEXT *sapi_context)
+{
+    TSS2_RC rc;
+    TPM2B_NONCE nonce_caller = {
+        .t = {
+            .size   = SHA256_DIGEST_SIZE,
+            .buffer = {
+                0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef,
+                0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef,
+                0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef,
+                0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef
+            }
+        }
+    };
+    TPM2B_NONCE nonce_tpm = {
+        .t = {
+            .size   = SHA256_DIGEST_SIZE,
+            .buffer = { 0 }
+        }
+    };
+    TPM2B_ENCRYPTED_SECRET encrypted_salt = { 0 };
+    TPMI_SH_AUTH_SESSION   session_handle = 0;
+    TPMT_SYM_DEF           symmetric      = { .algorithm = TPM_ALG_NULL };
+
+    print_log ("StartAuthSession for TPM_SE_POLICY (policy session)");
+    rc = Tss2_Sys_StartAuthSession (sapi_context,
+                                    TPM_RH_NULL,     /* tpmKey */
+                                    TPM_RH_NULL,     /* bind */
+                                    0,               /* cmdAuthsArray */
+                                    &nonce_caller,   /* nonceCaller */
+                                    &encrypted_salt, /* encryptedSalt */
+                                    TPM_SE_POLICY,   /* sessionType */
+                                    &symmetric,      /* symmetric */
+                                    TPM_ALG_SHA256,  /* authHash */
+                                    &session_handle, /* sessionHandle */
+                                    &nonce_tpm,      /* nonceTPM */
+                                    0                /* rspAuthsArray */
+                                    );
+    if (rc != TSS2_RC_SUCCESS)
+        print_fail ("Tss2_Sys_StartAuthSession failed: 0x%" PRIx32, rc);
+    print_log ("StartAuthSession for TPM_SE_POLICY success! Session handle: "
+               "0x%" PRIx32, session_handle);
+    /*
+     * Clean out the session we've created. Would be nice if we didn't have
+     * to do this ...
+     */
+    rc = Tss2_Sys_FlushContext (sapi_context, session_handle);
+    if (rc != TSS2_RC_SUCCESS)
+        print_fail ("Tss2_Sys_FlushContext failed: 0x%" PRIx32, rc);
+    print_log ("Flushed context for session handle: 0x%" PRIx32 " success!",
+               session_handle);
+
+    return 0;
+}


### PR DESCRIPTION
Currently this is a simple test that should execute successfully. Would
be good to get more including failure conditions.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>