### PR TITLE
fix misleading #error comments

### DIFF
--- a/include/sapi/sys_api_part3.h
+++ b/include/sapi/sys_api_part3.h
@@ -30,7 +30,7 @@
 
 #ifndef TSS2_API_VERSION_1_1_1_1
 #error Version mismatch among TSS2 header files. \
-       Do not include this file, #include <tcti/tpm20.h> instead.
+       Do not include this file, #include <sapi/tpm20.h> instead.
 #endif  /* TSS2_API_VERSION_1_1_1_1 */
 
 typedef struct {


### PR DESCRIPTION
It should be <sapi/tpm20.h> not tcti/tpm20.h