### PR TITLE
sapi.pc: Add libmarshal as a library required to build against libsapi.

### DIFF
--- a/lib/sapi.pc.in
+++ b/lib/sapi.pc.in
@@ -3,4 +3,4 @@ Description: TPM2 System API library.
 URL: https://github.com/01org/TPM2.0-TSS
 Version: @VERSION@
 Cflags: -I@includedir@/sapi
-Libs: -lsapi
+Libs: -lmarshal -lsapi


### PR DESCRIPTION
Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>