### PR TITLE
sort input files

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -8,7 +8,7 @@ src_listvar () {
     suffix=$2
     var=$3
 
-    find "${basedir}" -name "${suffix}" | tr '\n' ' ' | (echo -n "${var} = " && cat)
+    find "${basedir}" -name "${suffix}" | LC_ALL=C sort | tr '\n' ' ' | (echo -n "${var} = " && cat)
     echo ""
 }
 


### PR DESCRIPTION
when building packages (e.g. for openSUSE Linux)
(random) filesystem order of input files
influences ordering of functions in the output,
thus without the patch, builds (in disposable VMs) would differ.

See https://reproducible-builds.org/ for why this matters.