### PR TITLE
tpmclient: Fix and enable the hmac tests.

### DIFF
--- a/test/tpmclient/tpmclient.int.cpp
+++ b/test/tpmclient/tpmclient.int.cpp
@@ -4685,6 +4685,7 @@ void HmacSessionTest()
                     symmetric.keyBits.aes = 128;
                     symmetric.mode.aes = TPM_ALG_CFB;
 
+                    EndAuthSession (nvSession);
                     rval = StartAuthSessionWithParams( &nvSession, hmacTestSetups[j].tpmKey,  hmacTestSetups[j].salt, hmacTestSetups[j].bound, &nvAuth, &nonceOlder, &encryptedSalt, TPM_SE_HMAC, &symmetric, TPM_ALG_SHA1, resMgrTctiContext );
                     CheckPassed( rval );
 
@@ -6479,6 +6480,11 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
     TestDictionaryAttackLockReset();
 
     TestCreate();
+    rval = Tss2_Sys_FlushContext( sysContext, loadedSha1KeyHandle );
+    CheckPassed( rval );
+    HmacSessionTest();
+    TestTpmClear ();
+    TestCreate();
 
 #ifdef SKIP_TEST_CREATE1_TEST
     printf("** Skipping TestCreate1()\n");
@@ -6526,7 +6532,6 @@ test_invoke (TSS2_SYS_CONTEXT *sapi_context)
 #endif
     NvIndexProto();
     PasswordTest();
-    HmacSessionTest();
     TestQuote();
     TestDictionaryAttackLockReset();
     TestPcrAllocate();

--- a/test/tpmclient/tpmclient_wo_rm.h
+++ b/test/tpmclient/tpmclient_wo_rm.h
@@ -36,22 +36,6 @@
 // around line 2571
 #define SKIP_EVICT_TEST
 
-// Skipping to avoid TPM Error 0x902 when ComputeCommandHmacs() in HmacSessionTest()
-// around line 5211
-#define SKIP_UNBOUND_UNSALTED_HMAC_TEST
-
-// Skipping to avoid Application Error 0x50102 when StartAuthSessionWithParams() in HMacSessionTest()
-// around line 5159
-#define SKIP_BOUND_SESSION_HMAC_TEST
-
-// Skipping to avoid Application Error 0x50102 when StartAuthSessionWithParams() in HMacSessionTest()
-// around line 5159
-#define SKIP_SALTED_SESSION_HMAC_TEST
-
-// Skipping to avoid Application Error 0x50102 when StartAuthSessionWithParams() in HMacSessionTest()
-// around line 5159
-#define SKIP_BOUND_SALTED_SESSION_HMAC_TEST
-
 // Skipping to avoid hang
 #define SKIP_RM_TEST
 


### PR DESCRIPTION
The hmac tests only requrie the primary key referenced via the global
'handle2048rsa' handle variable. The hmac tests are run after the
TestCreate function (which loads this required key and one more) but
having this additional key loaded cause the hmac tests to fail with the
RC 0x902 aka 'TPM_RC_OBJECT_MEMORY'. Unloading this additional key manuall
allows the hmac tests to run successfully.

After the hmac tests run we flush the TPM and then re-run the TestCreate
function. This ensures that the keys referenced by the global handle2048rsa
and loadedSha1KeyHandle variables are loaded.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>