### PR TITLE
Remove redundant always-true if check

### DIFF
--- a/sysapi/sysapi_util/CopySessionData.c
+++ b/sysapi/sysapi_util/CopySessionData.c
@@ -188,14 +188,11 @@ TSS2_RC CopySessionsDataOut(
     {
         if( tag == TPM_ST_SESSIONS )
         {
-            if( rspAuthsArray != 0 )
+            for( i = 0; i < rspAuthsArray->rspAuthsCount; i++ )
             {
-                for( i = 0; i < rspAuthsArray->rspAuthsCount; i++ )
-                {
-                    rval = CopySessionDataOut( rspAuthsArray->rspAuths[i], &otherData, outBuffPtr, outBuffSize );
-                    if( rval != TSS2_RC_SUCCESS )
-                        break;
-                }
+                rval = CopySessionDataOut( rspAuthsArray->rspAuths[i], &otherData, outBuffPtr, outBuffSize );
+                if( rval != TSS2_RC_SUCCESS )
+                    break;
             }
         }
     }


### PR DESCRIPTION
We don't have to check the rspAuthsArray twice

Signed-off-by: Peter Huewe <peterhuewe@gmx.de>