### PR TITLE
configure; Remove dependency / check for pthreads.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -6,7 +6,7 @@ GNU Automake
 GNU Libtool
 C compiler
 C++ compiler
-C Library Development Libraries and Header Files (for pthreads headers)
+C Library Development Libraries and Header Files
 cmocka unit test framework
 pkg-config
 

--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,6 @@ AC_CONFIG_MACRO_DIR([m4])
 AC_PROG_CC
 AC_PROG_CXX
 LT_INIT()
-AX_PTHREAD([], [AC_MSG_ERROR([requires pthread])])
 AM_INIT_AUTOMAKE([foreign
                   subdir-objects])
 AC_CONFIG_FILES([Makefile])


### PR DESCRIPTION
The resourcemgr was using pthreads but it was removed. No need for this
library any longer.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>