### PR TITLE
Check for not-implemented commands in "tpmtest"

### DIFF
--- a/test/tpmtest/tpmtest.c
+++ b/test/tpmtest/tpmtest.c
@@ -88,6 +88,8 @@
 TPM_CC currentCommandCode;
 TPM_CC *currentCommandCodePtr = &currentCommandCode;
 
+TPML_CCA *supportedCommands;
+
 //----
 //char errorString[200];
 //----
@@ -458,6 +460,95 @@ void GetTpmVersion()
     }
 }
 
+// Get the TPM 2.0 commands supported by the TPM.
+TSS2_RC GetCommands( TSS2_SYS_CONTEXT *resMgrSysContext, TPML_CCA **supportedCommands )
+{
+    UINT32 numCommands;
+    TPMI_YES_NO moreData;
+    TPMS_CAPABILITY_DATA capabilityData;
+    TPMA_CC *commandPtr;
+    TSS2_RC rval = TSS2_RC_SUCCESS;
+    UINT32 i;
+
+    // First get the number of commands
+    rval = Tss2_Sys_GetCapability( resMgrSysContext, 0,
+            TPM_CAP_TPM_PROPERTIES, TPM_PT_TOTAL_COMMANDS,
+            1, 0, &capabilityData, 0 );
+    if( rval == TPM_RC_SUCCESS &&
+            capabilityData.capability == TPM_CAP_TPM_PROPERTIES &&
+            capabilityData.data.tpmProperties.count == 1 &&
+            capabilityData.data.tpmProperties.tpmProperty[0].property == TPM_PT_TOTAL_COMMANDS )
+    {
+        numCommands = capabilityData.data.tpmProperties.tpmProperty[0].value;
+    }
+    else
+    {
+        goto returnFromGetCommands;
+    }
+
+    // Allocate memory for them
+    *supportedCommands = (TPML_CCA *)malloc( numCommands * sizeof( TPMA_CC ) + sizeof( UINT32 ) );
+    if( !*supportedCommands )
+    {
+        rval = TSS2_BASE_RC_INSUFFICIENT_BUFFER + TSS2_RESMGR_ERROR_LEVEL;
+        goto returnFromGetCommands;
+    }
+
+    for( commandPtr = &( ( *supportedCommands )->commandAttributes[0] ), ( *supportedCommands )->count = 0;
+            ( *supportedCommands )->count < numCommands;
+            ( *supportedCommands )->count += capabilityData.data.command.count,
+                    commandPtr += capabilityData.data.command.count )
+    {
+        // Now get the command structures for all of them.
+        rval = Tss2_Sys_GetCapability( resMgrSysContext, 0,
+                TPM_CAP_COMMANDS, TPM_CC_FIRST,
+                numCommands, &moreData, &capabilityData, 0 );
+
+        if( rval == TPM_RC_SUCCESS &&
+                capabilityData.capability == TPM_CAP_COMMANDS  &&
+                capabilityData.data.command.count >= 1 )
+        {
+            for( i = 0; i < capabilityData.data.command.count; i ++ )
+            {
+                commandPtr[ ( *supportedCommands )->count + i ].val =
+                        capabilityData.data.command.commandAttributes[i].val;
+            }
+        }
+        else
+        {
+            break;
+        }
+    }
+
+returnFromGetCommands:
+    return rval;
+}
+
+//
+// Searches in a list for command attributes bit field for a command code.
+// Assumes that the supportedCommands structure has been populated by
+// calling GetCommands beforehand.
+//
+// Returns:
+//  1, if found.
+//  0, if not found.  This means that the TPM doesn't support this command.
+//
+UINT8 IsCommandImpl( TPM_CC commandCode, TPML_CCA *supportedCommands )
+{
+    UINT32 i;
+    UINT8 rval = 0;
+
+    for( i = 0; i < supportedCommands->count; i++ )
+    {
+        if( (TPM_CC)( supportedCommands->commandAttributes[i].commandIndex ) == commandCode )
+        {
+            rval = 1;
+			break;
+        }
+    }
+
+    return rval;
+}
 
 void TestDictionaryAttackLockReset()
 {
@@ -1045,6 +1136,12 @@ void TestChangeEps()
 
     printf( "\nCHANGE_EPS TESTS:\n" );
 
+    if (0 == IsCommandImpl( TPM_CC_ChangeEPS, supportedCommands ))
+    {
+        printf("Command TPM_CC_ChangeEPS not supported");
+        return;
+    }
+
 	sessionsData.cmdAuthsCount = 1;
 
     // Init authHandle
@@ -1090,6 +1187,12 @@ void TestChangePps()
     sessionsDataOut.rspAuthsCount = 1;
 
     printf( "\nCHANGE_PPS TESTS:\n" );
+
+    if (0 == IsCommandImpl( TPM_CC_ChangePPS, supportedCommands ))
+    {
+        printf("Command TPM_CC_ChangePPS not supported");
+        return;
+    }
 
     sessionsData.cmdAuthsCount = 1;
 
@@ -5134,6 +5237,12 @@ void TestEncryptDecryptSession()
 
     printf( "\n\nDECRYPT/ENCRYPT SESSION TESTS:\n" );
 
+    if (0 == IsCommandImpl( TPM_CC_EncryptDecrypt, supportedCommands ))
+    {
+        printf("Command TPM_CC_EncryptDecrypt not supported");
+        return;
+    }
+
     writeData.t.size = sizeof( writeDataString );
     memcpy( (void *)&writeData.t.buffer, (void *)&writeDataString,
             sizeof( writeDataString ) );
@@ -6378,6 +6487,12 @@ void EcEphemeralTest()
     UINT16 counter;
 
     printf( "\nEC Ephemeral TESTS:\n" );
+
+    if (0 == IsCommandImpl( TPM_CC_EC_Ephemeral, supportedCommands ))
+    {
+        printf("Command TPM_CC_EC_Ephemeral not supported");
+        return;
+    }
 
     // Test SAPI for case of Q size field not being set to 0.
     Q.t.size = 0xff;
@@ -8684,6 +8799,9 @@ void InitTpmTest()
 
     Tss2_Sys_Startup ( sysContext, TPM_SU_CLEAR );
     CheckTpmType();
+
+    GetCommands( sysContext, &supportedCommands );
+
     CheckHierarchy();
     if( nullPlatformAuth )
         ClearNVIndexList(TPM_RH_PLATFORM);


### PR DESCRIPTION
Due to "TCG PC Client Platform TPM Profile (PTP) Specification Level 00 Revision 00.43" folllowing commands are optional:
* TPM_CC_ChangeEPS
* TPM_CC_ChangePPS
* TPM_CC_EncryptDecrypt
* TPM_CC_EC_Ephemeral

Signed-off-by: Dominic Grauvogl <dominicmanuel.grauvogl@infineon.com>