### PR TITLE
Generate correct SYSAPI_H list

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -18,6 +18,7 @@ AUTORECONF=${AUTORECONF:-autoreconf}
 echo "Generating file lists: ${VARS_FILE}"
 (
   src_listvar "sysapi/sysapi" "*.c" "SYSAPI_C"
+  src_listvar "sysapi/include" "*.h" "SYSAPI_H"
   src_listvar "sysapi/sysapi_util" "*.c" "SYSAPIUTIL_C"
   printf "SYSAPI_SRC = \$(SYSAPI_H) \$(SYSAPI_C) \$(SYSAPIUTIL_C)\n"
 


### PR DESCRIPTION
SYSAPI_H is referenced in Makefile, but it is not generated
correctly.

This is a cherry-pick from master

Signed-off-by: Tadeusz Struk <tadeusz.struk@intel.com>