### PR TITLE
Fixed bug in KDFA function:  if requested key size in bytes rounded u…

### DIFF
--- a/test/common/sample/kdfa.c
+++ b/test/common/sample/kdfa.c
@@ -87,7 +87,7 @@ TPM_RC KDFa( TPMI_ALG_HASH hashAlg, TPM2B *key, char *label,
     {
         // Inner loop
 
-        i_Swizzled = CHANGE_ENDIAN_DWORD( i );
+        i_Swizzled = CHANGE_ENDIAN_DWORD( i++ );
         *(UINT32 *)tpm2b_i_2Ptr = i_Swizzled;
 
         j = 0;


### PR DESCRIPTION
…p was

greater than the hash size, the key would be generated incorrectly.

Found this bug in January, but unable to submit pull request until some legal issues wrt open source were resolved.  Sharing this now so that others don't spend the painful day's effort it cost me to find this bug.