### PR TITLE
tss2_tcti.h: Align return types from TCTI invocation macros with spec.

### DIFF
--- a/include/sapi/tss2_tcti.h
+++ b/include/sapi/tss2_tcti.h
@@ -90,14 +90,14 @@ typedef void TSS2_TCTI_POLL_HANDLE;
 
 // Macros to simplify invocation of functions from the common TCTI structure
 #define tss2_tcti_transmit(tctiContext, size, command) \
-    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_CONTEXT: \
+    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_REFERENCE: \
     (TSS2_TCTI_VERSION(tctiContext) < 1) ? \
         TSS2_TCTI_RC_ABI_MISMATCH: \
     (TSS2_TCTI_TRANSMIT(tctiContext) == NULL) ? \
         TSS2_TCTI_RC_NOT_IMPLEMENTED: \
     TSS2_TCTI_TRANSMIT(tctiContext)(tctiContext, size, command))
 #define tss2_tcti_receive(tctiContext, size, response, timeout) \
-    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_CONTEXT: \
+    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_REFERENCE: \
     (TSS2_TCTI_VERSION(tctiContext) < 1) ? \
         TSS2_TCTI_RC_ABI_MISMATCH: \
     (TSS2_TCTI_RECEIVE(tctiContext) == NULL) ? \
@@ -113,21 +113,21 @@ typedef void TSS2_TCTI_POLL_HANDLE;
         } \
     } while (0)
 #define tss2_tcti_cancel(tctiContext) \
-    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_CONTEXT: \
+    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_REFERENCE: \
     (TSS2_TCTI_VERSION(tctiContext) < 1) ? \
         TSS2_TCTI_RC_ABI_MISMATCH: \
     (TSS2_TCTI_CANCEL(tctiContext) == NULL) ? \
         TSS2_TCTI_RC_NOT_IMPLEMENTED: \
     TSS2_TCTI_CANCEL(tctiContext)(tctiContext))
 #define tss2_tcti_get_poll_handles(tctiContext, handles, num_handles) \
-    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_CONTEXT: \
+    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_REFERENCE: \
     (TSS2_TCTI_VERSION(tctiContext) < 1) ? \
         TSS2_TCTI_RC_ABI_MISMATCH: \
     (TSS2_TCTI_GET_POLL_HANDLES(tctiContext) == NULL) ? \
         TSS2_TCTI_RC_NOT_IMPLEMENTED: \
     TSS2_TCTI_GET_POLL_HANDLES(tctiContext)(tctiContext, handles, num_handles))
 #define tss2_tcti_set_locality(tctiContext, locality) \
-    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_CONTEXT: \
+    ((tctiContext == NULL) ? TSS2_TCTI_RC_BAD_REFERENCE: \
     (TSS2_TCTI_VERSION(tctiContext) < 1) ? \
         TSS2_TCTI_RC_ABI_MISMATCH: \
     (TSS2_TCTI_SET_LOCALITY(tctiContext) == NULL) ? \


### PR DESCRIPTION
The spec is a inconsistent w/r to the return type for a NULL context.
The inconsistency is between the example macro to invoke a function
pointer from those in the context structure in section 7.3.2 and the
description of these functions in 7.3.3.2.1 through 7.3.3.2.6.

This patch aligns with the "normative" text in the descriptions of the
functions and now returns BAD_REFERENCE instead of BAD_CONTEXT for NULL
contexts provided said functions.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>