### PR TITLE
Dockerfile: Builds from checked out repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,11 @@ RUN wget https://downloads.sourceforge.net/project/ibmswtpm2/ibmtpm532.tar && \
   tar axf ibmtpm532.tar -C ibmtpm532 && \
   make -C ibmtpm532/src -j$(nproc)
 
-RUN git clone https://github.com/01org/TPM2.0-TSS && \
-  cd TPM2.0-TSS && \
+COPY . TPM2.0-TSS
+
+RUN cd TPM2.0-TSS && \
   ./bootstrap && \
+  rm -rf ./build && \
   mkdir ./build && \
   cd ./build && \
   ../configure --enable-unit --with-simulatorbin=$(pwd)/../../ibmtpm532/src/tpm_server && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,9 @@ RUN cd TPM2.0-TSS && \
   cd ./build && \
   ../configure --enable-unit --with-simulatorbin=$(pwd)/../../ibmtpm532/src/tpm_server && \
   make -j$(nproc) && \
-  make simulator-build && \
+  make simulator-build
+
+RUN cd TPM2.0-TSS/build && \
   make -j$(nproc) check && \
   make simulator-start && \
   test/tpmclient/tpmclient && \


### PR DESCRIPTION
Got rid of how the Dockerfile cloned a new repo to build. Now it
builds from the already checked out one on the users machine.

Signed-off-by: John Andersen <john.s.andersen@intel.com>