### PR TITLE
Remove references to config.site from INSTALL

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -14,18 +14,14 @@ produced an official source release. To obtain the tpm2.0-tss sources you
 must clone them from the 01.org GitHub organization TPM2.0-TSS git repository:
 git clone https://github.com/01org/TPM2.0-TSS
 
-To configure the tpm2.0-tss source code first define the environment for your
-build using a config.site file. The default for the project is kept at
-./lib/default_config.site. Pass this environment to the build through the
-CONFIG_SITE variable:
+To configure the tpm2.0-tss source code first run the bootstrap script, which
+generates list of source files, and creates the configure script:
 $ ./bootstrap
-$ CONFIG_SITE=$(pwd)/lib/default_config.site ./configure
 
-You may also customize the config.site to your needs (please read the GNU
-documentation for config.site files) or use your platform / distro default
-by leaving the CONFIG_SITE environment variable undefined.
+Then run the configure script, which generates the makefiles:
+$ ./configure
 
-Then compile the code:
+Then compile the code using make:
 $ make
 
 Once you've built the tpm2.0-tss software it can be installed with:
@@ -47,23 +43,3 @@ directory from the build directory. This allows for a developer to do a debug
 build and a regular build from the same sources. Any changes to the source
 will be buildable from both build directories. Before you attempt this be sure
 that the source directory is clean.
-
-Our example requires 3 directories:
-TPM2.0-TSS where the sources reside,
-tpm2tss-default to hold the build with default configuration
-tpm2tss-debug to hold a build with debug configuration
-
-In the TPM2.0-TSS directory bootstrap the build:
-$ ./bootstrap
-
-From the tpm2tss-default directory build the TPM2.0-TSS source code with the
-project's default configuration:
-$ CONFIG_SITE=$(pwd)/../TPM2.0-TSS/lib/default_config.site \
-  ../TPM2.0-TSS/configure
-$ make
-
-From the tpm2tss-debug directory build the TPM2.0-TSS source code with
-optimization disabled and debug symbols:
-$ CONFIG_SITE=$(pwd)/../TPM2.0-TSS/lib/debug_config.site \
-  ../TPM2.0-TSS/configure
-$ make

--- a/bootstrap
+++ b/bootstrap
@@ -18,6 +18,7 @@ AUTORECONF=${AUTORECONF:-autoreconf}
 echo "Generating file lists: ${VARS_FILE}"
 (
   src_listvar "sysapi/sysapi" "*.c" "SYSAPI_C"
+  src_listvar "sysapi/include" "*.h" "SYSAPI_H"
   src_listvar "sysapi/sysapi_util" "*.c" "SYSAPIUTIL_C"
   printf "SYSAPI_SRC = \$(SYSAPI_H) \$(SYSAPI_C) \$(SYSAPIUTIL_C)\n"
 


### PR DESCRIPTION
We should be using the system config.site

Signed-off-by: Tadeusz Struk <tadeusz.struk@intel.com>