### PR TITLE
fix off-by-one error in CheckOverflow

### DIFF
--- a/common/checkoverflow.c
+++ b/common/checkoverflow.c
@@ -34,7 +34,7 @@ TSS2_RC CheckOverflow( UINT8 *buffer, UINT32 bufferSize, UINT8 *nextData, UINT32
     TSS2_RC rval = TSS2_RC_SUCCESS;
     INT64 usedSize;
 
-    usedSize = (INT64)(nextData - buffer) - 1 + size;
+    usedSize = (INT64)(nextData - buffer) + size;
     if( usedSize > (INT64)bufferSize )
     {
         rval = TSS2_SYS_RC_INSUFFICIENT_CONTEXT;


### PR DESCRIPTION
The overflow check as provided by CheckOverflow contains an off-by-one
error causing an out-of-bounds read by one byte to not be detected
properly. The used size should be calculated as
  usedSize = (INT64)(nextData - buffer) + size;
and not
  usedSize = (INT64)(nextData - buffer) - 1 + size;

For the latter case, consider the attempt of reading the very first two
bytes from a buffer of one byte size. 'usedSize' will be 1 (0x1000 -
0x1000 - 1 + 2). Because 'usedSize' is not greater than 'bufferSize'
(also 1), we will not detect the out-of-bounds read.
This change fixes the issue by removing the addend of -1.