### PR TITLE
configure: Remove check for C++ compiler.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,6 @@ m4_define([tpm20_version_string], [tpm20_major_version.tpm20_minor_version])
 AC_INIT([tpm2.0-tss], [tpm20_version_string])
 AC_CONFIG_MACRO_DIR([m4])
 AC_PROG_CC
-AC_PROG_CXX
 LT_INIT()
 AC_C_BIGENDIAN
 AX_PTHREAD([], [AC_MSG_ERROR([requires pthread])])


### PR DESCRIPTION
This should have been removed when all cpp files were converted to c.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>