### PR TITLE
Tpmclient option cleanup rewrite

### DIFF
--- a/test/tpmclient/tpmclient.c
+++ b/test/tpmclient/tpmclient.c
@@ -7236,7 +7236,7 @@ char version[] = "0.90";
 
 void PrintHelp()
 {
-    printf( "TPM client test app, Version %s\nUsage:  tpmclient [-rmhost hostname|ip_addr] [-rmport port] [-demoDelay delay] [-startAuthSessionTest] "
+    printf( "TPM client test app, Version %s\nUsage:  tpmclient [-rmhost hostname|ip_addr] [-rmport port] [-demoDelay delay] "
 #if __linux || __unix
             "[-localTctiTest]"
 #endif
@@ -7246,7 +7246,6 @@ void PrintHelp()
             "-rmhost specifies the host IP address for the system running the resource manager (default: %s)\n"
             "-rmport specifies the port number for the system running the resource manager (default: %d)\n"
             "-demoDelay specifies a delay in units of loops, not time (default:  0)\n"
-            "-startAuthSessionTest enables some special tests of the resource manager for starting sessions\n"
 #if __linux || __unix
             "-localTctiTest enables a TCTI interface test against a local TPM.  WARNING:  This test requires no resource manager and a local TPM\n"
 #endif

--- a/test/tpmclient/tpmclient.c
+++ b/test/tpmclient/tpmclient.c
@@ -254,8 +254,6 @@ void ErrorHandler( UINT32 rval )
     sprintf_s( errorString, errorStringSize, "%s Error: 0x%x\n", levelString, rval );
 }
 
-char resMgrInterfaceName[] = "Resource Manager";
-
 TSS2_RC InitTctiResMgrContext( TCTI_SOCKET_CONF *rmInterfaceConfig, TSS2_TCTI_CONTEXT **tctiContext, char *name )
 {
     size_t size;
@@ -6955,7 +6953,7 @@ int main(int argc, char* argv[])
     rval = InitSocketTctiContext( &rmInterfaceConfig, &resMgrTctiContext);
     if( rval != TSS2_RC_SUCCESS )
     {
-        DebugPrintf( NO_PREFIX, "Resource Mgr, %s, failed initialization: 0x%x.  Exiting...\n", resMgrInterfaceName, rval );
+        DebugPrintf( NO_PREFIX, "InitSocketTctiContext, failed initialization: 0x%x.  Exiting...\n", rval );
         if( resMgrTctiContext != 0 )
             free( resMgrTctiContext );
 

--- a/test/tpmclient/tpmclient.c
+++ b/test/tpmclient/tpmclient.c
@@ -6897,9 +6897,6 @@ void PrintHelp()
             "-rmhost specifies the host IP address for the system running the resource manager (default: %s)\n"
             "-rmport specifies the port number for the system running the resource manager (default: %d)\n"
             "-demoDelay specifies a delay in units of loops, not time (default:  0)\n"
-#ifdef SHARED_OUT_FILE
-            "-out selects the output file (default is stdout)\n"
-#endif
             , version, DEFAULT_HOSTNAME, DEFAULT_SIMULATOR_TPM_PORT );
 }
 
@@ -6909,11 +6906,7 @@ int main(int argc, char* argv[])
     TSS2_RC rval;
 
     setvbuf (stdout, NULL, _IONBF, BUFSIZ);
-#ifdef SHARED_OUT_FILE
-    if( argc > 12 )
-#else
     if( argc > 10 )
-#endif
     {
         PrintHelp();
         return 1;

--- a/test/tpmclient/tpmclient.c
+++ b/test/tpmclient/tpmclient.c
@@ -120,7 +120,6 @@ TPM2B_AUTH loadedSha1KeyAuth;
 TPM_HANDLE handle1024, handle2048sha1, handle2048rsa;
 
 UINT32 demoDelay = 0;
-int debugLevel = 0;
 UINT8 indent = 0;
 
 TSS2_SYS_CONTEXT *sysContext;
@@ -2495,10 +2494,6 @@ void TestEvict()
         DebugPrintf( NO_PREFIX, "Resource Mgr, failed initialization: 0x%x.  Exiting...\n", rval );
         Cleanup();
         return;
-    }
-    else
-    {
-        (( TSS2_TCTI_CONTEXT_INTEL *)otherResMgrTctiContext )->status.debugMsgEnabled = debugLevel;
     }
     
     otherSysContext = InitSysContext( 0, otherResMgrTctiContext, &abiVersion );
@@ -6643,10 +6638,6 @@ void TestRM()
         Cleanup();
         return;
     }
-    else
-    {
-        (( TSS2_TCTI_CONTEXT_INTEL *)otherResMgrTctiContext )->status.debugMsgEnabled = debugLevel;
-    }
 
     otherSysContext = InitSysContext( 0, otherResMgrTctiContext, &abiVersion );
     if( otherSysContext == 0 )
@@ -7096,11 +7087,6 @@ void TestLocalTCTI()
     }
     else
     {
-        if( debugLevel == DBG_COMMAND )
-        {
-            ((TSS2_TCTI_CONTEXT_INTEL *)downstreamTctiContext )->status.debugMsgEnabled = debugLevel;
-        }
-
         TestTctiApis( downstreamTctiContext, 0 );
 
         TeardownTctiContext( &downstreamTctiContext );
@@ -7250,7 +7236,7 @@ char version[] = "0.90";
 
 void PrintHelp()
 {
-    printf( "TPM client test app, Version %s\nUsage:  tpmclient [-rmhost hostname|ip_addr] [-rmport port] [-demoDelay delay] [-dbg dbgLevel] [-startAuthSessionTest] "
+    printf( "TPM client test app, Version %s\nUsage:  tpmclient [-rmhost hostname|ip_addr] [-rmport port] [-demoDelay delay] [-startAuthSessionTest] "
 #if __linux || __unix
             "[-localTctiTest]"
 #endif
@@ -7260,9 +7246,6 @@ void PrintHelp()
             "-rmhost specifies the host IP address for the system running the resource manager (default: %s)\n"
             "-rmport specifies the port number for the system running the resource manager (default: %d)\n"
             "-demoDelay specifies a delay in units of loops, not time (default:  0)\n"
-            "-dbg specifies level of debug messages:\n"
-            "   0 (high level test results)\n"
-            "   1 (test app send/receive byte streams)\n"
             "-startAuthSessionTest enables some special tests of the resource manager for starting sessions\n"
 #if __linux || __unix
             "-localTctiTest enables a TCTI interface test against a local TPM.  WARNING:  This test requires no resource manager and a local TPM\n"
@@ -7321,15 +7304,6 @@ int main(int argc, char* argv[])
                     return 1;
                 }
             }
-            else if( 0 == strcmp( argv[count], "-dbg" ) )
-            {
-                count++;
-                if( count >= argc || 1 != sscanf_s( argv[count], "%d", &debugLevel ) || debugLevel > 1 )
-                {
-                    PrintHelp();
-                    return 1;
-                }
-            }
 #if __linux || __unix
             else if( 0 == strcmp( argv[count], "-localTctiTest" ) )
             {
@@ -7361,7 +7335,6 @@ int main(int argc, char* argv[])
     }
     else
     {
-        (( TSS2_TCTI_CONTEXT_INTEL *)resMgrTctiContext )->status.debugMsgEnabled = debugLevel;
         resMgrInitialized = 1;
     }
 

--- a/test/tpmclient/tpmclient.c
+++ b/test/tpmclient/tpmclient.c
@@ -119,7 +119,6 @@ TPM2B_AUTH loadedSha1KeyAuth;
 
 TPM_HANDLE handle1024, handle2048sha1, handle2048rsa;
 
-UINT32 passCount = 1;
 UINT32 demoDelay = 0;
 int debugLevel = 0;
 UINT8 indent = 0;
@@ -7115,7 +7114,6 @@ void TestLocalTCTI()
 void TpmTest()
 {
     TSS2_RC rval = TSS2_RC_SUCCESS;
-    UINT32 i;
 
     nullSessionsDataOut.rspAuthsCount = 1;
     nullSessionsDataOut.rspAuths[0]->nonce = nullSessionNonceOut;
@@ -7200,66 +7198,44 @@ void TpmTest()
     SimpleHmacOrPolicyTest( false );
 #endif //SKIP_SIMPLE_HMAC_OR_POLCY_FALSE_TEST
 
-    for( i = 1; i <= (UINT32)passCount; i++ )
-    {
-        DebugPrintf( NO_PREFIX, "\n****** PASS #: %d ******\n\n", i );
+    TestTpmGetCapability();
 
-        TestTpmGetCapability();
-
-        TestPcrExtend();
+    TestPcrExtend();
 #ifdef SKIP_HASH_TEST
-	printf("** Skpping hash test\n");
+    printf("** Skpping hash test\n");
 #else
-        TestHash();
+    TestHash();
 #endif
 
-        TestPolicy();
-
-        TestTpmClear();
-
-        TestChangeEps();
-
-        TestChangePps();
-
-        TestHierarchyChangeAuth();
-
-        if( i < 2 )
-            TestShutdown();
-
-        TestNV();
-
-        TestCreate();
+    TestPolicy();
+    TestTpmClear();
+    TestChangeEps();
+    TestChangePps();
+    TestHierarchyChangeAuth();
+    TestShutdown();
+    TestNV();
+    TestCreate();
 #ifdef SKIP_EVICT_TEST
-	printf("** Skipping TestEvict()\n");
+    printf("** Skipping TestEvict()\n");
 #else
-        TestEvict();
+    TestEvict();
 #endif
-
-        NvIndexProto();
-
-        PasswordTest();
-
-        HmacSessionTest();
-
-        TestQuote();
-
-        TestDictionaryAttackLockReset();
-
-        TestPcrAllocate();
-
-        TestUnseal();
+    NvIndexProto();
+    PasswordTest();
+    HmacSessionTest();
+    TestQuote();
+    TestDictionaryAttackLockReset();
+    TestPcrAllocate();
+    TestUnseal();
 #ifdef SKIP_RM_TEST
-	printf("** Skipping TestRM()\n");
+    printf("** Skipping TestRM()\n");
 #else
-        TestRM();
+    TestRM();
 #endif
-
-        EcEphemeralTest();
+    EcEphemeralTest();
 #if 0
-        TestRsaEncryptDecrypt();
+    TestRsaEncryptDecrypt();
 #endif
-    }
-
     // Clear out RM entries for objects.
     rval = Tss2_Sys_FlushContext( sysContext, handle2048rsa );
     CheckPassed( rval );
@@ -7274,7 +7250,7 @@ char version[] = "0.90";
 
 void PrintHelp()
 {
-    printf( "TPM client test app, Version %s\nUsage:  tpmclient [-rmhost hostname|ip_addr] [-rmport port] [-passes passNum] [-demoDelay delay] [-dbg dbgLevel] [-startAuthSessionTest] "
+    printf( "TPM client test app, Version %s\nUsage:  tpmclient [-rmhost hostname|ip_addr] [-rmport port] [-demoDelay delay] [-dbg dbgLevel] [-startAuthSessionTest] "
 #if __linux || __unix
             "[-localTctiTest]"
 #endif
@@ -7283,7 +7259,6 @@ void PrintHelp()
             "\n"
             "-rmhost specifies the host IP address for the system running the resource manager (default: %s)\n"
             "-rmport specifies the port number for the system running the resource manager (default: %d)\n"
-            "-passes specifies the number of test passes (default: 1)\n"
             "-demoDelay specifies a delay in units of loops, not time (default:  0)\n"
             "-dbg specifies level of debug messages:\n"
             "   0 (high level test results)\n"
@@ -7332,15 +7307,6 @@ int main(int argc, char* argv[])
                 count++;
                 rmInterfaceConfig.port = strtoul(argv[count], NULL, 10);
                 if( count >= argc)
-                {
-                    PrintHelp();
-                    return 1;
-                }
-            }
-            else if( 0 == strcmp( argv[count], "-passes" ) )
-            {
-                count++;
-                if( count >= argc || 1 != sscanf_s( argv[count], "%x", &passCount ) )
                 {
                     PrintHelp();
                     return 1;


### PR DESCRIPTION
remove command line options that won't be useful when integrated into the test harness