### PR TITLE
travis.yml: remove configure step from coverity config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ addons:
       name: "01org/TPM2.0-TSS"
       description: Build submitted via Travis-CI
     notification_email: philip.b.tricca@intel.com
-    build_command_prepend: "./configure; make clean"
+    build_command_prepend: "make clean"
     build_command: "make --jobs=$(($(nproc)*2))"
     branch_pattern: coverity_scan
 


### PR DESCRIPTION
Since we do a manual VPATH build the build will already be configured
here.

Signed-off-by: Philip Tricca <philip.b.tricca@intel.com>