### PR TITLE
Makefile.am: Add missing dependency to libmarshal

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -157,7 +157,7 @@ tcti_libtcti_socket_la_SOURCES  = tcti/platformcommand.c tcti/tcti_socket.c \
 test_tpmclient_tpmclient_LDADD    = $(libsapi) $(libtcti_socket) $(libtcti_device) $(libmarshal)
 test_tpmclient_tpmclient_SOURCES  = test/tpmclient/tpmclient.c $(COMMON_C) $(SAMPLE_C)
 
-test_tpmtest_tpmtest_LDADD    = $(libsapi) $(libtcti_socket) $(libtcti_device)
+test_tpmtest_tpmtest_LDADD    = $(libsapi) $(libtcti_socket) $(libtcti_device) $(libmarshal)
 test_tpmtest_tpmtest_SOURCES  = test/tpmtest/tpmtest.c $(COMMON_C) $(SAMPLE_C)
 
 test_integration_libtest_utils_la_SOURCES = test/integration/test-options.c \


### PR DESCRIPTION
Without this fix, when cross-compiling for ARMv7, ld complains
`warning: libmarshal.so.0, needed by sysapi/.libs/libsapi.so, not found (try using -rpath or -rpath-link)`
and subsequently fails to build because of undefined references to the marshal functions.