### PR TITLE
make bootstrap binaries configurable via environment

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -13,6 +13,7 @@ src_listvar () {
 }
 
 VARS_FILE=src_vars.mk
+AUTORECONF=${AUTORECONF:-autoreconf}
 
 echo "Generating file lists: ${VARS_FILE}"
 (
@@ -29,4 +30,4 @@ echo "Generating file lists: ${VARS_FILE}"
   printf "SAMPLE_SRC = \$(SAMPLE_C) \$(SAMPLE_H)\n"
 ) > ${VARS_FILE}
 
-autoreconf --install --sym
+${AUTORECONF} --install --sym


### PR DESCRIPTION
The bootstrap script hard-codes the name of the autoreconf binary. This
hard-coding makes it unfeasible to run in a sandboxed environment where
those binaries are located at non-standard paths. Typically in
makefiles, binaries can be overwritten through environment variables.
This change adjusts the bootstrap script to honor the AUTORECONF
variable if present in the environment but is able to fall back to the
previous values if such variables are not present.