### PR TITLE
Make TPM2.0-TSS compilable with clang and add clang to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: cpp
 compiler:
   - gcc
+  - clang
 
 # This is a lie: we don't need sudo but this is required to get an
 # Ubuntu image with a libc that isn't ancient, and with cmocka libs.

--- a/sysapi/sysapi_util/CommandUtil.c
+++ b/sysapi/sysapi_util/CommandUtil.c
@@ -210,7 +210,7 @@ TSS2_RC CommonComplete( TSS2_SYS_CONTEXT *sysContext )
     }
     else
     {
-        TPM_ST tag;
+        TPM_ST tag = 0;
         SYS_CONTEXT->nextData = (UINT8 *)( SYS_CONTEXT->rspParamsSize );
 
         // Save response params size if command has authorization area.

--- a/test/tpmclient/tpmclient.c
+++ b/test/tpmclient/tpmclient.c
@@ -4949,7 +4949,8 @@ UINT8 decryptEncryptSetups[] = { PLAINTEXT_SESSION };
 void HmacSessionTest()
 {
     UINT32 rval;
-    unsigned int i, j, k, decryptEncryptMode;
+    int i, j, k;
+    unsigned int decryptEncryptMode;
     TPM2B_MAX_NV_BUFFER nvWriteData;
     UINT8 dataToWrite[] = { 0x00, 0xff, 0x55, 0xaa };
     TPM2B_NAME nvName;


### PR DESCRIPTION
Some people prefer using clang to compile their code.
Some minor modifications are needed to make the code pass the compilers stricter settings.
Once it builds we can also add this new configuration to travis.