### PR TITLE
Update location of algorithm ids

### DIFF
--- a/include/sapi/implementation.h
+++ b/include/sapi/implementation.h
@@ -318,7 +318,7 @@
     ((MAX_RSA_KEY_BYTES/2)*(3+CRT_FORMAT_RSA*2))
 #define  MAX_VENDOR_BUFFER_SIZE           1024
 
-// From TCG Algorithm Registry: Table 2 - Definition of TPM_ALG_ID Constants
+// From TCG Algorithm Registry: Table 3 - Definition of TPM_ALG_ID Constants
 
 typedef  UINT16             TPM_ALG_ID;
 #define  TPM_ALG_ERROR               (TPM_ALG_ID)(0x0000)


### PR DESCRIPTION
implementation.h stated that Table 2 contains the algorithm identifiers from the TCG Algorithm registry. The current document, here: https://trustedcomputinggroup.org/wp-content/uploads/TCG_Algorithm_Registry_Rev_1.24.pdf shows it in Table 3.