### PR TITLE
Rsp header save

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -154,7 +154,7 @@ tcti_libtcti_socket_la_SOURCES  = tcti/platformcommand.c tcti/tcti_socket.c \
     sysapi/sysapi_util/changeEndian.c tcti/commonchecks.c common/sockets.c \
     common/debug.c
 
-test_tpmclient_tpmclient_LDADD    = $(libsapi) $(libtcti_socket) $(libtcti_device)
+test_tpmclient_tpmclient_LDADD    = $(libsapi) $(libtcti_socket) $(libtcti_device) $(libmarshal)
 test_tpmclient_tpmclient_SOURCES  = test/tpmclient/tpmclient.c $(COMMON_C) $(SAMPLE_C)
 
 test_tpmtest_tpmtest_LDADD    = $(libsapi) $(libtcti_socket) $(libtcti_device)

--- a/sysapi/include/sysapi_util.h
+++ b/sysapi/include/sysapi_util.h
@@ -41,6 +41,12 @@ extern "C" {
 enum cmdStates { CMD_STAGE_INITIALIZE, CMD_STAGE_PREPARE, CMD_STAGE_SEND_COMMAND, CMD_STAGE_RECEIVE_RESPONSE, CMD_STAGE_ALL = 0xff };
 
 typedef struct {
+  TPM_ST  tag;
+  UINT32  size;
+  TPM_RC  rsp_code;
+} TPM20_Rsp_Header;
+
+typedef struct {
     //
     // These are inputs to system API functions.
     //
@@ -51,6 +57,8 @@ typedef struct {
     UINT32 maxCommandSize;          // Input: max size of command buffer area
     UINT8 *tpmOutBuffPtr;           // Input: Pointer to response buffer
     UINT32 maxResponseSize;         // Input: max size of response buffer area
+
+    TPM20_Rsp_Header rsp_header;
 
     //
     // These are set by system API and used by helper functions to calculate cpHash,
@@ -63,7 +71,6 @@ typedef struct {
     UINT32 rpBufferUsedSize;
     UINT8 *rpBuffer;
     UINT8 previousStage;            // Used to check for sequencing errors.
-    TPM_RC responseCode;
     UINT8 authsCount;
     UINT8 numResponseHandles;
     struct
@@ -119,18 +126,6 @@ typedef struct _TPM20_ErrorResponse {
   UINT32 responseSize;
   UINT32 responseCode;
 } TPM20_ErrorResponse;
-
-typedef struct {
-  TPM_ST tag;
-  UINT32 commandSize;
-  UINT32 commandCode;
-} TPM20_Cmd_Header;
-
-typedef struct {
-  TPM_ST tag;
-  UINT32 responseSize;
-  UINT32 responseCode;
-} TPM20_Rsp_Header;
 
 #pragma pack(pop)
 

--- a/sysapi/sysapi/authorizations.c
+++ b/sysapi/sysapi/authorizations.c
@@ -25,6 +25,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 //**********************************************************************;
 
+#include "marshal/base-types.h"
 #include "sapi/tpm20.h"
 #include "sysapi_util.h"
 
@@ -177,33 +178,33 @@ TSS2_RC Tss2_Sys_GetRspAuths(
 
                 otherDataSaved = otherData;
 
-                if( TPM_ST_SESSIONS == CHANGE_ENDIAN_WORD( ( (TPM20_Header_Out *)( SYS_CONTEXT->tpmOutBuffPtr ) )->tag ) )
+                if( TPM_ST_SESSIONS == SYS_CONTEXT->rsp_header.tag )
                 {
                     for( i = 0; i < rspAuthsArray->rspAuthsCount; i++ )
                     {
                         // Before copying, make sure that we aren't going to go past the output buffer + the response size.
-                        if( (UINT8 *)otherData > ( SYS_CONTEXT->tpmOutBuffPtr + CHANGE_ENDIAN_DWORD( ( (TPM20_Header_Out *)( SYS_CONTEXT->tpmOutBuffPtr ) )->responseSize ) ) )
+                        if( (UINT8 *)otherData > ( SYS_CONTEXT->tpmOutBuffPtr + SYS_CONTEXT->rsp_header.size) )
                         {
                             rval = TSS2_SYS_RC_MALFORMED_RESPONSE;
                             break;
                         }
 
                         otherData = (UINT8 *)otherData + sizeof( UINT16 ) + CHANGE_ENDIAN_WORD( *(UINT16 *)otherData ); // Nonce
-                        if( (UINT8 *)otherData > ( SYS_CONTEXT->tpmOutBuffPtr + CHANGE_ENDIAN_DWORD( ( (TPM20_Header_Out *)( SYS_CONTEXT->tpmOutBuffPtr ) )->responseSize ) ) )
+                        if( (UINT8 *)otherData > ( SYS_CONTEXT->tpmOutBuffPtr + SYS_CONTEXT->rsp_header.size) )
                         {
                             rval = TSS2_SYS_RC_MALFORMED_RESPONSE;
                             break;
                         }
 
                         otherData = (UINT8 *)otherData + 1;  // session attributes.
-                        if( (UINT8 *)otherData > ( SYS_CONTEXT->tpmOutBuffPtr + CHANGE_ENDIAN_DWORD( ( (TPM20_Header_Out *)( SYS_CONTEXT->tpmOutBuffPtr ) )->responseSize ) ) )
+                        if( (UINT8 *)otherData > ( SYS_CONTEXT->tpmOutBuffPtr + SYS_CONTEXT->rsp_header.size) )
                         {
                             rval = TSS2_SYS_RC_MALFORMED_RESPONSE;
                             break;
                         }
 
                         otherData = (UINT8 *)otherData + sizeof( UINT16 ) + CHANGE_ENDIAN_WORD( *(UINT16 *)otherData ); // hmac
-                        if( (UINT8 *)otherData > ( SYS_CONTEXT->tpmOutBuffPtr + CHANGE_ENDIAN_DWORD( ( (TPM20_Header_Out *)( SYS_CONTEXT->tpmOutBuffPtr ) )->responseSize ) ) )
+                        if( (UINT8 *)otherData > ( SYS_CONTEXT->tpmOutBuffPtr + SYS_CONTEXT->rsp_header.size) )
                         {
                             rval = TSS2_SYS_RC_MALFORMED_RESPONSE;
                             break;
@@ -230,7 +231,7 @@ TSS2_RC Tss2_Sys_GetRspAuths(
                             // Get start of authorization area.
                             otherData = otherDataSaved;
                             rval = CopySessionsDataOut( rspAuthsArray, otherData,
-                                    CHANGE_ENDIAN_WORD( ( (TPM20_Header_Out *)( SYS_CONTEXT->tpmOutBuffPtr ) )->tag ),
+                                    SYS_CONTEXT->rsp_header.tag,
                                     SYS_CONTEXT->tpmOutBuffPtr, SYS_CONTEXT->maxResponseSize );
                         }
                     }

--- a/sysapi/sysapi/authorizations.c
+++ b/sysapi/sysapi/authorizations.c
@@ -67,7 +67,7 @@ TSS2_RC Tss2_Sys_SetCmdAuths(
             if( cmdAuthsArray->cmdAuthsCount > 0 )
             {
                 // Change command tag.
-                ( (TPM20_Header_In *)( SYS_CONTEXT->tpmInBuffPtr ) )->tag = CHANGE_ENDIAN_WORD( TPM_ST_SESSIONS );
+                ( (TPM20_Header_In *)( SYS_CONTEXT->tpmInBuffPtr ) )->tag = HOST_TO_BE_16( TPM_ST_SESSIONS );
 
                 // Calculate size needed for authorization area
                 // and check for any null pointers.
@@ -97,7 +97,7 @@ TSS2_RC Tss2_Sys_SetCmdAuths(
                 if( rval == TSS2_RC_SUCCESS )
                 {
                     authSize += sizeof( UINT32 ); // authorization size field
-                    newCmdSize = (UINT64)authSize + (UINT64)CHANGE_ENDIAN_DWORD( ( (TPM20_Header_In *)( SYS_CONTEXT->tpmInBuffPtr ) )->commandSize );
+                    newCmdSize = (UINT64)authSize + (UINT64)BE_TO_HOST_32( ( (TPM20_Header_In *)( SYS_CONTEXT->tpmInBuffPtr ) )->commandSize );
 
                     if( newCmdSize > (UINT64)( SYS_CONTEXT->maxCommandSize ) )
                     {
@@ -121,7 +121,7 @@ TSS2_RC Tss2_Sys_SetCmdAuths(
                             SYS_CONTEXT->cpBuffer += authSize;
 
                             // Now update the command size.
-                            ( (TPM20_Header_In *)( SYS_CONTEXT->tpmInBuffPtr ) )->commandSize = CHANGE_ENDIAN_DWORD( (UINT32)newCmdSize );
+                            ( (TPM20_Header_In *)( SYS_CONTEXT->tpmInBuffPtr ) )->commandSize = HOST_TO_BE_32( (UINT32)newCmdSize );
 
                             SYS_CONTEXT->authsCount = cmdAuthsArray->cmdAuthsCount;
                         }
@@ -173,7 +173,7 @@ TSS2_RC Tss2_Sys_GetRspAuths(
                 otherData = SYS_CONTEXT->tpmOutBuffPtr;
                 otherData = (UINT8 *)otherData + sizeof( TPM20_Header_Out ) - 1;
                 otherData = (UINT8 *)otherData + SYS_CONTEXT->numResponseHandles * sizeof( TPM_HANDLE );
-                otherData = (UINT8 *)otherData + CHANGE_ENDIAN_DWORD( *( SYS_CONTEXT->rspParamsSize ) );
+                otherData = (UINT8 *)otherData + BE_TO_HOST_32( *( SYS_CONTEXT->rspParamsSize ) );
                 otherData = (UINT8 *)otherData + sizeof( UINT32 );
 
                 otherDataSaved = otherData;
@@ -189,7 +189,7 @@ TSS2_RC Tss2_Sys_GetRspAuths(
                             break;
                         }
 
-                        otherData = (UINT8 *)otherData + sizeof( UINT16 ) + CHANGE_ENDIAN_WORD( *(UINT16 *)otherData ); // Nonce
+                        otherData = (UINT8 *)otherData + sizeof( UINT16 ) + BE_TO_HOST_16( *(UINT16 *)otherData ); // Nonce
                         if( (UINT8 *)otherData > ( SYS_CONTEXT->tpmOutBuffPtr + SYS_CONTEXT->rsp_header.size) )
                         {
                             rval = TSS2_SYS_RC_MALFORMED_RESPONSE;
@@ -203,7 +203,7 @@ TSS2_RC Tss2_Sys_GetRspAuths(
                             break;
                         }
 
-                        otherData = (UINT8 *)otherData + sizeof( UINT16 ) + CHANGE_ENDIAN_WORD( *(UINT16 *)otherData ); // hmac
+                        otherData = (UINT8 *)otherData + sizeof( UINT16 ) + BE_TO_HOST_16( *(UINT16 *)otherData ); // hmac
                         if( (UINT8 *)otherData > ( SYS_CONTEXT->tpmOutBuffPtr + SYS_CONTEXT->rsp_header.size) )
                         {
                             rval = TSS2_SYS_RC_MALFORMED_RESPONSE;

--- a/sysapi/sysapi/authorizations.c
+++ b/sysapi/sysapi/authorizations.c
@@ -145,7 +145,7 @@ TSS2_RC Tss2_Sys_GetRspAuths(
         rval = TSS2_SYS_RC_BAD_REFERENCE;
     }
     else if( SYS_CONTEXT->previousStage != CMD_STAGE_RECEIVE_RESPONSE ||
-            CHANGE_ENDIAN_DWORD( ( (TPM20_Header_Out *)( SYS_CONTEXT->tpmOutBuffPtr ) )->responseCode ) != TPM_RC_SUCCESS ||
+             SYS_CONTEXT->rsp_header.rsp_code != TPM_RC_SUCCESS ||
             SYS_CONTEXT->authAllowed == 0 )
     {
         rval = TSS2_SYS_RC_BAD_SEQUENCE;

--- a/sysapi/sysapi/execute.c
+++ b/sysapi/sysapi/execute.c
@@ -113,18 +113,17 @@ TSS2_RC Tss2_Sys_ExecuteFinish(
                               &SYS_CONTEXT->nextData,
                               &SYS_CONTEXT->rsp_header.size,
                               &(SYS_CONTEXT->rval) );
-
+            Unmarshal_UINT32 (SYS_CONTEXT->tpmOutBuffPtr,
+                              SYS_CONTEXT->maxCommandSize,
+                              &SYS_CONTEXT->nextData,
+                              &SYS_CONTEXT->rsp_header.rsp_code,
+                              &SYS_CONTEXT->rval);
             if (SYS_CONTEXT->rsp_header.size < sizeof(TPM20_Header_Out) - 1)
             {
                 rval = SYS_CONTEXT->rval = TSS2_SYS_RC_INSUFFICIENT_RESPONSE;
             }
             else
             {
-                Unmarshal_UINT32 (SYS_CONTEXT->tpmOutBuffPtr,
-                                  SYS_CONTEXT->maxCommandSize,
-                                  &SYS_CONTEXT->nextData,
-                                  &SYS_CONTEXT->rsp_header.rsp_code,
-                                  &SYS_CONTEXT->rval);
                 if (SYS_CONTEXT->rsp_header.rsp_code == TSS2_RC_SUCCESS) {
                     if( SYS_CONTEXT->rval != TPM_RC_SUCCESS )
                     {

--- a/sysapi/sysapi_util/CommandUtil.c
+++ b/sysapi/sysapi_util/CommandUtil.c
@@ -255,7 +255,7 @@ TSS2_RC CommonOneCall(
 
         if ( SYS_CONTEXT->rval == TSS2_RC_SUCCESS )
         {
-            if( SYS_CONTEXT->responseCode == TPM_RC_SUCCESS )
+            if( SYS_CONTEXT->rsp_header.rsp_code == TPM_RC_SUCCESS )
             {
                 if( CHANGE_ENDIAN_WORD( ( (TPM20_Header_Out *)( SYS_CONTEXT->tpmOutBuffPtr )  )->tag ) == TPM_ST_SESSIONS &&
                         rspAuthsArray != 0 )


### PR DESCRIPTION
First steps toward simplifying the response processing path. These commits add a response header structure to the context to persist the unmarshalled response header. This keeps later code processing the response from having to do a bunch of redundant casting / unmarshalling. 